### PR TITLE
DEV: Cook post bodies to Markdown via Markbridge (v2 migrations)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport
       colored2
       i18n
+      markbridge
       migrations-core
       pg
       zeitwerk
@@ -348,6 +349,7 @@ GEM
       net-pop
       net-smtp
     mapping (1.1.3)
+    markbridge (0.2.0)
     matrix (0.4.3)
     maxminddb (0.1.22)
     memory_profiler (1.1.0)
@@ -1119,6 +1121,7 @@ CHECKSUMS
   lz4-ruby (0.3.3) sha256=011be5ee230cfddc8308d4e2e0b05300c7bc755a887de799377ca6c5b6aede89
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   mapping (1.1.3) sha256=2274931d20ecd46eaafdd1e00c58cc7472133b213bcac335cc7733d3c75f4da2
+  markbridge (0.2.0) sha256=b6e94b4871da692922cbcff5ca4bc01f1d169f7e9869e06a9706d713c6b8ae89
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   maxminddb (0.1.22) sha256=50933be438fbed9dceabef4163eab41884bd8830d171fdb8f739bee769c4907e
   memory_profiler (1.1.0) sha256=79a17df7980a140c83c469785905409d3027ca614c42c086089d128b805aa8f8

--- a/migrations/converters/lib/migrations/converters/content.rb
+++ b/migrations/converters/lib/migrations/converters/content.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "markbridge"
+
+module Migrations
+  module Converters
+    # Convert-time wrapper over the Markbridge gem: turns a source forum's post
+    # markup (BBCode, HTML, MediaWiki, TextFormatter XML) into Discourse Markdown,
+    # optionally deferring the embeds that cannot be finalized until import time.
+    #
+    # When an `on_embed` sink (an {EmbedBuffer}, or anything answering the embed
+    # callbacks) is passed, the configured embed node types are not rendered
+    # inline: each is recorded on the sink and replaced in the output by a
+    # placeholder token (see {Migrations::Placeholder}). Everything else renders
+    # natively. With no sink, this is a plain cook.
+    #
+    # Markbridge does not parse Markdown, so a Discourse -> Discourse migration
+    # (whose `raw` is already Markdown) does not use this; the cooker is for forums
+    # whose post bodies are in one of the formats above.
+    #
+    # @example deferring uploads and quotes into an EmbedBuffer
+    #   buffer = EmbedBuffer.new
+    #   raw = Content.new(format: :bbcode).to_markdown(item[:body], on_embed: buffer)
+    #   # `raw` now carries placeholder tokens; `buffer.uploads` / `buffer.quotes`
+    #   # hold the typed linkage descriptors.
+    class Content
+      class UnknownFormat < StandardError
+      end
+
+      # The `require` path for each supported source format. HTML / MediaWiki /
+      # TextFormatter additionally need nokogiri (provided by the host
+      # application); BBCode has no extra dependency.
+      FORMATS = {
+        bbcode: "markbridge/bbcode",
+        html: "markbridge/html",
+        mediawiki: "markbridge/mediawiki",
+        text_formatter_xml: "markbridge/textformatter",
+      }.freeze
+
+      # Embeds deferred unless the caller narrows or extends the set. These always
+      # need the import-time maps when present: uploads must be re-uploaded, quotes
+      # reference foreign post/topic/user ids, mentions reference a foreign
+      # username. `:link` is intentionally excluded by default — most URLs are
+      # external and render fine; a converter that rewrites internal links opts in
+      # explicitly with `defer:`.
+      DEFAULT_DEFER = %i[upload quote mention].freeze
+
+      # Maps a friendly embed kind to the Markbridge AST node class it overrides
+      # and the extraction that feeds the sink. Each lambda returns the placeholder
+      # token (the `EmbedBuffer#<kind>` call returns it), which Markbridge then
+      # emits as the node's rendered output.
+      def self.embed_handlers
+        @embed_handlers ||= {
+          upload: [
+            Markbridge::AST::Upload,
+            ->(sink, node, _iface) { sink.upload(upload_id: node.sha1) },
+          ],
+          quote: [
+            Markbridge::AST::Quote,
+            ->(sink, node, iface) do
+              # Only the attribution carries the foreign post/topic/user reference
+              # that needs remapping; the quoted body renders normally and the
+              # closing tag stays in place. A quote with no such reference has
+              # nothing to remap, so it renders natively (preserving its
+              # attribution exactly). The token stands in for the opening
+              # `[quote="…"]`, which PlaceholderResolver#render_quote rebuilds.
+              unless node.post || node.topic || node.username
+                next Markbridge::Renderers::Discourse::Tags::QuoteTag.new.render(node, iface)
+              end
+
+              token = sink.quote(quoted_post_id: node.post, quoted_username: node.username)
+              content = iface.render_children(node, context: iface.with_parent(node))
+              "\n\n#{token}\n#{content}\n[/quote]\n\n"
+            end,
+          ],
+          mention: [
+            Markbridge::AST::Mention,
+            ->(sink, node, _iface) { sink.mention(mention_type: node.type.to_s, name: node.name) },
+          ],
+          link: [
+            Markbridge::AST::Url,
+            ->(sink, node, iface) { sink.link(url: node.href, text: iface.render_children(node)) },
+          ],
+        }
+      end
+
+      # @param format [Symbol] one of {FORMATS}.
+      def initialize(format: :bbcode)
+        @format = format.to_sym
+        raise UnknownFormat, "Unknown source format: #{format}" unless FORMATS.key?(@format)
+
+        require FORMATS.fetch(@format)
+      end
+
+      # @param source [String] the source post body.
+      # @param on_embed [#upload, #quote, #mention, #link, nil] the embed sink; when
+      #   nil the embeds render natively.
+      # @param defer [Array<Symbol>] which embed kinds to defer (default
+      #   {DEFAULT_DEFER}). Ignored when `on_embed` is nil.
+      # @return [String] Discourse Markdown.
+      def to_markdown(source, on_embed: nil, defer: DEFAULT_DEFER)
+        renderer = on_embed ? deferring_renderer(on_embed, defer) : nil
+        Markbridge.convert(source, format: @format, renderer:).markdown
+      end
+
+      private
+
+      def deferring_renderer(sink, defer)
+        tags =
+          Array(defer).each_with_object({}) do |kind, mapping|
+            node_class, extract = self.class.embed_handlers.fetch(kind)
+            mapping[node_class] = Markbridge::Renderers::Discourse::Tag.new do |node, iface|
+              extract.call(sink, node, iface)
+            end
+          end
+
+        Markbridge.discourse_renderer(tags:)
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/embed_buffer.rb
+++ b/migrations/converters/lib/migrations/converters/embed_buffer.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    # Pure, per-post accumulator for deferred embeds discovered while a post body
+    # is converted to Markdown.
+    #
+    # The cooker calls back here for every fragment it cannot finalize at convert
+    # time — a quote, link, mention, poll, event or upload — because rendering it
+    # needs the `original_id -> discourse_id` maps that only exist at import time.
+    # `EmbedBuffer` mints a collision-proof token via `Migrations::Placeholder`,
+    # records a typed descriptor carrying that token, and returns the token for the
+    # cooker to splice into the raw in place of the fragment.
+    #
+    # After the body is converted, the Posts step writes the post and then drains
+    # each typed collection into its IntermediateDB linkage table, e.g.
+    #
+    #     buffer.quotes.each { |q| IntermediateDB::PostQuote.create(post_id:, **q) }
+    #
+    # The descriptors are plain hashes whose keys match the linkage table columns
+    # (minus `post_id`), so they splat straight into `create`. Keeping the buffer
+    # free of any DB or id-map access is what lets `process_item` stay a pure
+    # function of `(item, static config)`, safe to run on the converter's worker
+    # threads and reusable across every converter.
+    class EmbedBuffer
+      attr_reader :quotes, :links, :mentions, :polls, :events, :uploads
+
+      # @param placeholder [Migrations::Placeholder] the token minter; a fresh
+      #   instance (with its own random nonce) is used per buffer by default.
+      def initialize(placeholder: Migrations::Placeholder.new)
+        @placeholder = placeholder
+        @quotes = []
+        @links = []
+        @mentions = []
+        @polls = []
+        @events = []
+        @uploads = []
+      end
+
+      # @return [String] the token to splice into the raw in place of the quote.
+      def quote(quoted_post_id: nil, quoted_user_id: nil, quoted_username: nil)
+        record(@quotes, :quote, quoted_post_id:, quoted_user_id:, quoted_username:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the link.
+      def link(url: nil, text: nil, target_topic_id: nil, target_post_id: nil)
+        record(@links, :link, url:, text:, target_topic_id:, target_post_id:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the mention.
+      def mention(mention_type: nil, target_id: nil, name: nil)
+        record(@mentions, :mention, mention_type:, target_id:, name:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the poll.
+      def poll(poll_id: nil)
+        record(@polls, :poll, poll_id:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the event.
+      def event(event_id: nil)
+        record(@events, :event, event_id:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the upload.
+      def upload(upload_id: nil)
+        record(@uploads, :upload, upload_id:)
+      end
+
+      # Every token this buffer has minted, across all kinds, in mint order. Mirrors
+      # what should be present in the post raw — handy for asserting the contract.
+      #
+      # @return [Array<String>]
+      def placeholders
+        descriptors.map { |descriptor| descriptor[:placeholder] }
+      end
+
+      # @return [Boolean] whether the post had no deferred embeds.
+      def empty?
+        descriptors.empty?
+      end
+
+      private
+
+      def descriptors
+        @quotes + @links + @mentions + @polls + @events + @uploads
+      end
+
+      def record(collection, kind, **fields)
+        placeholder = @placeholder.mint(kind)
+        collection << { placeholder:, **fields }
+        placeholder
+      end
+    end
+  end
+end

--- a/migrations/converters/migrations-converters.gemspec
+++ b/migrations/converters/migrations-converters.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport"
   s.add_dependency "colored2"
   s.add_dependency "i18n"
+  s.add_dependency "markbridge"
   s.add_dependency "pg"
   s.add_dependency "zeitwerk"
 end

--- a/migrations/converters/spec/lib/migrations/converters/content_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/content_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Converters::Content do
+  describe "#to_markdown without an embed sink" do
+    subject(:cooker) { described_class.new(format: :bbcode) }
+
+    it "cooks BBCode to Discourse Markdown" do
+      expect(cooker.to_markdown("[b]hi[/b] and [url=https://example.com]a link[/url]")).to eq(
+        "**hi** and [a link](https://example.com)",
+      )
+    end
+
+    it "raises for an unknown source format" do
+      expect { described_class.new(format: :wikitextish) }.to raise_error(
+        described_class::UnknownFormat,
+      )
+    end
+  end
+
+  describe "#to_markdown deferring embeds into an EmbedBuffer" do
+    subject(:cooker) { described_class.new(format: :bbcode) }
+
+    let(:buffer) { Migrations::Converters::EmbedBuffer.new }
+
+    it "defers an attributed quote, recording the linkage and preserving the body" do
+      raw =
+        cooker.to_markdown(
+          '[quote="John, post:12, topic:34, username:john"]quoted body[/quote]',
+          on_embed: buffer,
+        )
+
+      expect(buffer.quotes.size).to eq(1)
+      descriptor = buffer.quotes.first
+      expect(descriptor[:quoted_post_id]).to eq("12")
+      expect(descriptor[:quoted_username]).to eq("John")
+
+      # The token stands in for the opening tag; the body and closer remain.
+      expect(raw).to include(descriptor[:placeholder])
+      expect(raw).to include("quoted body")
+      expect(raw).to include("[/quote]")
+    end
+
+    it "renders an unattributed quote natively (nothing to remap)" do
+      raw = cooker.to_markdown("[quote]just text[/quote]", on_embed: buffer)
+
+      expect(buffer).to be_empty
+      expect(Migrations::Placeholder).not_to be_include(raw)
+    end
+
+    it "defers links only when asked via defer:" do
+      raw =
+        cooker.to_markdown(
+          "see [url=https://example.com/t/5]here[/url]",
+          on_embed: buffer,
+          defer: %i[link],
+        )
+
+      expect(buffer.links.size).to eq(1)
+      descriptor = buffer.links.first
+      expect(descriptor[:url]).to eq("https://example.com/t/5")
+      expect(descriptor[:text]).to eq("here")
+      expect(raw).to include(descriptor[:placeholder])
+    end
+
+    it "leaves links alone by default" do
+      raw = cooker.to_markdown("see [url=https://example.com]here[/url]", on_embed: buffer)
+
+      expect(buffer.links).to be_empty
+      expect(raw).to eq("see [here](https://example.com)")
+    end
+
+    # The contract: every token in the cooked raw maps to exactly one recorded
+    # linkage descriptor.
+    it "keeps placeholders and linkage rows one-to-one" do
+      raw =
+        cooker.to_markdown(
+          'a [quote="A, post:1, topic:2, username:a"]q[/quote] b ' \
+            "[url=https://example.com/t/9]L[/url] c",
+          on_embed: buffer,
+          defer: %i[quote link],
+        )
+
+      expect(Migrations::Placeholder.scan(raw)).to match_array(buffer.placeholders)
+    end
+  end
+
+  describe ".embed_handlers extraction" do
+    # Upload and Mention nodes don't arise from BBCode, so exercise their
+    # extraction lambdas directly against the real AST nodes.
+    let(:sink) { Migrations::Converters::EmbedBuffer.new }
+
+    it "maps an Upload node's sha1 to upload_id" do
+      _node_class, extract = described_class.embed_handlers.fetch(:upload)
+      node = Markbridge::AST::Upload.new(sha1: "abc123", filename: "x.png")
+
+      token = extract.call(sink, node, nil)
+
+      expect(sink.uploads).to contain_exactly({ placeholder: token, upload_id: "abc123" })
+    end
+
+    it "maps a Mention node's type and name" do
+      _node_class, extract = described_class.embed_handlers.fetch(:mention)
+      node = Markbridge::AST::Mention.new(name: "gerhard", type: :user)
+
+      token = extract.call(sink, node, nil)
+
+      expect(sink.mentions).to contain_exactly(
+        { placeholder: token, mention_type: "user", target_id: nil, name: "gerhard" },
+      )
+    end
+  end
+end

--- a/migrations/converters/spec/lib/migrations/converters/embed_buffer_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/embed_buffer_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Converters::EmbedBuffer do
+  subject(:buffer) { described_class.new }
+
+  describe "recording embeds" do
+    it "records a quote descriptor keyed for IntermediateDB::PostQuote" do
+      token = buffer.quote(quoted_post_id: 1, quoted_user_id: 2, quoted_username: "bob")
+
+      expect(buffer.quotes).to contain_exactly(
+        { placeholder: token, quoted_post_id: 1, quoted_user_id: 2, quoted_username: "bob" },
+      )
+    end
+
+    it "records a link descriptor keyed for IntermediateDB::PostLink" do
+      token = buffer.link(url: "https://example.com", text: "here", target_topic_id: 9)
+
+      expect(buffer.links).to contain_exactly(
+        {
+          placeholder: token,
+          url: "https://example.com",
+          text: "here",
+          target_topic_id: 9,
+          target_post_id: nil,
+        },
+      )
+    end
+
+    it "records a mention descriptor keyed for IntermediateDB::PostMention" do
+      token = buffer.mention(mention_type: "user", target_id: 7, name: "bob")
+
+      expect(buffer.mentions).to contain_exactly(
+        { placeholder: token, mention_type: "user", target_id: 7, name: "bob" },
+      )
+    end
+
+    it "records a poll descriptor keyed for IntermediateDB::PostPoll" do
+      token = buffer.poll(poll_id: 3)
+
+      expect(buffer.polls).to contain_exactly({ placeholder: token, poll_id: 3 })
+    end
+
+    it "records an event descriptor keyed for IntermediateDB::PostEvent" do
+      token = buffer.event(event_id: 4)
+
+      expect(buffer.events).to contain_exactly({ placeholder: token, event_id: 4 })
+    end
+
+    it "records an upload descriptor keyed for IntermediateDB::PostUpload" do
+      token = buffer.upload(upload_id: "abc123")
+
+      expect(buffer.uploads).to contain_exactly({ placeholder: token, upload_id: "abc123" })
+    end
+
+    it "returns the minted token so the cooker can splice it into the raw" do
+      expect(buffer.quote(quoted_user_id: 1)).to eq(buffer.quotes.last[:placeholder])
+    end
+  end
+
+  describe "#empty?" do
+    it "is true before anything is recorded" do
+      expect(buffer).to be_empty
+    end
+
+    it "is false once an embed is recorded" do
+      buffer.upload(upload_id: "x")
+
+      expect(buffer).not_to be_empty
+    end
+  end
+
+  # The single invariant the whole design rests on: the token spliced into the raw
+  # and the `placeholder` on the linkage row are byte-identical, one-to-one.
+  describe "the placeholder contract" do
+    it "mints one token per embed, each present exactly once in the cooked raw" do
+      raw = +"Intro "
+      raw << buffer.quote(quoted_user_id: 5)
+      raw << " see "
+      raw << buffer.link(url: "https://example.com", text: "x")
+      raw << " hi "
+      raw << buffer.mention(mention_type: "user", target_id: 7, name: "bob")
+      raw << " poll "
+      raw << buffer.poll(poll_id: 1)
+      raw << " event "
+      raw << buffer.event(event_id: 2)
+      raw << " pic "
+      raw << buffer.upload(upload_id: "sha1")
+      raw << " end"
+
+      tokens_in_raw = Migrations::Placeholder.scan(raw)
+
+      # Every token in the raw has exactly one matching linkage descriptor, and
+      # every descriptor's placeholder is present in the raw.
+      expect(tokens_in_raw).to match_array(buffer.placeholders)
+      expect(tokens_in_raw.size).to eq(buffer.placeholders.size)
+      buffer.placeholders.each { |placeholder| expect(raw.scan(placeholder).size).to eq(1) }
+    end
+
+    it "never mints the same token twice" do
+      tokens = Array.new(10) { buffer.upload(upload_id: "x") }
+
+      expect(tokens.uniq.size).to eq(10)
+    end
+  end
+end

--- a/migrations/core/db/intermediate_db_schema/100-base-schema.sql
+++ b/migrations/core/db/intermediate_db_schema/100-base-schema.sql
@@ -183,6 +183,67 @@ CREATE TABLE permalink_normalizations
 );
 
 
+CREATE TABLE post_events
+(
+    event_id    NUMERIC,
+    placeholder TEXT    NOT NULL,
+    post_id     NUMERIC NOT NULL
+);
+
+CREATE INDEX idx_post_events_post_id ON post_events (post_id);
+
+CREATE TABLE post_links
+(
+    placeholder     TEXT    NOT NULL,
+    post_id         NUMERIC NOT NULL,
+    target_post_id  NUMERIC,
+    target_topic_id NUMERIC,
+    text            TEXT,
+    url             TEXT
+);
+
+CREATE INDEX idx_post_links_post_id ON post_links (post_id);
+
+CREATE TABLE post_mentions
+(
+    mention_type TEXT,
+    name         TEXT,
+    placeholder  TEXT    NOT NULL,
+    post_id      NUMERIC NOT NULL,
+    target_id    NUMERIC
+);
+
+CREATE INDEX idx_post_mentions_post_id ON post_mentions (post_id);
+
+CREATE TABLE post_polls
+(
+    placeholder TEXT    NOT NULL,
+    poll_id     NUMERIC,
+    post_id     NUMERIC NOT NULL
+);
+
+CREATE INDEX idx_post_polls_post_id ON post_polls (post_id);
+
+CREATE TABLE post_quotes
+(
+    placeholder     TEXT    NOT NULL,
+    post_id         NUMERIC NOT NULL,
+    quoted_post_id  NUMERIC,
+    quoted_user_id  NUMERIC,
+    quoted_username TEXT
+);
+
+CREATE INDEX idx_post_quotes_post_id ON post_quotes (post_id);
+
+CREATE TABLE post_uploads
+(
+    placeholder TEXT    NOT NULL,
+    post_id     NUMERIC NOT NULL,
+    upload_id   TEXT
+);
+
+CREATE INDEX idx_post_uploads_post_id ON post_uploads (post_id);
+
 CREATE TABLE site_settings
 (
     name            TEXT         NOT NULL PRIMARY KEY,

--- a/migrations/core/lib/migrations/database/intermediate_db/post_event.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_event.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostEvent
+        SQL = <<~SQL
+          INSERT INTO post_events (
+            event_id,
+            placeholder,
+            post_id
+          )
+          VALUES (
+            ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_events` record in the IntermediateDB.
+        #
+        # @param event_id      [Integer, String, nil]
+        # @param placeholder   [String]
+        # @param post_id       [Integer, String]
+        #
+        # @return [void]
+        def self.create(event_id: nil, placeholder:, post_id:)
+          Migrations::Database::IntermediateDB.insert(SQL, event_id, placeholder, post_id)
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_link.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_link.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostLink
+        SQL = <<~SQL
+          INSERT INTO post_links (
+            placeholder,
+            post_id,
+            target_post_id,
+            target_topic_id,
+            text,
+            url
+          )
+          VALUES (
+            ?, ?, ?, ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_links` record in the IntermediateDB.
+        #
+        # @param placeholder       [String]
+        # @param post_id           [Integer, String]
+        # @param target_post_id    [Integer, String, nil]
+        # @param target_topic_id   [Integer, String, nil]
+        # @param text              [String, nil]
+        # @param url               [String, nil]
+        #
+        # @return [void]
+        def self.create(
+          placeholder:,
+          post_id:,
+          target_post_id: nil,
+          target_topic_id: nil,
+          text: nil,
+          url: nil
+        )
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            placeholder,
+            post_id,
+            target_post_id,
+            target_topic_id,
+            text,
+            url,
+          )
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_mention.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_mention.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostMention
+        SQL = <<~SQL
+          INSERT INTO post_mentions (
+            mention_type,
+            name,
+            placeholder,
+            post_id,
+            target_id
+          )
+          VALUES (
+            ?, ?, ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_mentions` record in the IntermediateDB.
+        #
+        # @param mention_type   [String, nil]
+        # @param name           [String, nil]
+        # @param placeholder    [String]
+        # @param post_id        [Integer, String]
+        # @param target_id      [Integer, String, nil]
+        #
+        # @return [void]
+        def self.create(mention_type: nil, name: nil, placeholder:, post_id:, target_id: nil)
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            mention_type,
+            name,
+            placeholder,
+            post_id,
+            target_id,
+          )
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_poll.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_poll.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostPoll
+        SQL = <<~SQL
+          INSERT INTO post_polls (
+            placeholder,
+            poll_id,
+            post_id
+          )
+          VALUES (
+            ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_polls` record in the IntermediateDB.
+        #
+        # @param placeholder   [String]
+        # @param poll_id       [Integer, String, nil]
+        # @param post_id       [Integer, String]
+        #
+        # @return [void]
+        def self.create(placeholder:, poll_id: nil, post_id:)
+          Migrations::Database::IntermediateDB.insert(SQL, placeholder, poll_id, post_id)
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_quote.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_quote.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostQuote
+        SQL = <<~SQL
+          INSERT INTO post_quotes (
+            placeholder,
+            post_id,
+            quoted_post_id,
+            quoted_user_id,
+            quoted_username
+          )
+          VALUES (
+            ?, ?, ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_quotes` record in the IntermediateDB.
+        #
+        # @param placeholder       [String]
+        # @param post_id           [Integer, String]
+        # @param quoted_post_id    [Integer, String, nil]
+        # @param quoted_user_id    [Integer, String, nil]
+        # @param quoted_username   [String, nil]
+        #
+        # @return [void]
+        def self.create(
+          placeholder:,
+          post_id:,
+          quoted_post_id: nil,
+          quoted_user_id: nil,
+          quoted_username: nil
+        )
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            placeholder,
+            post_id,
+            quoted_post_id,
+            quoted_user_id,
+            quoted_username,
+          )
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_upload.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_upload.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostUpload
+        SQL = <<~SQL
+          INSERT INTO post_uploads (
+            placeholder,
+            post_id,
+            upload_id
+          )
+          VALUES (
+            ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_uploads` record in the IntermediateDB.
+        #
+        # @param placeholder   [String]
+        # @param post_id       [Integer, String]
+        # @param upload_id     [String, nil]
+        #
+        # @return [void]
+        def self.create(placeholder:, post_id:, upload_id: nil)
+          Migrations::Database::IntermediateDB.insert(SQL, placeholder, post_id, upload_id)
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/placeholder.rb
+++ b/migrations/core/lib/migrations/placeholder.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Migrations
+  # Single source of truth for the opaque tokens that stand in for deferred post
+  # embeds (uploads, polls, events, quotes, links, mentions) inside `post.raw`.
+  #
+  # An embed cannot always be finalized while a post is converted: rendering it
+  # needs the `original_id -> discourse_id` maps that only exist at import time.
+  # The converter therefore splices a *placeholder* token into the raw and records
+  # a typed linkage row carrying the same token; the importer rewrites the token
+  # once the maps are available (see `Migrations::Importer::PlaceholderResolver`).
+  #
+  # The contract that makes this safe is a single invariant: the token spliced into
+  # `raw` and the `placeholder` stored on the linkage row are byte-identical. Because
+  # this class owns the token grammar, substitution at import time is a plain `gsub`
+  # — no whitespace-padding hacks, no per-post SQL.
+  #
+  # ## Token format
+  #
+  # A token is bracketed by a Unicode Private Use Area delimiter (`U+E000`) and
+  # carries a per-run random nonce:
+  #
+  #     <nonce>.<kind>.<sequence>
+  #
+  # Two independent guarantees keep a token from ever colliding with user content:
+  #
+  #   1. **Delimiter** — `U+E000` is a private-use code point with no assigned
+  #      meaning; it does not occur in real post content, so a bare `gsub` of the
+  #      whole token is unambiguous and the v1 link whitespace-padding hack is
+  #      unnecessary.
+  #   2. **Nonce** — a random value generated once per `Placeholder` instance (i.e.
+  #      once per conversion run). Even if a delimiter somehow leaked into source
+  #      text, the token still could not be forged because the nonce is
+  #      unpredictable.
+  #
+  # The `kind` and `sequence` segments are not required for correctness —
+  # uniqueness comes from the nonce plus the monotonic sequence — but they keep
+  # tokens readable when inspecting a raw body while debugging.
+  class Placeholder
+    # Private Use Area code point used to bracket every token.
+    DELIMITER = "\u{E000}"
+
+    # Matches a whole token regardless of which run minted it (the nonce is opaque
+    # here). Used by the importer and tests to find every token in a raw body.
+    PATTERN = /#{DELIMITER}[^#{DELIMITER}]+#{DELIMITER}/
+
+    # @param nonce [String] overridable only so tests can mint deterministic
+    #   tokens; production code should let it default to a random value.
+    def initialize(nonce: SecureRandom.alphanumeric(16))
+      @nonce = nonce
+      @sequence = 0
+    end
+
+    # Mints the next unique token for the given embed `kind` (e.g. `:quote`).
+    #
+    # @param kind [Symbol, String]
+    # @return [String] the token to splice into `raw` and store as `placeholder`.
+    def mint(kind)
+      @sequence += 1
+      "#{DELIMITER}#{@nonce}.#{kind}.#{@sequence}#{DELIMITER}"
+    end
+
+    # @return [Array<String>] every token present in `text`, in order of appearance.
+    def self.scan(text)
+      text.to_s.scan(PATTERN)
+    end
+
+    # @return [Boolean] whether `text` still contains at least one token.
+    def self.include?(text)
+      PATTERN.match?(text.to_s)
+    end
+  end
+end

--- a/migrations/core/spec/lib/placeholder_spec.rb
+++ b/migrations/core/spec/lib/placeholder_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Placeholder do
+  subject(:placeholder) { described_class.new(nonce: "testnonce") }
+
+  describe "#mint" do
+    it "wraps every token in the Private Use Area delimiter" do
+      token = placeholder.mint(:quote)
+
+      expect(token).to start_with(described_class::DELIMITER)
+      expect(token).to end_with(described_class::DELIMITER)
+    end
+
+    it "embeds the nonce and kind for readability" do
+      expect(placeholder.mint(:upload)).to include("testnonce", "upload")
+    end
+
+    it "mints a unique token on every call" do
+      tokens = Array.new(5) { placeholder.mint(:link) }
+
+      expect(tokens.uniq.size).to eq(5)
+    end
+
+    it "produces different tokens across runs (different nonces)" do
+      other = described_class.new
+
+      expect(placeholder.mint(:quote)).not_to eq(other.mint(:quote))
+    end
+
+    it "does not produce a token that could appear in ordinary user content" do
+      token = placeholder.mint(:mention)
+      sentence = "a normal sentence with @mentions and [links](http://x)"
+
+      # The delimiter is a private-use code point, so it cannot occur in real text.
+      expect(sentence).not_to include(described_class::DELIMITER)
+      expect(token).to include(described_class::DELIMITER)
+    end
+  end
+
+  describe ".scan" do
+    it "finds every token in a raw body, in order" do
+      first = placeholder.mint(:quote)
+      second = placeholder.mint(:link)
+      raw = "before #{first} middle #{second} after"
+
+      expect(described_class.scan(raw)).to eq([first, second])
+    end
+
+    it "returns an empty array when there are no tokens" do
+      expect(described_class.scan("no tokens here")).to be_empty
+    end
+
+    it "tolerates nil" do
+      expect(described_class.scan(nil)).to be_empty
+    end
+  end
+
+  describe ".include?" do
+    it "is true when a token is present" do
+      raw = "x #{placeholder.mint(:event)} y"
+
+      expect(described_class).to be_include(raw)
+    end
+
+    it "is false for plain text" do
+      expect(described_class).not_to be_include("just text")
+    end
+  end
+end

--- a/migrations/importer/lib/migrations/importer/placeholder_resolver.rb
+++ b/migrations/importer/lib/migrations/importer/placeholder_resolver.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Importer
+    # Import-time counterpart of the converter's `EmbedBuffer`: it rewrites the
+    # opaque placeholder tokens left in `post.raw` back into real Markdown, now that
+    # the `original_id -> discourse_id` maps exist.
+    #
+    # This is the v2 replacement for the v1 `raw_with_placeholders_interpolated`
+    # helper. Two things change, both deliberate:
+    #
+    #   * **Load once, substitute many.** All linkage rows for a batch of posts are
+    #     read up front (one query per kind), then every body is rewritten purely in
+    #     memory. The v1 version ran several SQL queries *inside* the per-post
+    #     substitution loop; here there is no SQL on the substitution path.
+    #   * **Plain `gsub`, no padding hacks.** Because `Migrations::Placeholder`
+    #     brackets every token in a Private Use Area delimiter, a token can never
+    #     collide with user content, so the v1 link whitespace-padding regex dance is
+    #     gone — each token is replaced with a bare `String#gsub`.
+    #
+    # ## The `maps` collaborator
+    #
+    # Rendering needs the already-built import maps. They are injected as a single
+    # duck-typed `maps` object so the resolver stays pure (no DB access while
+    # substituting) and unit-testable. It must respond to:
+    #
+    #   * `user(original_id)`          => `{ username:, name: }` or `nil`
+    #   * `group_name(original_id)`    => `String` or `nil`
+    #   * `post(original_id)`          => `{ topic_id:, post_number: }` or `nil`
+    #   * `topic_id(original_id)`      => discourse topic id or `nil`
+    #   * `upload_markdown(original_id)` => resolved `upload://…` Markdown or `nil`
+    #   * `poll_markdown(original_id)` => the poll's rendered Markdown or `nil`
+    #   * `event_markdown(original_id)` => the event's rendered Markdown or `nil`
+    #   * `base_url`                   => the destination site's base URL
+    #
+    # Lookups that return `nil` fall back to the source value (or an empty string),
+    # mirroring the v1 behaviour.
+    class PlaceholderResolver
+      # Maps each typed collection to its IntermediateDB linkage table.
+      TABLES = {
+        quote: "post_quotes",
+        link: "post_links",
+        mention: "post_mentions",
+        poll: "post_polls",
+        event: "post_events",
+        upload: "post_uploads",
+      }.freeze
+      private_constant :TABLES
+
+      # @param intermediate_db [Migrations::Database::Connection] read-only access to
+      #   the IntermediateDB linkage tables.
+      # @param maps [#user, #group_name, #post, #topic_id, #upload_markdown,
+      #   #poll_markdown, #event_markdown, #base_url] the built import maps.
+      def initialize(intermediate_db, maps)
+        @intermediate_db = intermediate_db
+        @maps = maps
+      end
+
+      # Resolves the placeholder tokens in a batch of posts.
+      #
+      # @param posts [Array<Hash>] each with `:id` (the source post original_id) and
+      #   `:raw`.
+      # @return [Hash{Object => String}] source post id => resolved raw.
+      def resolve_all(posts)
+        linkages = load_linkages(posts.map { |post| post[:id] })
+
+        posts.each_with_object({}) do |post, result|
+          result[post[:id]] = substitute(post[:raw], linkages[post[:id]])
+        end
+      end
+
+      # Resolves the placeholder tokens in a single raw body against its already
+      # loaded linkage rows. Used by `resolve_all`; exposed for callers that load
+      # linkage rows themselves.
+      #
+      # @param raw [String, nil]
+      # @param linkage_rows [Array<Hash>, nil] rows tagged with `:_kind`.
+      # @return [String, nil]
+      def substitute(raw, linkage_rows)
+        return raw if raw.nil? || linkage_rows.nil? || linkage_rows.empty?
+
+        result = raw.dup
+        linkage_rows.each { |row| result = result.gsub(row[:placeholder], render(row)) }
+        result
+      end
+
+      private
+
+      # One query per kind, grouped by post id. This is the only place that touches
+      # the database; the substitution path below is pure.
+      def load_linkages(post_ids)
+        buckets = Hash.new { |hash, key| hash[key] = [] }
+        return buckets if post_ids.empty?
+
+        bind_params = (["?"] * post_ids.size).join(", ")
+
+        TABLES.each do |kind, table|
+          sql = "SELECT * FROM #{table} WHERE post_id IN (#{bind_params})"
+          @intermediate_db.query(sql, *post_ids) do |row|
+            row[:_kind] = kind
+            buckets[row[:post_id]] << row
+          end
+        end
+
+        buckets
+      end
+
+      def render(row)
+        case row[:_kind]
+        when :quote
+          render_quote(row)
+        when :link
+          render_link(row)
+        when :mention
+          render_mention(row)
+        when :poll
+          @maps.poll_markdown(row[:poll_id]).to_s
+        when :event
+          @maps.event_markdown(row[:event_id]).to_s
+        when :upload
+          @maps.upload_markdown(row[:upload_id]).to_s
+        else
+          raise ArgumentError, "Unknown placeholder kind: #{row[:_kind].inspect}"
+        end
+      end
+
+      def render_quote(row)
+        user = row[:quoted_user_id] ? @maps.user(row[:quoted_user_id]) : nil
+        username = user&.fetch(:username, nil) || row[:quoted_username]
+        name = user&.fetch(:name, nil)
+
+        if row[:quoted_post_id] && (post = @maps.post(row[:quoted_post_id]))
+          topic_id = post[:topic_id]
+          post_number = post[:post_number]
+        end
+
+        return "[quote]" if username.blank? && name.blank?
+
+        parts = []
+        parts << (name.presence || username)
+        parts << "post:#{post_number}" if post_number.present?
+        parts << "topic:#{topic_id}" if topic_id.present?
+        parts << "username:#{username}" if username.present? && name.present?
+
+        "[quote=\"#{parts.join(", ")}\"]"
+      end
+
+      def render_link(row)
+        url =
+          if row[:target_topic_id]
+            (topic_id = @maps.topic_id(row[:target_topic_id])) ? topic_url(topic_id) : row[:url]
+          elsif row[:target_post_id] && (post = @maps.post(row[:target_post_id]))
+            post[:topic_id] && post[:post_number] ? post_url(post) : row[:url]
+          else
+            row[:url]
+          end
+
+        row[:text] ? "[#{row[:text]}](#{url})" : url.to_s
+      end
+
+      def render_mention(row)
+        name =
+          case row[:mention_type]
+          when "here"
+            "here"
+          when "all"
+            "all"
+          when "group"
+            @maps.group_name(row[:target_id]) || row[:name]
+          else
+            @maps.user(row[:target_id])&.fetch(:username, nil) || row[:name]
+          end
+
+        name.present? ? " @#{name} " : ""
+      end
+
+      def topic_url(topic_id)
+        "#{@maps.base_url}/t/#{topic_id}"
+      end
+
+      def post_url(post)
+        "#{@maps.base_url}/t/#{post[:topic_id]}/#{post[:post_number]}"
+      end
+    end
+  end
+end

--- a/migrations/importer/spec/lib/migrations/importer/placeholder_resolver_spec.rb
+++ b/migrations/importer/spec/lib/migrations/importer/placeholder_resolver_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+# A minimal stand-in for the import maps. Production wiring (mappings DB, uploads
+# store, Discourse base URL) lands with the Posts import step; the resolver only
+# depends on this small duck-typed surface.
+class FakePlaceholderMaps
+  def initialize(**lookups)
+    @lookups = lookups
+  end
+
+  %i[user group_name post topic_id upload_markdown poll_markdown event_markdown].each do |name|
+    define_method(name) { |original_id| (@lookups[name] || {})[original_id] }
+  end
+
+  def base_url
+    @lookups.fetch(:base_url, "https://dest.example.com")
+  end
+end
+
+RSpec.describe Migrations::Importer::PlaceholderResolver do
+  subject(:resolver) { described_class.new(intermediate_db, maps) }
+
+  let(:placeholder) { Migrations::Placeholder.new(nonce: "n") }
+  let(:intermediate_db) { @intermediate_db }
+  let(:maps) { FakePlaceholderMaps.new }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      db_path = File.join(dir, "intermediate.db")
+      Migrations::Database.migrate(
+        db_path,
+        migrations_path: Migrations::Database::INTERMEDIATE_DB_SCHEMA_PATH,
+      )
+      @intermediate_db = Migrations::Database.connect(db_path)
+      Migrations::Database::IntermediateDB.setup(@intermediate_db)
+      example.run
+    ensure
+      Migrations::Database::IntermediateDB.setup(nil)
+    end
+  end
+
+  describe "#resolve_all" do
+    it "rewrites every kind of token using the maps" do
+      quote = placeholder.mint(:quote)
+      link = placeholder.mint(:link)
+      mention = placeholder.mint(:mention)
+      upload = placeholder.mint(:upload)
+
+      Migrations::Database::IntermediateDB::PostQuote.create(
+        post_id: 100,
+        placeholder: quote,
+        quoted_post_id: 200,
+        quoted_user_id: 5,
+      )
+      Migrations::Database::IntermediateDB::PostLink.create(
+        post_id: 100,
+        placeholder: link,
+        url: "https://old.example.com/x",
+        text: "See",
+        target_topic_id: 300,
+      )
+      Migrations::Database::IntermediateDB::PostMention.create(
+        post_id: 100,
+        placeholder: mention,
+        mention_type: "user",
+        target_id: 7,
+        name: "stale-name",
+      )
+      Migrations::Database::IntermediateDB::PostUpload.create(
+        post_id: 100,
+        placeholder: upload,
+        upload_id: "sha1",
+      )
+
+      maps =
+        FakePlaceholderMaps.new(
+          user: {
+            5 => {
+              username: "alice",
+              name: "Alice A",
+            },
+            7 => {
+              username: "bob",
+              name: "Bob",
+            },
+          },
+          post: {
+            200 => {
+              topic_id: 42,
+              post_number: 3,
+            },
+          },
+          topic_id: {
+            300 => 99,
+          },
+          upload_markdown: {
+            "sha1" => "![pic](upload://sha1.png)",
+          },
+        )
+      resolver = described_class.new(intermediate_db, maps)
+
+      raw = "Q #{quote} L #{link} M #{mention} U #{upload} end"
+
+      resolved = resolver.resolve_all([{ id: 100, raw: }])
+
+      expect(resolved[100]).to eq(
+        'Q [quote="Alice A, post:3, topic:42, username:alice"] ' \
+          "L [See](https://dest.example.com/t/99) M  @bob  U ![pic](upload://sha1.png) end",
+      )
+      expect(Migrations::Placeholder).not_to be_include(resolved[100])
+    end
+
+    it "resolves a batch of posts, loading linkage rows once" do
+      first = placeholder.mint(:mention)
+      second = placeholder.mint(:mention)
+
+      Migrations::Database::IntermediateDB::PostMention.create(
+        post_id: 1,
+        placeholder: first,
+        mention_type: "all",
+      )
+      Migrations::Database::IntermediateDB::PostMention.create(
+        post_id: 2,
+        placeholder: second,
+        mention_type: "here",
+      )
+
+      resolved =
+        resolver.resolve_all([{ id: 1, raw: "a #{first} b" }, { id: 2, raw: "c #{second} d" }])
+
+      expect(resolved).to eq({ 1 => "a  @all  b", 2 => "c  @here  d" })
+    end
+
+    it "leaves a body untouched when it has no linkage rows" do
+      expect(resolver.resolve_all([{ id: 9, raw: "plain body" }])).to eq({ 9 => "plain body" })
+    end
+  end
+
+  describe "rendering fallbacks" do
+    it "keeps the source URL when the link target is unmapped" do
+      link = placeholder.mint(:link)
+      Migrations::Database::IntermediateDB::PostLink.create(
+        post_id: 1,
+        placeholder: link,
+        url: "https://old.example.com/x",
+        text: "See",
+        target_topic_id: 300,
+      )
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "x #{link} y" }])
+
+      expect(resolved[1]).to eq("x [See](https://old.example.com/x) y")
+    end
+
+    it "falls back to the recorded username when the user is unmapped" do
+      quote = placeholder.mint(:quote)
+      Migrations::Database::IntermediateDB::PostQuote.create(
+        post_id: 1,
+        placeholder: quote,
+        quoted_user_id: 5,
+        quoted_username: "ghost",
+      )
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "x #{quote} y" }])
+
+      expect(resolved[1]).to eq('x [quote="ghost"] y')
+    end
+
+    it "renders a bare [quote] when nothing identifies the quoted author" do
+      quote = placeholder.mint(:quote)
+      Migrations::Database::IntermediateDB::PostQuote.create(post_id: 1, placeholder: quote)
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "x #{quote} y" }])
+
+      expect(resolved[1]).to eq("x [quote] y")
+    end
+
+    it "drops an entity-backed embed whose markdown is unavailable" do
+      poll = placeholder.mint(:poll)
+      Migrations::Database::IntermediateDB::PostPoll.create(
+        post_id: 1,
+        placeholder: poll,
+        poll_id: 3,
+      )
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "before #{poll} after" }])
+
+      expect(resolved[1]).to eq("before  after")
+      expect(Migrations::Placeholder).not_to be_include(resolved[1])
+    end
+  end
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_events.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_events.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Deferred event embeds. Entity-backed — `event_id` carries the source
+# `original_id` of an event converted by its own step (the `events` table), which
+# the importer renders into the post body once that entity is available. The
+# `placeholder` column holds the token spliced into `post.raw`; see
+# `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_events do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :event_id, :numeric
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_links.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_links.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Deferred internal/external links. Pure artifacts — they reference no Discourse
+# entity and exist only as raw substitutions that the importer finalizes once the
+# `original_id -> discourse_id` maps are available. `target_topic_id` /
+# `target_post_id` carry the source `original_id` of the linked entity, if any.
+# The `placeholder` column holds the token spliced into `post.raw`; see
+# `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_links do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :url, :text
+  add_column :text, :text
+  add_column :target_topic_id, :numeric
+  add_column :target_post_id, :numeric
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_mentions.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_mentions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Deferred `@mention` embeds. Pure artifacts — they reference no Discourse entity
+# and exist only as raw substitutions that the importer finalizes once the
+# `original_id -> discourse_id` maps are available. `mention_type` is one of
+# `user` / `group` / `here` / `all`; `target_id` carries the source `original_id`
+# of the mentioned user or group (nil for `here` / `all`). The `placeholder`
+# column holds the token spliced into `post.raw`; see `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_mentions do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :mention_type, :text
+  add_column :target_id, :numeric
+  add_column :name, :text
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_polls.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_polls.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Deferred poll embeds. Entity-backed — `poll_id` carries the source `original_id`
+# of a poll converted by its own step (the `polls` table), which the importer
+# renders into the post body once that entity is available. The `placeholder`
+# column holds the token spliced into `post.raw`; see `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_polls do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :poll_id, :numeric
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_quotes.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_quotes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Deferred `[quote]` embeds. Pure artifacts — they reference no Discourse entity
+# and exist only as raw substitutions that the importer finalizes once the
+# `original_id -> discourse_id` maps are available. The `placeholder` column holds
+# the token spliced into `post.raw`; see `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_quotes do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :quoted_post_id, :numeric
+  add_column :quoted_user_id, :numeric
+  add_column :quoted_username, :text
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_uploads.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_uploads.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Deferred upload embeds. Entity-backed — `upload_id` references a row in the
+# `uploads` table; the importer reads that upload's resolved `upload://…` markdown
+# from the uploads store and substitutes it into the post body. The `placeholder`
+# column holds the token spliced into `post.raw`; see `Migrations::Placeholder`.
+#
+# NOTE: `upload_id` is `:text`, not `:numeric`. Upload `original_id`s in the
+# IntermediateDB are content hashes (see `uploads.id`, also `:text`), matching the
+# global `.*upload.*_id$ => :text` convention, so the reference must be text too.
+Migrations::Tooling::Schema.table :post_uploads do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :upload_id, :text
+
+  index :post_id
+end


### PR DESCRIPTION
Stacked on #204 (review/merge that first; this PR's diff is just the cooker commit and will retarget to `main` once #204 lands).

Adds the convert-time cooker the placeholder model plugs into. **`Migrations::Converters::Content`** wraps the [`markbridge`](https://github.com/discourse/markbridge) gem to turn a source forum's post markup (BBCode, HTML, MediaWiki, TextFormatter XML) into Discourse Markdown.

### How it works
- The Markbridge placeholder rendering is implemented **once** and shared by every converter. `Content.embed_handlers` is the single registry mapping each Markbridge AST node (`Upload`/`Quote`/`Mention`/`Url`) to the extraction that records into the sink and returns a placeholder token. Adding a converter needs **zero** placeholder-rendering code — it just calls `Content.new(format:).to_markdown(item[:body], on_embed: buffer)`.
- When given an `EmbedBuffer` (or any embed sink), the configured embed node types are not rendered inline: each is recorded on the sink and replaced in the output by a `Migrations::Placeholder` token, which the importer's `PlaceholderResolver` finalizes once the id maps exist.
- The overrides use Markbridge's documented extension point — `discourse_renderer(tags:)` with custom `Tag` handlers keyed by AST node class.

### Design notes
- Markbridge AST nodes carry **source content** (sha1, username, poll options), not foreign ids, so deferral is selective: uploads/quotes/mentions deferred by default; links opt-in (most URLs are external and render fine); polls/events/images render natively (self-contained). Their linkage tables remain for converters that source them separately.
- A **quote defers only its attribution**, preserving the quoted body, and falls back to native rendering when there is no foreign reference to remap.
- Markbridge parses BBCode/HTML/MediaWiki/TextFormatter, **not Markdown**, so a Discourse → Discourse migration (whose `raw` is already Markdown) does not use the cooker. HTML/MediaWiki/TextFormatter need nokogiri (provided by the host app); BBCode does not.

### Tests
- 9 cooker specs run against the real `markbridge` 0.2.0 gem; full converters suite green (28).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfxiZpzMVW2YoyH1EWDoij)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gschlager/discourse/205)
<!-- Reviewable:end -->
