### PR TITLE
DEV: Extract PostEmbedWriter and teach coverage about it

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport
       colored2
       i18n
+      markbridge
       migrations-core
       pg
       zeitwerk
@@ -348,6 +349,7 @@ GEM
       net-pop
       net-smtp
     mapping (1.1.3)
+    markbridge (0.2.0)
     matrix (0.4.3)
     maxminddb (0.1.22)
     memory_profiler (1.1.0)
@@ -1119,6 +1121,7 @@ CHECKSUMS
   lz4-ruby (0.3.3) sha256=011be5ee230cfddc8308d4e2e0b05300c7bc755a887de799377ca6c5b6aede89
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   mapping (1.1.3) sha256=2274931d20ecd46eaafdd1e00c58cc7472133b213bcac335cc7733d3c75f4da2
+  markbridge (0.2.0) sha256=b6e94b4871da692922cbcff5ca4bc01f1d169f7e9869e06a9706d713c6b8ae89
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   maxminddb (0.1.22) sha256=50933be438fbed9dceabef4163eab41884bd8830d171fdb8f739bee769c4907e
   memory_profiler (1.1.0) sha256=79a17df7980a140c83c469785905409d3027ca614c42c086089d128b805aa8f8

--- a/migrations/converters/lib/migrations/converters/content.rb
+++ b/migrations/converters/lib/migrations/converters/content.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "markbridge"
+
+module Migrations
+  module Converters
+    # Convert-time wrapper over the Markbridge gem: turns a source forum's post
+    # markup (BBCode, HTML, MediaWiki, TextFormatter XML) into Discourse Markdown,
+    # optionally deferring the embeds that cannot be finalized until import time.
+    #
+    # When an `on_embed` sink (an {EmbedBuffer}, or anything answering the embed
+    # callbacks) is passed, the configured embed node types are not rendered
+    # inline: each is recorded on the sink and replaced in the output by a
+    # placeholder token (see {Migrations::Placeholder}). Everything else renders
+    # natively. With no sink, this is a plain cook.
+    #
+    # Markbridge does not parse Markdown, so a Discourse -> Discourse migration
+    # (whose `raw` is already Markdown) does not use this; the cooker is for forums
+    # whose post bodies are in one of the formats above.
+    #
+    # @example deferring uploads and quotes into an EmbedBuffer
+    #   buffer = EmbedBuffer.new
+    #   raw = Content.new(format: :bbcode).to_markdown(item[:body], on_embed: buffer)
+    #   # `raw` now carries placeholder tokens; `buffer.uploads` / `buffer.quotes`
+    #   # hold the typed linkage descriptors.
+    class Content
+      class UnknownFormat < StandardError
+      end
+
+      # The `require` path for each supported source format. HTML / MediaWiki /
+      # TextFormatter additionally need nokogiri (provided by the host
+      # application); BBCode has no extra dependency.
+      FORMATS = {
+        bbcode: "markbridge/bbcode",
+        html: "markbridge/html",
+        mediawiki: "markbridge/mediawiki",
+        text_formatter_xml: "markbridge/textformatter",
+      }.freeze
+
+      # Embeds deferred unless the caller narrows or extends the set. These always
+      # need the import-time maps when present: uploads must be re-uploaded, quotes
+      # reference foreign post/topic/user ids, mentions reference a foreign
+      # username. `:link` is intentionally excluded by default — most URLs are
+      # external and render fine; a converter that rewrites internal links opts in
+      # explicitly with `defer:`.
+      DEFAULT_DEFER = %i[upload quote mention].freeze
+
+      # Maps a friendly embed kind to the Markbridge AST node class it overrides
+      # and the extraction that feeds the sink. Each lambda returns the placeholder
+      # token (the `EmbedBuffer#<kind>` call returns it), which Markbridge then
+      # emits as the node's rendered output.
+      def self.embed_handlers
+        @embed_handlers ||= {
+          upload: [
+            Markbridge::AST::Upload,
+            ->(sink, node, _iface) { sink.upload(upload_id: node.sha1) },
+          ],
+          quote: [
+            Markbridge::AST::Quote,
+            ->(sink, node, iface) do
+              # Only the attribution carries the foreign post/topic/user reference
+              # that needs remapping; the quoted body renders normally and the
+              # closing tag stays in place. A quote with no such reference has
+              # nothing to remap, so it renders natively (preserving its
+              # attribution exactly). The token stands in for the opening
+              # `[quote="…"]`, which PlaceholderResolver#render_quote rebuilds.
+              unless node.post || node.topic || node.username
+                next Markbridge::Renderers::Discourse::Tags::QuoteTag.new.render(node, iface)
+              end
+
+              token = sink.quote(quoted_post_id: node.post, quoted_username: node.username)
+              content = iface.render_children(node, context: iface.with_parent(node))
+              "\n\n#{token}\n#{content}\n[/quote]\n\n"
+            end,
+          ],
+          mention: [
+            Markbridge::AST::Mention,
+            ->(sink, node, _iface) { sink.mention(mention_type: node.type.to_s, name: node.name) },
+          ],
+          link: [
+            Markbridge::AST::Url,
+            ->(sink, node, iface) { sink.link(url: node.href, text: iface.render_children(node)) },
+          ],
+        }
+      end
+
+      # @param format [Symbol] one of {FORMATS}.
+      def initialize(format: :bbcode)
+        @format = format.to_sym
+        raise UnknownFormat, "Unknown source format: #{format}" unless FORMATS.key?(@format)
+
+        require FORMATS.fetch(@format)
+      end
+
+      # @param source [String] the source post body.
+      # @param on_embed [#upload, #quote, #mention, #link, nil] the embed sink; when
+      #   nil the embeds render natively.
+      # @param defer [Array<Symbol>] which embed kinds to defer (default
+      #   {DEFAULT_DEFER}). Ignored when `on_embed` is nil.
+      # @return [String] Discourse Markdown.
+      def to_markdown(source, on_embed: nil, defer: DEFAULT_DEFER)
+        renderer = on_embed ? deferring_renderer(on_embed, defer) : nil
+        Markbridge.convert(source, format: @format, renderer:).markdown
+      end
+
+      private
+
+      def deferring_renderer(sink, defer)
+        tags =
+          Array(defer).each_with_object({}) do |kind, mapping|
+            node_class, extract = self.class.embed_handlers.fetch(kind)
+            mapping[node_class] = Markbridge::Renderers::Discourse::Tag.new do |node, iface|
+              extract.call(sink, node, iface)
+            end
+          end
+
+        Markbridge.discourse_renderer(tags:)
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/discourse/converter.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/converter.rb
@@ -10,7 +10,26 @@ module Migrations
         end
 
         def step_args(step_class)
-          { source_db: @source_db }
+          { source_db: @source_db, group_names:, here_mention: }
+        end
+
+        private
+
+        # Lowercased source group names, so the Posts step can classify `@group`
+        # mentions. Loaded once and shared with every step's processor (steps that
+        # don't declare an accessor simply ignore it).
+        def group_names
+          @group_names ||=
+            @source_db.query("SELECT LOWER(name) AS name FROM groups").map { |row| row[:name] }
+        end
+
+        # The source's `here_mention` setting value (the configurable name that
+        # triggers an `@here` mention); falls back to the Discourse default when the
+        # source uses it (defaults aren't stored in `site_settings`).
+        def here_mention
+          @here_mention ||=
+            @source_db.query_value("SELECT value FROM site_settings WHERE name = 'here_mention'") ||
+              "here"
         end
       end
     end

--- a/migrations/converters/lib/migrations/converters/discourse/markdown_scanner.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/markdown_scanner.rb
@@ -1,0 +1,429 @@
+# frozen_string_literal: true
+
+require "markbridge"
+
+module Migrations
+  module Converters
+    module Discourse
+      # Single-pass scanner for Discourse Markdown that extracts specific constructs
+      # (uploads, quote attributions, mentions) while leaving everything else — and,
+      # crucially, anything inside fenced/indented/inline **code** — untouched.
+      #
+      # This is vendored from Markbridge 0.2.0's `Processors::DiscourseMarkdown`
+      # (`Scanner` + `CodeBlockTracker` + the upload/mention detectors). That
+      # Markdown-scanning logic is Discourse-specific and is being removed from
+      # Markbridge, which keeps only the format-agnostic AST and renderer — so it
+      # lives here now. We still rely on `Markbridge::AST::*` for the node types.
+      #
+      # The scanner walks the input character by character; on a successful match it
+      # asks the supplied block for the replacement text (a placeholder token) and
+      # skips past the matched span.
+      module MarkdownScanner
+        # A deferred quote attribution. Markbridge has no quote AST node of this
+        # shape (its `AST::Quote` is a full block element), and only the opening
+        # `[quote="…"]` carries the post/topic/user references that need remapping.
+        QuoteAttribution = Data.define(:username, :post)
+
+        module Detectors
+          # Result of a successful detection.
+          Match = Data.define(:start_pos, :end_pos, :node)
+
+          # Base class for construct detectors.
+          class Base
+            # @return [Match, nil]
+            def detect(input, pos)
+              raise NotImplementedError, "#{self.class} must implement #detect"
+            end
+
+            private
+
+            WORD_PATTERN = /\A[\w\-]*/
+            private_constant :WORD_PATTERN
+
+            def word_boundary?(input, pos)
+              return true if pos.zero?
+
+              !input[pos - 1].match?(/\w/)
+            end
+
+            # Extract a word starting at position. Caller must ensure pos is within
+            # bounds (`pos <= input.length`).
+            def extract_word(input, pos)
+              input[pos..].match(WORD_PATTERN)[0]
+            end
+          end
+
+          # Detects user and group mentions (`@name`). The mention *type* is decided
+          # later by the converter's MentionResolver (it needs the source's groups
+          # and `here_mention` setting), so the node just carries the name.
+          class Mention < Base
+            def detect(input, pos)
+              return nil unless input[pos] == "@"
+              return nil unless word_boundary?(input, pos)
+
+              name = extract_word(input, pos + 1)
+              return nil if name.empty?
+
+              Match.new(
+                start_pos: pos,
+                end_pos: pos + 1 + name.length,
+                node: Markbridge::AST::Mention.new(name:),
+              )
+            end
+          end
+
+          # Detects Discourse upload references (`upload://` URLs), both
+          # `![alt|dims](upload://sha1.ext)` images and
+          # `[file|attachment](upload://sha1.ext) (size)` attachments.
+          class Upload < Base
+            IMAGE_PATTERN =
+              %r{\A!\[(?<alt>[^|\]]*)(?:\|(?<dimensions>[^\]]*))?\]\(upload://(?<url>[^)]+)\)}
+
+            ATTACHMENT_PATTERN =
+              %r{
+              \A
+              \[(?<filename>[^|\]]*)\|attachment\]
+              \(upload://(?<url>[^)]+)\)
+              (?:\s*\((?<size>[^)]+)\))?
+            }xi
+
+            def detect(input, pos)
+              remaining = input[pos..]
+
+              case input[pos]
+              when "!"
+                detect_image(remaining, pos)
+              when "["
+                detect_attachment(remaining, pos)
+              end
+            end
+
+            private
+
+            def detect_image(remaining, pos)
+              match = IMAGE_PATTERN.match(remaining)
+              return nil unless match
+
+              sha1, filename = parse_upload_url(match[:url])
+              alt = match[:alt]
+              alt = nil if alt.empty?
+
+              node =
+                Markbridge::AST::Upload.new(
+                  sha1:,
+                  filename:,
+                  alt:,
+                  dimensions: match[:dimensions],
+                  raw: match[0],
+                )
+
+              Match.new(start_pos: pos, end_pos: pos + match[0].length, node:)
+            end
+
+            def detect_attachment(remaining, pos)
+              match = ATTACHMENT_PATTERN.match(remaining)
+              return nil unless match
+
+              sha1, = parse_upload_url(match[:url])
+
+              node =
+                Markbridge::AST::Upload.new(
+                  sha1:,
+                  filename: match[:filename],
+                  type: :attachment,
+                  size: match[:size],
+                  raw: match[0],
+                )
+
+              Match.new(start_pos: pos, end_pos: pos + match[0].length, node:)
+            end
+
+            # URL format: `sha1.ext` or just `sha1`. Returns `[sha1, filename-or-nil]`.
+            def parse_upload_url(url_part)
+              sha1, _, ext = url_part.partition(".")
+              [sha1, ext.empty? ? nil : url_part]
+            end
+          end
+
+          # Detects only the opening tag of a Discourse quote (`[quote="…"]`); the
+          # body and `[/quote]` stay in place, and any embeds inside the body are
+          # still scanned. Returns nil for an unattributed `[quote]`.
+          class Quote < Base
+            OPENING = /\A\[quote="(?<attribution>[^"\]]*)"\]/
+
+            def detect(input, pos)
+              return nil unless input[pos] == "["
+
+              match = OPENING.match(input[pos..])
+              return nil unless match
+
+              username, post = parse_attribution(match[:attribution])
+              return nil if username.nil?
+
+              Match.new(
+                start_pos: pos,
+                end_pos: pos + match[0].length,
+                node: QuoteAttribution.new(username:, post:),
+              )
+            end
+
+            private
+
+            # The username is the explicit `username:` value when present (Discourse
+            # uses it when the display name differs), else the leading bare token.
+            def parse_attribution(string)
+              username = post = name = nil
+
+              string
+                .split(",")
+                .map(&:strip)
+                .each_with_index do |part, index|
+                  case part
+                  when /\Apost:(\d+)\z/
+                    post = Regexp.last_match(1)
+                  when /\Atopic:\d+\z/
+                    next
+                  when /\Ausername:(.+)\z/
+                    username = Regexp.last_match(1)
+                  else
+                    name = part if index.zero? && !part.empty?
+                  end
+                end
+
+              [username || name, post]
+            end
+          end
+        end
+
+        # Tracks whether the current position is inside a code block: fenced
+        # (``` ``` ``` / `~~~`), indented (4+ spaces or a tab), or inline (`` ` ``).
+        class CodeBlockTracker
+          attr_reader :in_fenced_block, :in_indented_block, :in_inline_code
+
+          def initialize
+            @in_fenced_block = false
+            @in_indented_block = false
+            @in_inline_code = false
+          end
+
+          def in_code?
+            @in_fenced_block || @in_indented_block || @in_inline_code
+          end
+
+          # @return [Integer, nil] end position after a fence, or nil.
+          def check_fenced_boundary(input, pos, line_start:)
+            return nil unless line_start
+
+            input_length = input.length
+            scan_pos = skip_leading_spaces(input, pos)
+            fence_char = input[scan_pos]
+            return nil unless fence_char == "`" || fence_char == "~"
+
+            fence_length, scan_pos = count_fence_chars(input, scan_pos, fence_char, input_length)
+            return nil if fence_length < 3
+
+            if @in_fenced_block
+              try_close_fence(input, scan_pos, fence_char, fence_length, input_length)
+            else
+              open_fence(input, scan_pos, fence_char, fence_length, input_length)
+            end
+          end
+
+          # @return [Integer, nil] end position after an indented-code line, or nil.
+          def check_indented_boundary(input, pos, line_start:)
+            return nil unless line_start
+            return nil if @in_fenced_block
+
+            input_length = input.length
+            line_end = input.index("\n", pos) || input_length
+            line_content = input[pos...line_end]
+            is_blank = line_content.match?(/\A\s*\z/)
+            has_code_indent = line_content.start_with?("    ") || line_content.start_with?("\t")
+
+            if @in_indented_block
+              if is_blank || has_code_indent
+                pos_after_line(line_end, input_length)
+              else
+                @in_indented_block = false
+                nil
+              end
+            elsif has_code_indent
+              @in_indented_block = true
+              pos_after_line(line_end, input_length)
+            end
+          end
+
+          # @return [Integer, nil] end position after inline code delimiter, or nil.
+          def check_inline_boundary(input, pos)
+            return nil if @in_fenced_block || @in_indented_block
+            return nil if input[pos] != "`"
+
+            input_length = input.length
+            if @in_inline_code
+              try_close_inline(input, pos, input_length)
+            else
+              open_inline(input, pos, input_length)
+            end
+          end
+
+          private
+
+          def skip_leading_spaces(input, pos)
+            scan_pos = pos
+            spaces = 0
+            while spaces < 3 && input[scan_pos] == " "
+              spaces += 1
+              scan_pos += 1
+            end
+            scan_pos
+          end
+
+          def count_fence_chars(input, scan_pos, fence_char, input_length)
+            fence_length = 0
+            while scan_pos < input_length && input[scan_pos] == fence_char
+              fence_length += 1
+              scan_pos += 1
+            end
+            [fence_length, scan_pos]
+          end
+
+          def try_close_fence(input, scan_pos, fence_char, fence_length, input_length)
+            return nil unless fence_char == @fence_char && fence_length >= @fence_length
+
+            scan_pos += 1 while scan_pos < input_length && input[scan_pos] == " "
+            return nil unless scan_pos >= input_length || input[scan_pos] == "\n"
+
+            @in_fenced_block = false
+            pos_after_line(scan_pos, input_length)
+          end
+
+          def open_fence(input, scan_pos, fence_char, fence_length, input_length)
+            scan_pos += 1 while scan_pos < input_length && input[scan_pos] != "\n"
+
+            @in_fenced_block = true
+            @fence_char = fence_char
+            @fence_length = fence_length
+            pos_after_line(scan_pos, input_length)
+          end
+
+          def try_close_inline(input, pos, input_length)
+            delimiter_length = @inline_delimiter.length
+            return nil unless input[pos, delimiter_length] == @inline_delimiter
+
+            next_pos = pos + delimiter_length
+            return nil if next_pos < input_length && input[next_pos] == "`"
+
+            @in_inline_code = false
+            next_pos
+          end
+
+          def open_inline(input, pos, input_length)
+            delimiter_start = pos
+            pos += 1 while pos < input_length && input[pos] == "`"
+
+            @inline_delimiter = input[delimiter_start...pos]
+            @in_inline_code = true
+            pos
+          end
+
+          def pos_after_line(line_end, input_length)
+            line_end < input_length ? line_end + 1 : line_end
+          end
+        end
+
+        # Walks Discourse Markdown and replaces detected constructs (outside code)
+        # with whatever the given block returns for each detected node.
+        class Scanner
+          TRIGGER_CHARS = Set.new(["@", "[", "!"]).freeze
+          private_constant :TRIGGER_CHARS
+
+          # @param detectors [Array<Detectors::Base>] detector instances in priority
+          #   order.
+          # @yieldparam node the detected AST node; the block returns its replacement.
+          def initialize(detectors:, &on_node)
+            @detectors = detectors
+            @on_node = on_node
+          end
+
+          # @param input [String]
+          # @return [String] the input with detected constructs replaced.
+          def scan(input)
+            @code_tracker = CodeBlockTracker.new
+            @result = +""
+            @pos = 0
+            @input = input.to_s
+            @line_start = true
+
+            scan_input
+            @result
+          end
+
+          private
+
+          def scan_input
+            while @pos < @input.length
+              if @line_start
+                next if advance_code_boundary(:check_fenced_boundary)
+                next if advance_code_boundary(:check_indented_boundary)
+              end
+
+              if @input[@pos] == "`"
+                new_pos = @code_tracker.check_inline_boundary(@input, @pos)
+                if new_pos
+                  @result << @input[@pos...new_pos]
+                  @pos = new_pos
+                  @line_start = false
+                  next
+                end
+              end
+
+              if @code_tracker.in_code?
+                @result << @input[@pos]
+                @line_start = @input[@pos] == "\n"
+                @pos += 1
+                next
+              end
+
+              char = @input[@pos]
+              if TRIGGER_CHARS.include?(char)
+                match = detect_at_position
+                if match
+                  handle_match(match)
+                  next
+                end
+              end
+
+              @result << char
+              @line_start = char == "\n"
+              @pos += 1
+            end
+          end
+
+          def advance_code_boundary(method)
+            new_pos = @code_tracker.public_send(method, @input, @pos, line_start: true)
+            return false unless new_pos
+
+            @result << @input[@pos...new_pos]
+            @pos = new_pos
+            @line_start = true
+            true
+          end
+
+          def detect_at_position
+            @detectors.each do |detector|
+              match = detector.detect(@input, @pos)
+              return match if match
+            end
+            nil
+          end
+
+          def handle_match(match)
+            @result << @on_node.call(match.node).to_s
+            @pos = match.end_pos
+            @line_start = false
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/discourse/mention_resolver.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/mention_resolver.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Discourse
+      # Classifies an `@name` mention into the `mention_type` stored on
+      # `post_mentions`: `"here"`, `"all"`, `"group"` or `"user"`.
+      #
+      #   * `@here` is recognized by the source's `here_mention` site setting — its
+      #     name is configurable, so we don't hard-code `"here"`.
+      #   * `@all` is recognized by the literal name `all`.
+      #   * group mentions are recognized from the source's group names.
+      #   * everything else is a user mention.
+      #
+      # Matching is case-insensitive (Discourse usernames and group names are). The
+      # importer remaps the recorded name to a destination user or group.
+      class MentionResolver
+        ALL = "all"
+
+        # @param here_mention [String, nil] the source's `here_mention` setting value.
+        # @param group_names [Enumerable<String>] the source's group names.
+        def initialize(here_mention: "here", group_names: [])
+          @here_mention = here_mention&.downcase
+          @group_names = group_names.map(&:downcase).to_set
+        end
+
+        # @param name [String] the mention name (without the leading `@`).
+        # @return [String] one of `"here"`, `"all"`, `"group"`, `"user"`.
+        def call(name)
+          normalized = name.downcase
+
+          return "here" if @here_mention && normalized == @here_mention
+          return ALL if normalized == ALL
+          return "group" if @group_names.include?(normalized)
+
+          "user"
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/discourse/raw_extractor.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/raw_extractor.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Discourse
+      # Extracts deferred embeds from a Discourse post's Markdown `raw` and replaces
+      # each with a placeholder token, recording a typed descriptor on the given
+      # embed sink (an {EmbedBuffer}). The importer's `PlaceholderResolver` rewrites
+      # the tokens once the `original_id -> discourse_id` maps exist.
+      #
+      # The hard part of extracting from Markdown is *not* extracting from places
+      # that only look like embeds — inside fenced/indented/inline code. That is
+      # handled by {MarkdownScanner}, which we drive here: for each detected node we
+      # record the embed on the sink and return the placeholder token the scanner
+      # splices into the output.
+      #
+      # We detect uploads, quote attributions and mentions. Polls and events are
+      # self-contained (no id remapping needed), so they're left in `raw` verbatim.
+      class RawExtractor
+        Detectors = MarkdownScanner::Detectors
+
+        DETECTORS = [Detectors::Upload, Detectors::Quote, Detectors::Mention].freeze
+        private_constant :DETECTORS
+
+        # @param mention_resolver [#call] maps a mention name to its `mention_type`
+        #   (`"here"` / `"all"` / `"group"` / `"user"`). Defaults to a resolver with
+        #   no group knowledge (so only `@here` / `@all` are special-cased).
+        def initialize(mention_resolver: MentionResolver.new)
+          @mention_resolver = mention_resolver
+        end
+
+        # @param raw [String, nil] the source post body (Discourse Markdown).
+        # @param on_embed [#upload, #quote, #mention] the embed sink.
+        # @return [String, nil] the body with embeds replaced by placeholder tokens.
+        def extract(raw, on_embed:)
+          return raw if raw.nil?
+
+          scanner = MarkdownScanner::Scanner.new(detectors:) { |node| defer(node, on_embed) }
+          scanner.scan(raw)
+        end
+
+        private
+
+        def detectors
+          DETECTORS.map(&:new)
+        end
+
+        # Records the detected embed on the sink and returns the placeholder token.
+        def defer(node, sink)
+          case node
+          when Markbridge::AST::Upload
+            sink.upload(upload_id: node.sha1)
+          when Markbridge::AST::Mention
+            sink.mention(mention_type: @mention_resolver.call(node.name), name: node.name)
+          when MarkdownScanner::QuoteAttribution
+            sink.quote(quoted_username: node.username, quoted_post_id: node.post)
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/discourse/steps/posts.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/posts.rb
@@ -69,67 +69,10 @@ module Migrations
               wiki: item[:wiki],
             )
 
-            write_embeds(item[:id], embeds)
+            PostEmbedWriter.write(item[:id], embeds)
           end
 
           private
-
-          def write_embeds(post_id, embeds)
-            embeds.quotes.each do |quote|
-              IntermediateDB::PostQuote.create(
-                post_id:,
-                placeholder: quote[:placeholder],
-                quoted_post_id: quote[:quoted_post_id],
-                quoted_user_id: quote[:quoted_user_id],
-                quoted_username: quote[:quoted_username],
-              )
-            end
-
-            embeds.links.each do |link|
-              IntermediateDB::PostLink.create(
-                post_id:,
-                placeholder: link[:placeholder],
-                url: link[:url],
-                text: link[:text],
-                target_topic_id: link[:target_topic_id],
-                target_post_id: link[:target_post_id],
-              )
-            end
-
-            embeds.mentions.each do |mention|
-              IntermediateDB::PostMention.create(
-                post_id:,
-                placeholder: mention[:placeholder],
-                mention_type: mention[:mention_type],
-                target_id: mention[:target_id],
-                name: mention[:name],
-              )
-            end
-
-            embeds.polls.each do |poll|
-              IntermediateDB::PostPoll.create(
-                post_id:,
-                placeholder: poll[:placeholder],
-                poll_id: poll[:poll_id],
-              )
-            end
-
-            embeds.events.each do |event|
-              IntermediateDB::PostEvent.create(
-                post_id:,
-                placeholder: event[:placeholder],
-                event_id: event[:event_id],
-              )
-            end
-
-            embeds.uploads.each do |upload|
-              IntermediateDB::PostUpload.create(
-                post_id:,
-                placeholder: upload[:placeholder],
-                upload_id: upload[:upload_id],
-              )
-            end
-          end
 
           # Keeps only values the enum recognizes, otherwise the fallback (the
           # source may carry values from plugins or versions we don't model).

--- a/migrations/converters/lib/migrations/converters/discourse/steps/posts.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/posts.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Discourse
+      class Posts < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            @source_db.count <<~SQL
+              SELECT COUNT(*) FROM posts
+            SQL
+          end
+
+          def items
+            # `reply_to_post_id` resolves the source `reply_to_post_number` to the
+            # parent post's id (same topic) so the reference survives renumbering.
+            @source_db.query <<~SQL
+              SELECT posts.*,
+                     reply_to.id AS reply_to_post_id
+                FROM posts
+                     LEFT JOIN posts reply_to
+                       ON reply_to.topic_id = posts.topic_id
+                      AND reply_to.post_number = posts.reply_to_post_number
+              ORDER BY posts.topic_id, posts.post_number
+            SQL
+          end
+        end
+
+        processor do
+          attr_accessor :group_names, :here_mention
+
+          def setup
+            @extractor =
+              RawExtractor.new(
+                mention_resolver:
+                  MentionResolver.new(here_mention:, group_names: group_names || []),
+              )
+          end
+
+          def process(item)
+            embeds = EmbedBuffer.new
+            raw = @extractor.extract(item[:raw], on_embed: embeds)
+
+            IntermediateDB::Post.create(
+              original_id: item[:id],
+              action_code: item[:action_code],
+              created_at: item[:created_at],
+              deleted_at: item[:deleted_at],
+              deleted_by_id: item[:deleted_by_id],
+              hidden: item[:hidden],
+              hidden_at: item[:hidden_at],
+              hidden_reason_id: valid_enum(Enums::PostHiddenReason, item[:hidden_reason_id]),
+              last_editor_id: item[:last_editor_id],
+              like_count: item[:like_count],
+              locked_by_id: item[:locked_by_id],
+              original_raw: item[:raw],
+              post_number: item[:post_number],
+              post_type:
+                valid_enum(Enums::PostType, item[:post_type], fallback: Enums::PostType::REGULAR),
+              raw:,
+              reply_to_post_id: item[:reply_to_post_id],
+              reply_to_user_id: item[:reply_to_user_id],
+              sort_order: item[:sort_order],
+              topic_id: item[:topic_id],
+              user_deleted: item[:user_deleted],
+              user_id: item[:user_id],
+              wiki: item[:wiki],
+            )
+
+            write_embeds(item[:id], embeds)
+          end
+
+          private
+
+          def write_embeds(post_id, embeds)
+            embeds.quotes.each do |quote|
+              IntermediateDB::PostQuote.create(
+                post_id:,
+                placeholder: quote[:placeholder],
+                quoted_post_id: quote[:quoted_post_id],
+                quoted_user_id: quote[:quoted_user_id],
+                quoted_username: quote[:quoted_username],
+              )
+            end
+
+            embeds.links.each do |link|
+              IntermediateDB::PostLink.create(
+                post_id:,
+                placeholder: link[:placeholder],
+                url: link[:url],
+                text: link[:text],
+                target_topic_id: link[:target_topic_id],
+                target_post_id: link[:target_post_id],
+              )
+            end
+
+            embeds.mentions.each do |mention|
+              IntermediateDB::PostMention.create(
+                post_id:,
+                placeholder: mention[:placeholder],
+                mention_type: mention[:mention_type],
+                target_id: mention[:target_id],
+                name: mention[:name],
+              )
+            end
+
+            embeds.polls.each do |poll|
+              IntermediateDB::PostPoll.create(
+                post_id:,
+                placeholder: poll[:placeholder],
+                poll_id: poll[:poll_id],
+              )
+            end
+
+            embeds.events.each do |event|
+              IntermediateDB::PostEvent.create(
+                post_id:,
+                placeholder: event[:placeholder],
+                event_id: event[:event_id],
+              )
+            end
+
+            embeds.uploads.each do |upload|
+              IntermediateDB::PostUpload.create(
+                post_id:,
+                placeholder: upload[:placeholder],
+                upload_id: upload[:upload_id],
+              )
+            end
+          end
+
+          # Keeps only values the enum recognizes, otherwise the fallback (the
+          # source may carry values from plugins or versions we don't model).
+          def valid_enum(enum_module, value, fallback: nil)
+            return fallback if value.nil?
+            enum_module.valid?(value) ? value : fallback
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/embed_buffer.rb
+++ b/migrations/converters/lib/migrations/converters/embed_buffer.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    # Pure, per-post accumulator for deferred embeds discovered while a post body
+    # is converted to Markdown.
+    #
+    # The cooker calls back here for every fragment it cannot finalize at convert
+    # time — a quote, link, mention, poll, event or upload — because rendering it
+    # needs the `original_id -> discourse_id` maps that only exist at import time.
+    # `EmbedBuffer` mints a collision-proof token via `Migrations::Placeholder`,
+    # records a typed descriptor carrying that token, and returns the token for the
+    # cooker to splice into the raw in place of the fragment.
+    #
+    # After the body is converted, the Posts step writes the post and then drains
+    # each typed collection into its IntermediateDB linkage table, e.g.
+    #
+    #     buffer.quotes.each { |q| IntermediateDB::PostQuote.create(post_id:, **q) }
+    #
+    # The descriptors are plain hashes whose keys match the linkage table columns
+    # (minus `post_id`), so they splat straight into `create`. Keeping the buffer
+    # free of any DB or id-map access is what lets `process_item` stay a pure
+    # function of `(item, static config)`, safe to run on the converter's worker
+    # threads and reusable across every converter.
+    class EmbedBuffer
+      attr_reader :quotes, :links, :mentions, :polls, :events, :uploads
+
+      # @param placeholder [Migrations::Placeholder] the token minter; a fresh
+      #   instance (with its own random nonce) is used per buffer by default.
+      def initialize(placeholder: Migrations::Placeholder.new)
+        @placeholder = placeholder
+        @quotes = []
+        @links = []
+        @mentions = []
+        @polls = []
+        @events = []
+        @uploads = []
+      end
+
+      # @return [String] the token to splice into the raw in place of the quote.
+      def quote(quoted_post_id: nil, quoted_user_id: nil, quoted_username: nil)
+        record(@quotes, :quote, quoted_post_id:, quoted_user_id:, quoted_username:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the link.
+      def link(url: nil, text: nil, target_topic_id: nil, target_post_id: nil)
+        record(@links, :link, url:, text:, target_topic_id:, target_post_id:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the mention.
+      def mention(mention_type: nil, target_id: nil, name: nil)
+        record(@mentions, :mention, mention_type:, target_id:, name:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the poll.
+      def poll(poll_id: nil)
+        record(@polls, :poll, poll_id:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the event.
+      def event(event_id: nil)
+        record(@events, :event, event_id:)
+      end
+
+      # @return [String] the token to splice into the raw in place of the upload.
+      def upload(upload_id: nil)
+        record(@uploads, :upload, upload_id:)
+      end
+
+      # Every token this buffer has minted, across all kinds, in mint order. Mirrors
+      # what should be present in the post raw — handy for asserting the contract.
+      #
+      # @return [Array<String>]
+      def placeholders
+        descriptors.map { |descriptor| descriptor[:placeholder] }
+      end
+
+      # @return [Boolean] whether the post had no deferred embeds.
+      def empty?
+        descriptors.empty?
+      end
+
+      private
+
+      def descriptors
+        @quotes + @links + @mentions + @polls + @events + @uploads
+      end
+
+      def record(collection, kind, **fields)
+        placeholder = @placeholder.mint(kind)
+        collection << { placeholder:, **fields }
+        placeholder
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/post_embed_writer.rb
+++ b/migrations/converters/lib/migrations/converters/post_embed_writer.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    # Drains an {EmbedBuffer}'s typed descriptors into the matching IntermediateDB
+    # `post_*` linkage tables, once the Posts step has written the post itself.
+    #
+    # Every converter that defers post embeds needs exactly this, and it is fully
+    # converter-agnostic: the buffer's six collections map one-to-one onto the six
+    # linkage tables, and each descriptor hash is already keyed to its table's
+    # columns (minus `post_id`), so it splats straight into `create`.
+    #
+    # The drain lives here rather than on {EmbedBuffer} on purpose: the buffer's
+    # contract is "no DB or id-map access", which is what keeps a processor's
+    # `process` a pure function safe to run on forked workers. Touching the
+    # IntermediateDB is a separate, processor-side concern.
+    module PostEmbedWriter
+      IntermediateDB = Database::IntermediateDB
+
+      # @param post_id [Integer] the source `original_id` of the post the embeds
+      #   were extracted from.
+      # @param embeds [EmbedBuffer] the post's drained embed sink.
+      # @return [void]
+      def self.write(post_id, embeds)
+        embeds.uploads.each { |embed| IntermediateDB::PostUpload.create(post_id:, **embed) }
+        embeds.quotes.each { |embed| IntermediateDB::PostQuote.create(post_id:, **embed) }
+        embeds.mentions.each { |embed| IntermediateDB::PostMention.create(post_id:, **embed) }
+        embeds.links.each { |embed| IntermediateDB::PostLink.create(post_id:, **embed) }
+        embeds.polls.each { |embed| IntermediateDB::PostPoll.create(post_id:, **embed) }
+        embeds.events.each { |embed| IntermediateDB::PostEvent.create(post_id:, **embed) }
+        nil
+      end
+    end
+  end
+end

--- a/migrations/converters/migrations-converters.gemspec
+++ b/migrations/converters/migrations-converters.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport"
   s.add_dependency "colored2"
   s.add_dependency "i18n"
+  s.add_dependency "markbridge"
   s.add_dependency "pg"
   s.add_dependency "zeitwerk"
 end

--- a/migrations/converters/spec/lib/migrations/converters/content_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/content_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Converters::Content do
+  describe "#to_markdown without an embed sink" do
+    subject(:cooker) { described_class.new(format: :bbcode) }
+
+    it "cooks BBCode to Discourse Markdown" do
+      expect(cooker.to_markdown("[b]hi[/b] and [url=https://example.com]a link[/url]")).to eq(
+        "**hi** and [a link](https://example.com)",
+      )
+    end
+
+    it "raises for an unknown source format" do
+      expect { described_class.new(format: :wikitextish) }.to raise_error(
+        described_class::UnknownFormat,
+      )
+    end
+  end
+
+  describe "#to_markdown deferring embeds into an EmbedBuffer" do
+    subject(:cooker) { described_class.new(format: :bbcode) }
+
+    let(:buffer) { Migrations::Converters::EmbedBuffer.new }
+
+    it "defers an attributed quote, recording the linkage and preserving the body" do
+      raw =
+        cooker.to_markdown(
+          '[quote="John, post:12, topic:34, username:john"]quoted body[/quote]',
+          on_embed: buffer,
+        )
+
+      expect(buffer.quotes.size).to eq(1)
+      descriptor = buffer.quotes.first
+      expect(descriptor[:quoted_post_id]).to eq("12")
+      expect(descriptor[:quoted_username]).to eq("John")
+
+      # The token stands in for the opening tag; the body and closer remain.
+      expect(raw).to include(descriptor[:placeholder])
+      expect(raw).to include("quoted body")
+      expect(raw).to include("[/quote]")
+    end
+
+    it "renders an unattributed quote natively (nothing to remap)" do
+      raw = cooker.to_markdown("[quote]just text[/quote]", on_embed: buffer)
+
+      expect(buffer).to be_empty
+      expect(Migrations::Placeholder).not_to be_include(raw)
+    end
+
+    it "defers links only when asked via defer:" do
+      raw =
+        cooker.to_markdown(
+          "see [url=https://example.com/t/5]here[/url]",
+          on_embed: buffer,
+          defer: %i[link],
+        )
+
+      expect(buffer.links.size).to eq(1)
+      descriptor = buffer.links.first
+      expect(descriptor[:url]).to eq("https://example.com/t/5")
+      expect(descriptor[:text]).to eq("here")
+      expect(raw).to include(descriptor[:placeholder])
+    end
+
+    it "leaves links alone by default" do
+      raw = cooker.to_markdown("see [url=https://example.com]here[/url]", on_embed: buffer)
+
+      expect(buffer.links).to be_empty
+      expect(raw).to eq("see [here](https://example.com)")
+    end
+
+    # The contract: every token in the cooked raw maps to exactly one recorded
+    # linkage descriptor.
+    it "keeps placeholders and linkage rows one-to-one" do
+      raw =
+        cooker.to_markdown(
+          'a [quote="A, post:1, topic:2, username:a"]q[/quote] b ' \
+            "[url=https://example.com/t/9]L[/url] c",
+          on_embed: buffer,
+          defer: %i[quote link],
+        )
+
+      expect(Migrations::Placeholder.scan(raw)).to match_array(buffer.placeholders)
+    end
+  end
+
+  describe ".embed_handlers extraction" do
+    # Upload and Mention nodes don't arise from BBCode, so exercise their
+    # extraction lambdas directly against the real AST nodes.
+    let(:sink) { Migrations::Converters::EmbedBuffer.new }
+
+    it "maps an Upload node's sha1 to upload_id" do
+      _node_class, extract = described_class.embed_handlers.fetch(:upload)
+      node = Markbridge::AST::Upload.new(sha1: "abc123", filename: "x.png")
+
+      token = extract.call(sink, node, nil)
+
+      expect(sink.uploads).to contain_exactly({ placeholder: token, upload_id: "abc123" })
+    end
+
+    it "maps a Mention node's type and name" do
+      _node_class, extract = described_class.embed_handlers.fetch(:mention)
+      node = Markbridge::AST::Mention.new(name: "gerhard", type: :user)
+
+      token = extract.call(sink, node, nil)
+
+      expect(sink.mentions).to contain_exactly(
+        { placeholder: token, mention_type: "user", target_id: nil, name: "gerhard" },
+      )
+    end
+  end
+end

--- a/migrations/converters/spec/lib/migrations/converters/discourse/mention_resolver_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/discourse/mention_resolver_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Converters::Discourse::MentionResolver do
+  it "classifies a plain name as a user mention" do
+    expect(described_class.new.call("gerhard")).to eq("user")
+  end
+
+  it "classifies @all as an all mention" do
+    expect(described_class.new.call("all")).to eq("all")
+    expect(described_class.new.call("All")).to eq("all")
+  end
+
+  describe "here mentions" do
+    it "recognizes the default here_mention name" do
+      expect(described_class.new.call("here")).to eq("here")
+    end
+
+    it "honors a custom here_mention setting value" do
+      resolver = described_class.new(here_mention: "staff")
+
+      expect(resolver.call("staff")).to eq("here")
+      expect(resolver.call("here")).to eq("user")
+    end
+  end
+
+  describe "group mentions" do
+    subject(:resolver) { described_class.new(group_names: %w[Admins Moderators]) }
+
+    it "recognizes a source group name, case-insensitively" do
+      expect(resolver.call("admins")).to eq("group")
+      expect(resolver.call("Moderators")).to eq("group")
+    end
+
+    it "treats an unknown name as a user mention" do
+      expect(resolver.call("gerhard")).to eq("user")
+    end
+  end
+end

--- a/migrations/converters/spec/lib/migrations/converters/discourse/raw_extractor_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/discourse/raw_extractor_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Converters::Discourse::RawExtractor do
+  subject(:extractor) { described_class.new }
+
+  let(:buffer) { Migrations::Converters::EmbedBuffer.new }
+
+  def extract(raw)
+    extractor.extract(raw, on_embed: buffer)
+  end
+
+  it "returns nil for a nil body" do
+    expect(extract(nil)).to be_nil
+  end
+
+  it "leaves a body with no embeds untouched" do
+    raw = "Just some **plain** text with a (paren) and a / slash."
+
+    expect(extract(raw)).to eq(raw)
+    expect(buffer).to be_empty
+  end
+
+  describe "uploads" do
+    it "defers an image upload, recording the sha1" do
+      result = extract("before ![alt|690x388](upload://abc123XYZ.png) after")
+
+      expect(buffer.uploads.size).to eq(1)
+      upload = buffer.uploads.first
+      expect(upload[:upload_id]).to eq("abc123XYZ")
+      expect(result).to eq("before #{upload[:placeholder]} after")
+    end
+
+    it "defers an attachment upload" do
+      extract("[report.pdf|attachment](upload://Zm9vYmFy.pdf)")
+
+      expect(buffer.uploads.first[:upload_id]).to eq("Zm9vYmFy")
+    end
+  end
+
+  describe "quotes" do
+    it "defers the attribution and preserves the quoted body and closing tag" do
+      result = extract(%([quote="bob, post:12, topic:5"]\nquoted body\n[/quote]))
+
+      expect(buffer.quotes.size).to eq(1)
+      quote = buffer.quotes.first
+      expect(quote[:quoted_username]).to eq("bob")
+      expect(quote[:quoted_post_id]).to eq("12")
+      expect(result).to eq("#{quote[:placeholder]}\nquoted body\n[/quote]")
+    end
+
+    it "uses the explicit username: attribute when a display name is present" do
+      extract(%([quote="Bob Jones, post:1, topic:2, username:bjones"]hi[/quote]))
+
+      expect(buffer.quotes.first[:quoted_username]).to eq("bjones")
+      expect(buffer.quotes.first[:quoted_post_id]).to eq("1")
+    end
+
+    it "defers a username-only quote" do
+      extract(%([quote="alice"]hello[/quote]))
+
+      expect(buffer.quotes.first).to include(quoted_username: "alice", quoted_post_id: nil)
+    end
+
+    it "leaves an unattributed quote alone" do
+      raw = "[quote]anonymous[/quote]"
+
+      expect(extract(raw)).to eq(raw)
+      expect(buffer.quotes).to be_empty
+    end
+  end
+
+  describe "mentions" do
+    it "defers a mention, recording the username and preserving surrounding text" do
+      result = extract("hey @alice, welcome")
+
+      expect(buffer.mentions.size).to eq(1)
+      mention = buffer.mentions.first
+      expect(mention).to include(mention_type: "user", name: "alice")
+      expect(result).to eq("hey #{mention[:placeholder]}, welcome")
+    end
+
+    it "defers a mention at the very start of the body" do
+      result = extract("@bob hi")
+
+      expect(buffer.mentions.first[:name]).to eq("bob")
+      expect(result).to eq("#{buffer.mentions.first[:placeholder]} hi")
+    end
+
+    it "does not treat an e-mail address as a mention" do
+      raw = "email me at bob@example.com please"
+
+      expect(extract(raw)).to eq(raw)
+      expect(buffer.mentions).to be_empty
+    end
+
+    it "classifies mention types via the injected resolver" do
+      resolver =
+        Migrations::Converters::Discourse::MentionResolver.new(
+          here_mention: "here",
+          group_names: %w[admins],
+        )
+      extractor = described_class.new(mention_resolver: resolver)
+
+      extractor.extract("@gerhard @admins @here all there", on_embed: buffer)
+
+      expect(buffer.mentions.map { |m| [m[:name], m[:mention_type]] }).to eq(
+        [%w[gerhard user], %w[admins group], %w[here here]],
+      )
+    end
+  end
+
+  # The whole reason to wrap Markbridge's scanner: things that only look like
+  # embeds inside code must be left alone.
+  describe "code blocks" do
+    it "does not extract from a fenced code block" do
+      raw = <<~MD
+        real @alice here
+
+        ```
+        not a @mention and ![x](upload://nope.png) and [quote="ghost"]q[/quote]
+        ```
+      MD
+
+      result = extract(raw)
+
+      expect(buffer.mentions.map { |m| m[:name] }).to eq(%w[alice])
+      expect(buffer.uploads).to be_empty
+      expect(buffer.quotes).to be_empty
+      expect(result).to include("not a @mention and ![x](upload://nope.png)")
+    end
+
+    it "does not extract from inline code" do
+      result = extract("use `@channel` carefully, @alice")
+
+      expect(buffer.mentions.map { |m| m[:name] }).to eq(%w[alice])
+      expect(result).to include("`@channel`")
+    end
+  end
+
+  # The contract: every token spliced into the result maps to exactly one recorded
+  # linkage descriptor.
+  it "keeps placeholders and linkage rows one-to-one" do
+    result =
+      extract(
+        "intro @carol see ![pic](upload://h45h.png) and " \
+          "[quote=\"dan, post:9, topic:3\"]q[/quote] done",
+      )
+
+    expect(Migrations::Placeholder.scan(result)).to match_array(buffer.placeholders)
+  end
+end

--- a/migrations/converters/spec/lib/migrations/converters/embed_buffer_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/embed_buffer_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Converters::EmbedBuffer do
+  subject(:buffer) { described_class.new }
+
+  describe "recording embeds" do
+    it "records a quote descriptor keyed for IntermediateDB::PostQuote" do
+      token = buffer.quote(quoted_post_id: 1, quoted_user_id: 2, quoted_username: "bob")
+
+      expect(buffer.quotes).to contain_exactly(
+        { placeholder: token, quoted_post_id: 1, quoted_user_id: 2, quoted_username: "bob" },
+      )
+    end
+
+    it "records a link descriptor keyed for IntermediateDB::PostLink" do
+      token = buffer.link(url: "https://example.com", text: "here", target_topic_id: 9)
+
+      expect(buffer.links).to contain_exactly(
+        {
+          placeholder: token,
+          url: "https://example.com",
+          text: "here",
+          target_topic_id: 9,
+          target_post_id: nil,
+        },
+      )
+    end
+
+    it "records a mention descriptor keyed for IntermediateDB::PostMention" do
+      token = buffer.mention(mention_type: "user", target_id: 7, name: "bob")
+
+      expect(buffer.mentions).to contain_exactly(
+        { placeholder: token, mention_type: "user", target_id: 7, name: "bob" },
+      )
+    end
+
+    it "records a poll descriptor keyed for IntermediateDB::PostPoll" do
+      token = buffer.poll(poll_id: 3)
+
+      expect(buffer.polls).to contain_exactly({ placeholder: token, poll_id: 3 })
+    end
+
+    it "records an event descriptor keyed for IntermediateDB::PostEvent" do
+      token = buffer.event(event_id: 4)
+
+      expect(buffer.events).to contain_exactly({ placeholder: token, event_id: 4 })
+    end
+
+    it "records an upload descriptor keyed for IntermediateDB::PostUpload" do
+      token = buffer.upload(upload_id: "abc123")
+
+      expect(buffer.uploads).to contain_exactly({ placeholder: token, upload_id: "abc123" })
+    end
+
+    it "returns the minted token so the cooker can splice it into the raw" do
+      expect(buffer.quote(quoted_user_id: 1)).to eq(buffer.quotes.last[:placeholder])
+    end
+  end
+
+  describe "#empty?" do
+    it "is true before anything is recorded" do
+      expect(buffer).to be_empty
+    end
+
+    it "is false once an embed is recorded" do
+      buffer.upload(upload_id: "x")
+
+      expect(buffer).not_to be_empty
+    end
+  end
+
+  # The single invariant the whole design rests on: the token spliced into the raw
+  # and the `placeholder` on the linkage row are byte-identical, one-to-one.
+  describe "the placeholder contract" do
+    it "mints one token per embed, each present exactly once in the cooked raw" do
+      raw = +"Intro "
+      raw << buffer.quote(quoted_user_id: 5)
+      raw << " see "
+      raw << buffer.link(url: "https://example.com", text: "x")
+      raw << " hi "
+      raw << buffer.mention(mention_type: "user", target_id: 7, name: "bob")
+      raw << " poll "
+      raw << buffer.poll(poll_id: 1)
+      raw << " event "
+      raw << buffer.event(event_id: 2)
+      raw << " pic "
+      raw << buffer.upload(upload_id: "sha1")
+      raw << " end"
+
+      tokens_in_raw = Migrations::Placeholder.scan(raw)
+
+      # Every token in the raw has exactly one matching linkage descriptor, and
+      # every descriptor's placeholder is present in the raw.
+      expect(tokens_in_raw).to match_array(buffer.placeholders)
+      expect(tokens_in_raw.size).to eq(buffer.placeholders.size)
+      buffer.placeholders.each { |placeholder| expect(raw.scan(placeholder).size).to eq(1) }
+    end
+
+    it "never mints the same token twice" do
+      tokens = Array.new(10) { buffer.upload(upload_id: "x") }
+
+      expect(tokens.uniq.size).to eq(10)
+    end
+  end
+end

--- a/migrations/converters/spec/lib/migrations/converters/post_embed_writer_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/post_embed_writer_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.describe Migrations::Converters::PostEmbedWriter do
+  let(:placeholder) { Migrations::Placeholder.new(nonce: "n") }
+  let(:buffer) { Migrations::Converters::EmbedBuffer.new(placeholder:) }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      db_path = File.join(dir, "intermediate.db")
+      Migrations::Database.migrate(
+        db_path,
+        migrations_path: Migrations::Database::INTERMEDIATE_DB_SCHEMA_PATH,
+      )
+      @intermediate_db = Migrations::Database.connect(db_path)
+      Migrations::Database::IntermediateDB.setup(@intermediate_db)
+      example.run
+    ensure
+      Migrations::Database::IntermediateDB.setup(nil)
+    end
+  end
+
+  def rows(table)
+    [].tap do |result|
+      @intermediate_db.query("SELECT * FROM #{table} ORDER BY rowid") { |row| result << row }
+    end
+  end
+
+  it "drains every kind of descriptor into its linkage table, splatting cleanly" do
+    upload = buffer.upload(upload_id: "abc123")
+    quote = buffer.quote(quoted_post_id: 200, quoted_user_id: 5, quoted_username: "bob")
+    mention = buffer.mention(mention_type: "user", target_id: 7, name: "carol")
+    link =
+      buffer.link(url: "https://example.com", text: "here", target_topic_id: 9, target_post_id: 10)
+    poll = buffer.poll(poll_id: 3)
+    event = buffer.event(event_id: 4)
+
+    described_class.write(100, buffer)
+
+    expect(rows("post_uploads")).to contain_exactly(
+      { post_id: 100, placeholder: upload, upload_id: "abc123" },
+    )
+    expect(rows("post_quotes")).to contain_exactly(
+      {
+        post_id: 100,
+        placeholder: quote,
+        quoted_post_id: 200,
+        quoted_user_id: 5,
+        quoted_username: "bob",
+      },
+    )
+    expect(rows("post_mentions")).to contain_exactly(
+      { post_id: 100, placeholder: mention, mention_type: "user", target_id: 7, name: "carol" },
+    )
+    expect(rows("post_links")).to contain_exactly(
+      {
+        post_id: 100,
+        placeholder: link,
+        url: "https://example.com",
+        text: "here",
+        target_topic_id: 9,
+        target_post_id: 10,
+      },
+    )
+    expect(rows("post_polls")).to contain_exactly({ post_id: 100, placeholder: poll, poll_id: 3 })
+    expect(rows("post_events")).to contain_exactly(
+      { post_id: 100, placeholder: event, event_id: 4 },
+    )
+  end
+
+  it "writes nothing for an empty buffer" do
+    described_class.write(100, buffer)
+
+    expect(rows("post_uploads")).to be_empty
+    expect(rows("post_quotes")).to be_empty
+    expect(rows("post_mentions")).to be_empty
+    expect(rows("post_links")).to be_empty
+    expect(rows("post_polls")).to be_empty
+    expect(rows("post_events")).to be_empty
+  end
+
+  it "writes one linkage row per buffered embed of the same kind" do
+    first = buffer.upload(upload_id: "one")
+    second = buffer.upload(upload_id: "two")
+
+    described_class.write(100, buffer)
+
+    expect(rows("post_uploads")).to contain_exactly(
+      { post_id: 100, placeholder: first, upload_id: "one" },
+      { post_id: 100, placeholder: second, upload_id: "two" },
+    )
+  end
+end

--- a/migrations/core/db/intermediate_db_schema/100-base-schema.sql
+++ b/migrations/core/db/intermediate_db_schema/100-base-schema.sql
@@ -183,6 +183,67 @@ CREATE TABLE permalink_normalizations
 );
 
 
+CREATE TABLE post_events
+(
+    event_id    NUMERIC,
+    placeholder TEXT    NOT NULL,
+    post_id     NUMERIC NOT NULL
+);
+
+CREATE INDEX idx_post_events_post_id ON post_events (post_id);
+
+CREATE TABLE post_links
+(
+    placeholder     TEXT    NOT NULL,
+    post_id         NUMERIC NOT NULL,
+    target_post_id  NUMERIC,
+    target_topic_id NUMERIC,
+    text            TEXT,
+    url             TEXT
+);
+
+CREATE INDEX idx_post_links_post_id ON post_links (post_id);
+
+CREATE TABLE post_mentions
+(
+    mention_type TEXT,
+    name         TEXT,
+    placeholder  TEXT    NOT NULL,
+    post_id      NUMERIC NOT NULL,
+    target_id    NUMERIC
+);
+
+CREATE INDEX idx_post_mentions_post_id ON post_mentions (post_id);
+
+CREATE TABLE post_polls
+(
+    placeholder TEXT    NOT NULL,
+    poll_id     NUMERIC,
+    post_id     NUMERIC NOT NULL
+);
+
+CREATE INDEX idx_post_polls_post_id ON post_polls (post_id);
+
+CREATE TABLE post_quotes
+(
+    placeholder     TEXT    NOT NULL,
+    post_id         NUMERIC NOT NULL,
+    quoted_post_id  NUMERIC,
+    quoted_user_id  NUMERIC,
+    quoted_username TEXT
+);
+
+CREATE INDEX idx_post_quotes_post_id ON post_quotes (post_id);
+
+CREATE TABLE post_uploads
+(
+    placeholder TEXT    NOT NULL,
+    post_id     NUMERIC NOT NULL,
+    upload_id   TEXT
+);
+
+CREATE INDEX idx_post_uploads_post_id ON post_uploads (post_id);
+
 CREATE TABLE site_settings
 (
     name            TEXT         NOT NULL PRIMARY KEY,

--- a/migrations/core/db/intermediate_db_schema/100-base-schema.sql
+++ b/migrations/core/db/intermediate_db_schema/100-base-schema.sql
@@ -244,6 +244,34 @@ CREATE TABLE post_uploads
 
 CREATE INDEX idx_post_uploads_post_id ON post_uploads (post_id);
 
+CREATE TABLE posts
+(
+    original_id      NUMERIC      NOT NULL PRIMARY KEY,
+    action_code      TEXT,
+    created_at       DATETIME,
+    deleted_at       DATETIME,
+    deleted_by_id    NUMERIC,
+    hidden           BOOLEAN,
+    hidden_at        DATETIME,
+    hidden_reason_id ENUM_INTEGER,
+    last_editor_id   NUMERIC,
+    like_count       INTEGER,
+    locked_by_id     NUMERIC,
+    original_raw     TEXT,
+    post_number      INTEGER,
+    post_type        ENUM_INTEGER,
+    raw              TEXT         NOT NULL,
+    reply_to_post_id INTEGER,
+    reply_to_user_id NUMERIC,
+    sort_order       INTEGER,
+    topic_id         NUMERIC      NOT NULL,
+    user_deleted     BOOLEAN,
+    user_id          NUMERIC,
+    wiki             BOOLEAN
+);
+
+CREATE INDEX idx_posts_topic_id_post_number ON posts (topic_id, post_number);
+
 CREATE TABLE site_settings
 (
     name            TEXT         NOT NULL PRIMARY KEY,

--- a/migrations/core/lib/migrations/database/intermediate_db/enums/post_hidden_reason.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/enums/post_hidden_reason.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module Enums
+        module PostHiddenReason
+          extend Migrations::Enum
+
+          FLAG_THRESHOLD_REACHED = 1
+          FLAG_THRESHOLD_REACHED_AGAIN = 2
+          NEW_USER_SPAM_THRESHOLD_REACHED = 3
+          FLAGGED_BY_TL3_USER = 4
+          EMAIL_SPAM_HEADER_FOUND = 5
+          FLAGGED_BY_TL4_USER = 6
+          EMAIL_AUTHENTICATION_RESULT_HEADER = 7
+          IMPORTED_AS_UNLISTED = 8
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/enums/post_type.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/enums/post_type.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module Enums
+        module PostType
+          extend Migrations::Enum
+
+          REGULAR = 1
+          MODERATOR_ACTION = 2
+          SMALL_ACTION = 3
+          WHISPER = 4
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module Post
+        SQL = <<~SQL
+          INSERT INTO posts (
+            original_id,
+            action_code,
+            created_at,
+            deleted_at,
+            deleted_by_id,
+            hidden,
+            hidden_at,
+            hidden_reason_id,
+            last_editor_id,
+            like_count,
+            locked_by_id,
+            original_raw,
+            post_number,
+            post_type,
+            raw,
+            reply_to_post_id,
+            reply_to_user_id,
+            sort_order,
+            topic_id,
+            user_deleted,
+            user_id,
+            wiki
+          )
+          VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `posts` record in the IntermediateDB.
+        #
+        # @param original_id        [Integer, String]
+        # @param action_code        [String, nil]
+        # @param created_at         [Time, nil]
+        # @param deleted_at         [Time, nil]
+        # @param deleted_by_id      [Integer, String, nil]
+        # @param hidden             [Boolean, nil]
+        # @param hidden_at          [Time, nil]
+        # @param hidden_reason_id   [Integer, nil]
+        #   Any constant from PostHiddenReason (e.g. PostHiddenReason::FLAG_THRESHOLD_REACHED)
+        # @param last_editor_id     [Integer, String, nil]
+        # @param like_count         [Integer, nil]
+        # @param locked_by_id       [Integer, String, nil]
+        # @param original_raw       [String, nil]
+        # @param post_number        [Integer, nil]
+        # @param post_type          [Integer, nil]
+        #   Any constant from PostType (e.g. PostType::REGULAR)
+        # @param raw                [String]
+        # @param reply_to_post_id   [Integer, nil]
+        # @param reply_to_user_id   [Integer, String, nil]
+        # @param sort_order         [Integer, nil]
+        # @param topic_id           [Integer, String]
+        # @param user_deleted       [Boolean, nil]
+        # @param user_id            [Integer, String, nil]
+        # @param wiki               [Boolean, nil]
+        #
+        # @return [void]
+        #
+        # @see Migrations::Database::IntermediateDB::Enums::PostHiddenReason
+        # @see Migrations::Database::IntermediateDB::Enums::PostType
+        def self.create(
+          original_id:,
+          action_code: nil,
+          created_at: nil,
+          deleted_at: nil,
+          deleted_by_id: nil,
+          hidden: nil,
+          hidden_at: nil,
+          hidden_reason_id: nil,
+          last_editor_id: nil,
+          like_count: nil,
+          locked_by_id: nil,
+          original_raw: nil,
+          post_number: nil,
+          post_type: nil,
+          raw:,
+          reply_to_post_id: nil,
+          reply_to_user_id: nil,
+          sort_order: nil,
+          topic_id:,
+          user_deleted: nil,
+          user_id: nil,
+          wiki: nil
+        )
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            original_id,
+            action_code,
+            Migrations::Database.format_datetime(created_at),
+            Migrations::Database.format_datetime(deleted_at),
+            deleted_by_id,
+            Migrations::Database.format_boolean(hidden),
+            Migrations::Database.format_datetime(hidden_at),
+            hidden_reason_id,
+            last_editor_id,
+            like_count,
+            locked_by_id,
+            original_raw,
+            post_number,
+            post_type,
+            raw,
+            reply_to_post_id,
+            reply_to_user_id,
+            sort_order,
+            topic_id,
+            Migrations::Database.format_boolean(user_deleted),
+            user_id,
+            Migrations::Database.format_boolean(wiki),
+          )
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_event.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_event.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostEvent
+        SQL = <<~SQL
+          INSERT INTO post_events (
+            event_id,
+            placeholder,
+            post_id
+          )
+          VALUES (
+            ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_events` record in the IntermediateDB.
+        #
+        # @param event_id      [Integer, String, nil]
+        # @param placeholder   [String]
+        # @param post_id       [Integer, String]
+        #
+        # @return [void]
+        def self.create(event_id: nil, placeholder:, post_id:)
+          Migrations::Database::IntermediateDB.insert(SQL, event_id, placeholder, post_id)
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_link.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_link.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostLink
+        SQL = <<~SQL
+          INSERT INTO post_links (
+            placeholder,
+            post_id,
+            target_post_id,
+            target_topic_id,
+            text,
+            url
+          )
+          VALUES (
+            ?, ?, ?, ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_links` record in the IntermediateDB.
+        #
+        # @param placeholder       [String]
+        # @param post_id           [Integer, String]
+        # @param target_post_id    [Integer, String, nil]
+        # @param target_topic_id   [Integer, String, nil]
+        # @param text              [String, nil]
+        # @param url               [String, nil]
+        #
+        # @return [void]
+        def self.create(
+          placeholder:,
+          post_id:,
+          target_post_id: nil,
+          target_topic_id: nil,
+          text: nil,
+          url: nil
+        )
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            placeholder,
+            post_id,
+            target_post_id,
+            target_topic_id,
+            text,
+            url,
+          )
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_mention.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_mention.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostMention
+        SQL = <<~SQL
+          INSERT INTO post_mentions (
+            mention_type,
+            name,
+            placeholder,
+            post_id,
+            target_id
+          )
+          VALUES (
+            ?, ?, ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_mentions` record in the IntermediateDB.
+        #
+        # @param mention_type   [String, nil]
+        # @param name           [String, nil]
+        # @param placeholder    [String]
+        # @param post_id        [Integer, String]
+        # @param target_id      [Integer, String, nil]
+        #
+        # @return [void]
+        def self.create(mention_type: nil, name: nil, placeholder:, post_id:, target_id: nil)
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            mention_type,
+            name,
+            placeholder,
+            post_id,
+            target_id,
+          )
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_poll.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_poll.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostPoll
+        SQL = <<~SQL
+          INSERT INTO post_polls (
+            placeholder,
+            poll_id,
+            post_id
+          )
+          VALUES (
+            ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_polls` record in the IntermediateDB.
+        #
+        # @param placeholder   [String]
+        # @param poll_id       [Integer, String, nil]
+        # @param post_id       [Integer, String]
+        #
+        # @return [void]
+        def self.create(placeholder:, poll_id: nil, post_id:)
+          Migrations::Database::IntermediateDB.insert(SQL, placeholder, poll_id, post_id)
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_quote.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_quote.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostQuote
+        SQL = <<~SQL
+          INSERT INTO post_quotes (
+            placeholder,
+            post_id,
+            quoted_post_id,
+            quoted_user_id,
+            quoted_username
+          )
+          VALUES (
+            ?, ?, ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_quotes` record in the IntermediateDB.
+        #
+        # @param placeholder       [String]
+        # @param post_id           [Integer, String]
+        # @param quoted_post_id    [Integer, String, nil]
+        # @param quoted_user_id    [Integer, String, nil]
+        # @param quoted_username   [String, nil]
+        #
+        # @return [void]
+        def self.create(
+          placeholder:,
+          post_id:,
+          quoted_post_id: nil,
+          quoted_user_id: nil,
+          quoted_username: nil
+        )
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            placeholder,
+            post_id,
+            quoted_post_id,
+            quoted_user_id,
+            quoted_username,
+          )
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post_upload.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post_upload.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module PostUpload
+        SQL = <<~SQL
+          INSERT INTO post_uploads (
+            placeholder,
+            post_id,
+            upload_id
+          )
+          VALUES (
+            ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `post_uploads` record in the IntermediateDB.
+        #
+        # @param placeholder   [String]
+        # @param post_id       [Integer, String]
+        # @param upload_id     [String, nil]
+        #
+        # @return [void]
+        def self.create(placeholder:, post_id:, upload_id: nil)
+          Migrations::Database::IntermediateDB.insert(SQL, placeholder, post_id, upload_id)
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/placeholder.rb
+++ b/migrations/core/lib/migrations/placeholder.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module Migrations
+  # Single source of truth for the opaque tokens that stand in for deferred post
+  # embeds (uploads, polls, events, quotes, links, mentions) inside `post.raw`.
+  #
+  # An embed cannot always be finalized while a post is converted: rendering it
+  # needs the `original_id -> discourse_id` maps that only exist at import time.
+  # The converter therefore splices a *placeholder* token into the raw and records
+  # a typed linkage row carrying the same token; the importer rewrites the token
+  # once the maps are available (see `Migrations::Importer::PlaceholderResolver`).
+  #
+  # The contract that makes this safe is a single invariant: the token spliced into
+  # `raw` and the `placeholder` stored on the linkage row are byte-identical. Because
+  # this class owns the token grammar, substitution at import time is a plain `gsub`
+  # — no whitespace-padding hacks, no per-post SQL.
+  #
+  # ## Token format
+  #
+  # A token is bracketed by a Unicode Private Use Area delimiter (`U+E000`) and
+  # carries a per-run random nonce:
+  #
+  #     <nonce>.<kind>.<sequence>
+  #
+  # Two independent guarantees keep a token from ever colliding with user content:
+  #
+  #   1. **Delimiter** — `U+E000` is a private-use code point with no assigned
+  #      meaning; it does not occur in real post content, so a bare `gsub` of the
+  #      whole token is unambiguous and the v1 link whitespace-padding hack is
+  #      unnecessary.
+  #   2. **Nonce** — a random value generated once per `Placeholder` instance (i.e.
+  #      once per conversion run). Even if a delimiter somehow leaked into source
+  #      text, the token still could not be forged because the nonce is
+  #      unpredictable.
+  #
+  # The `kind` and `sequence` segments are not required for correctness —
+  # uniqueness comes from the nonce plus the monotonic sequence — but they keep
+  # tokens readable when inspecting a raw body while debugging.
+  class Placeholder
+    # Private Use Area code point used to bracket every token.
+    DELIMITER = "\u{E000}"
+
+    # Matches a whole token regardless of which run minted it (the nonce is opaque
+    # here). Used by the importer and tests to find every token in a raw body.
+    PATTERN = /#{DELIMITER}[^#{DELIMITER}]+#{DELIMITER}/
+
+    # @param nonce [String] overridable only so tests can mint deterministic
+    #   tokens; production code should let it default to a random value.
+    def initialize(nonce: SecureRandom.alphanumeric(16))
+      @nonce = nonce
+      @sequence = 0
+    end
+
+    # Mints the next unique token for the given embed `kind` (e.g. `:quote`).
+    #
+    # @param kind [Symbol, String]
+    # @return [String] the token to splice into `raw` and store as `placeholder`.
+    def mint(kind)
+      @sequence += 1
+      "#{DELIMITER}#{@nonce}.#{kind}.#{@sequence}#{DELIMITER}"
+    end
+
+    # @return [Array<String>] every token present in `text`, in order of appearance.
+    def self.scan(text)
+      text.to_s.scan(PATTERN)
+    end
+
+    # @return [Boolean] whether `text` still contains at least one token.
+    def self.include?(text)
+      PATTERN.match?(text.to_s)
+    end
+  end
+end

--- a/migrations/core/spec/lib/placeholder_spec.rb
+++ b/migrations/core/spec/lib/placeholder_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Placeholder do
+  subject(:placeholder) { described_class.new(nonce: "testnonce") }
+
+  describe "#mint" do
+    it "wraps every token in the Private Use Area delimiter" do
+      token = placeholder.mint(:quote)
+
+      expect(token).to start_with(described_class::DELIMITER)
+      expect(token).to end_with(described_class::DELIMITER)
+    end
+
+    it "embeds the nonce and kind for readability" do
+      expect(placeholder.mint(:upload)).to include("testnonce", "upload")
+    end
+
+    it "mints a unique token on every call" do
+      tokens = Array.new(5) { placeholder.mint(:link) }
+
+      expect(tokens.uniq.size).to eq(5)
+    end
+
+    it "produces different tokens across runs (different nonces)" do
+      other = described_class.new
+
+      expect(placeholder.mint(:quote)).not_to eq(other.mint(:quote))
+    end
+
+    it "does not produce a token that could appear in ordinary user content" do
+      token = placeholder.mint(:mention)
+      sentence = "a normal sentence with @mentions and [links](http://x)"
+
+      # The delimiter is a private-use code point, so it cannot occur in real text.
+      expect(sentence).not_to include(described_class::DELIMITER)
+      expect(token).to include(described_class::DELIMITER)
+    end
+  end
+
+  describe ".scan" do
+    it "finds every token in a raw body, in order" do
+      first = placeholder.mint(:quote)
+      second = placeholder.mint(:link)
+      raw = "before #{first} middle #{second} after"
+
+      expect(described_class.scan(raw)).to eq([first, second])
+    end
+
+    it "returns an empty array when there are no tokens" do
+      expect(described_class.scan("no tokens here")).to be_empty
+    end
+
+    it "tolerates nil" do
+      expect(described_class.scan(nil)).to be_empty
+    end
+  end
+
+  describe ".include?" do
+    it "is true when a token is present" do
+      raw = "x #{placeholder.mint(:event)} y"
+
+      expect(described_class).to be_include(raw)
+    end
+
+    it "is false for plain text" do
+      expect(described_class).not_to be_include("just text")
+    end
+  end
+end

--- a/migrations/importer/lib/migrations/importer/placeholder_resolver.rb
+++ b/migrations/importer/lib/migrations/importer/placeholder_resolver.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Importer
+    # Import-time counterpart of the converter's `EmbedBuffer`: it rewrites the
+    # opaque placeholder tokens left in `post.raw` back into real Markdown, now that
+    # the `original_id -> discourse_id` maps exist.
+    #
+    # This is the v2 replacement for the v1 `raw_with_placeholders_interpolated`
+    # helper. Two things change, both deliberate:
+    #
+    #   * **Load once, substitute many.** All linkage rows for a batch of posts are
+    #     read up front (one query per kind), then every body is rewritten purely in
+    #     memory. The v1 version ran several SQL queries *inside* the per-post
+    #     substitution loop; here there is no SQL on the substitution path.
+    #   * **Plain `gsub`, no padding hacks.** Because `Migrations::Placeholder`
+    #     brackets every token in a Private Use Area delimiter, a token can never
+    #     collide with user content, so the v1 link whitespace-padding regex dance is
+    #     gone — each token is replaced with a bare `String#gsub`.
+    #
+    # ## The `maps` collaborator
+    #
+    # Rendering needs the already-built import maps. They are injected as a single
+    # duck-typed `maps` object so the resolver stays pure (no DB access while
+    # substituting) and unit-testable. It must respond to:
+    #
+    #   * `user(original_id)`          => `{ username:, name: }` or `nil`
+    #   * `group_name(original_id)`    => `String` or `nil`
+    #   * `post(original_id)`          => `{ topic_id:, post_number: }` or `nil`
+    #   * `topic_id(original_id)`      => discourse topic id or `nil`
+    #   * `upload_markdown(original_id)` => resolved `upload://…` Markdown or `nil`
+    #   * `poll_markdown(original_id)` => the poll's rendered Markdown or `nil`
+    #   * `event_markdown(original_id)` => the event's rendered Markdown or `nil`
+    #   * `base_url`                   => the destination site's base URL
+    #
+    # Lookups that return `nil` fall back to the source value (or an empty string),
+    # mirroring the v1 behaviour.
+    class PlaceholderResolver
+      # Maps each typed collection to its IntermediateDB linkage table.
+      TABLES = {
+        quote: "post_quotes",
+        link: "post_links",
+        mention: "post_mentions",
+        poll: "post_polls",
+        event: "post_events",
+        upload: "post_uploads",
+      }.freeze
+      private_constant :TABLES
+
+      # @param intermediate_db [Migrations::Database::Connection] read-only access to
+      #   the IntermediateDB linkage tables.
+      # @param maps [#user, #group_name, #post, #topic_id, #upload_markdown,
+      #   #poll_markdown, #event_markdown, #base_url] the built import maps.
+      def initialize(intermediate_db, maps)
+        @intermediate_db = intermediate_db
+        @maps = maps
+      end
+
+      # Resolves the placeholder tokens in a batch of posts.
+      #
+      # @param posts [Array<Hash>] each with `:id` (the source post original_id) and
+      #   `:raw`.
+      # @return [Hash{Object => String}] source post id => resolved raw.
+      def resolve_all(posts)
+        linkages = load_linkages(posts.map { |post| post[:id] })
+
+        posts.each_with_object({}) do |post, result|
+          result[post[:id]] = substitute(post[:raw], linkages[post[:id]])
+        end
+      end
+
+      # Resolves the placeholder tokens in a single raw body against its already
+      # loaded linkage rows. Used by `resolve_all`; exposed for callers that load
+      # linkage rows themselves.
+      #
+      # @param raw [String, nil]
+      # @param linkage_rows [Array<Hash>, nil] rows tagged with `:_kind`.
+      # @return [String, nil]
+      def substitute(raw, linkage_rows)
+        return raw if raw.nil? || linkage_rows.nil? || linkage_rows.empty?
+
+        result = raw.dup
+        linkage_rows.each { |row| result = result.gsub(row[:placeholder], render(row)) }
+        result
+      end
+
+      private
+
+      # One query per kind, grouped by post id. This is the only place that touches
+      # the database; the substitution path below is pure.
+      def load_linkages(post_ids)
+        buckets = Hash.new { |hash, key| hash[key] = [] }
+        return buckets if post_ids.empty?
+
+        bind_params = (["?"] * post_ids.size).join(", ")
+
+        TABLES.each do |kind, table|
+          sql = "SELECT * FROM #{table} WHERE post_id IN (#{bind_params})"
+          @intermediate_db.query(sql, *post_ids) do |row|
+            row[:_kind] = kind
+            buckets[row[:post_id]] << row
+          end
+        end
+
+        buckets
+      end
+
+      def render(row)
+        case row[:_kind]
+        when :quote
+          render_quote(row)
+        when :link
+          render_link(row)
+        when :mention
+          render_mention(row)
+        when :poll
+          @maps.poll_markdown(row[:poll_id]).to_s
+        when :event
+          @maps.event_markdown(row[:event_id]).to_s
+        when :upload
+          @maps.upload_markdown(row[:upload_id]).to_s
+        else
+          raise ArgumentError, "Unknown placeholder kind: #{row[:_kind].inspect}"
+        end
+      end
+
+      def render_quote(row)
+        user = row[:quoted_user_id] ? @maps.user(row[:quoted_user_id]) : nil
+        username = user&.fetch(:username, nil) || row[:quoted_username]
+        name = user&.fetch(:name, nil)
+
+        if row[:quoted_post_id] && (post = @maps.post(row[:quoted_post_id]))
+          topic_id = post[:topic_id]
+          post_number = post[:post_number]
+        end
+
+        return "[quote]" if username.blank? && name.blank?
+
+        parts = []
+        parts << (name.presence || username)
+        parts << "post:#{post_number}" if post_number.present?
+        parts << "topic:#{topic_id}" if topic_id.present?
+        parts << "username:#{username}" if username.present? && name.present?
+
+        "[quote=\"#{parts.join(", ")}\"]"
+      end
+
+      def render_link(row)
+        url =
+          if row[:target_topic_id]
+            (topic_id = @maps.topic_id(row[:target_topic_id])) ? topic_url(topic_id) : row[:url]
+          elsif row[:target_post_id] && (post = @maps.post(row[:target_post_id]))
+            post[:topic_id] && post[:post_number] ? post_url(post) : row[:url]
+          else
+            row[:url]
+          end
+
+        row[:text] ? "[#{row[:text]}](#{url})" : url.to_s
+      end
+
+      def render_mention(row)
+        name =
+          case row[:mention_type]
+          when "here"
+            "here"
+          when "all"
+            "all"
+          when "group"
+            @maps.group_name(row[:target_id]) || row[:name]
+          else
+            @maps.user(row[:target_id])&.fetch(:username, nil) || row[:name]
+          end
+
+        name.present? ? " @#{name} " : ""
+      end
+
+      def topic_url(topic_id)
+        "#{@maps.base_url}/t/#{topic_id}"
+      end
+
+      def post_url(post)
+        "#{@maps.base_url}/t/#{post[:topic_id]}/#{post[:post_number]}"
+      end
+    end
+  end
+end

--- a/migrations/importer/spec/lib/migrations/importer/placeholder_resolver_spec.rb
+++ b/migrations/importer/spec/lib/migrations/importer/placeholder_resolver_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+# A minimal stand-in for the import maps. Production wiring (mappings DB, uploads
+# store, Discourse base URL) lands with the Posts import step; the resolver only
+# depends on this small duck-typed surface.
+class FakePlaceholderMaps
+  def initialize(**lookups)
+    @lookups = lookups
+  end
+
+  %i[user group_name post topic_id upload_markdown poll_markdown event_markdown].each do |name|
+    define_method(name) { |original_id| (@lookups[name] || {})[original_id] }
+  end
+
+  def base_url
+    @lookups.fetch(:base_url, "https://dest.example.com")
+  end
+end
+
+RSpec.describe Migrations::Importer::PlaceholderResolver do
+  subject(:resolver) { described_class.new(intermediate_db, maps) }
+
+  let(:placeholder) { Migrations::Placeholder.new(nonce: "n") }
+  let(:intermediate_db) { @intermediate_db }
+  let(:maps) { FakePlaceholderMaps.new }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      db_path = File.join(dir, "intermediate.db")
+      Migrations::Database.migrate(
+        db_path,
+        migrations_path: Migrations::Database::INTERMEDIATE_DB_SCHEMA_PATH,
+      )
+      @intermediate_db = Migrations::Database.connect(db_path)
+      Migrations::Database::IntermediateDB.setup(@intermediate_db)
+      example.run
+    ensure
+      Migrations::Database::IntermediateDB.setup(nil)
+    end
+  end
+
+  describe "#resolve_all" do
+    it "rewrites every kind of token using the maps" do
+      quote = placeholder.mint(:quote)
+      link = placeholder.mint(:link)
+      mention = placeholder.mint(:mention)
+      upload = placeholder.mint(:upload)
+
+      Migrations::Database::IntermediateDB::PostQuote.create(
+        post_id: 100,
+        placeholder: quote,
+        quoted_post_id: 200,
+        quoted_user_id: 5,
+      )
+      Migrations::Database::IntermediateDB::PostLink.create(
+        post_id: 100,
+        placeholder: link,
+        url: "https://old.example.com/x",
+        text: "See",
+        target_topic_id: 300,
+      )
+      Migrations::Database::IntermediateDB::PostMention.create(
+        post_id: 100,
+        placeholder: mention,
+        mention_type: "user",
+        target_id: 7,
+        name: "stale-name",
+      )
+      Migrations::Database::IntermediateDB::PostUpload.create(
+        post_id: 100,
+        placeholder: upload,
+        upload_id: "sha1",
+      )
+
+      maps =
+        FakePlaceholderMaps.new(
+          user: {
+            5 => {
+              username: "alice",
+              name: "Alice A",
+            },
+            7 => {
+              username: "bob",
+              name: "Bob",
+            },
+          },
+          post: {
+            200 => {
+              topic_id: 42,
+              post_number: 3,
+            },
+          },
+          topic_id: {
+            300 => 99,
+          },
+          upload_markdown: {
+            "sha1" => "![pic](upload://sha1.png)",
+          },
+        )
+      resolver = described_class.new(intermediate_db, maps)
+
+      raw = "Q #{quote} L #{link} M #{mention} U #{upload} end"
+
+      resolved = resolver.resolve_all([{ id: 100, raw: }])
+
+      expect(resolved[100]).to eq(
+        'Q [quote="Alice A, post:3, topic:42, username:alice"] ' \
+          "L [See](https://dest.example.com/t/99) M  @bob  U ![pic](upload://sha1.png) end",
+      )
+      expect(Migrations::Placeholder).not_to be_include(resolved[100])
+    end
+
+    it "resolves a batch of posts, loading linkage rows once" do
+      first = placeholder.mint(:mention)
+      second = placeholder.mint(:mention)
+
+      Migrations::Database::IntermediateDB::PostMention.create(
+        post_id: 1,
+        placeholder: first,
+        mention_type: "all",
+      )
+      Migrations::Database::IntermediateDB::PostMention.create(
+        post_id: 2,
+        placeholder: second,
+        mention_type: "here",
+      )
+
+      resolved =
+        resolver.resolve_all([{ id: 1, raw: "a #{first} b" }, { id: 2, raw: "c #{second} d" }])
+
+      expect(resolved).to eq({ 1 => "a  @all  b", 2 => "c  @here  d" })
+    end
+
+    it "leaves a body untouched when it has no linkage rows" do
+      expect(resolver.resolve_all([{ id: 9, raw: "plain body" }])).to eq({ 9 => "plain body" })
+    end
+  end
+
+  describe "rendering fallbacks" do
+    it "keeps the source URL when the link target is unmapped" do
+      link = placeholder.mint(:link)
+      Migrations::Database::IntermediateDB::PostLink.create(
+        post_id: 1,
+        placeholder: link,
+        url: "https://old.example.com/x",
+        text: "See",
+        target_topic_id: 300,
+      )
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "x #{link} y" }])
+
+      expect(resolved[1]).to eq("x [See](https://old.example.com/x) y")
+    end
+
+    it "falls back to the recorded username when the user is unmapped" do
+      quote = placeholder.mint(:quote)
+      Migrations::Database::IntermediateDB::PostQuote.create(
+        post_id: 1,
+        placeholder: quote,
+        quoted_user_id: 5,
+        quoted_username: "ghost",
+      )
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "x #{quote} y" }])
+
+      expect(resolved[1]).to eq('x [quote="ghost"] y')
+    end
+
+    it "renders a bare [quote] when nothing identifies the quoted author" do
+      quote = placeholder.mint(:quote)
+      Migrations::Database::IntermediateDB::PostQuote.create(post_id: 1, placeholder: quote)
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "x #{quote} y" }])
+
+      expect(resolved[1]).to eq("x [quote] y")
+    end
+
+    it "drops an entity-backed embed whose markdown is unavailable" do
+      poll = placeholder.mint(:poll)
+      Migrations::Database::IntermediateDB::PostPoll.create(
+        post_id: 1,
+        placeholder: poll,
+        poll_id: 3,
+      )
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "before #{poll} after" }])
+
+      expect(resolved[1]).to eq("before  after")
+      expect(Migrations::Placeholder).not_to be_include(resolved[1])
+    end
+  end
+end

--- a/migrations/tooling/config/schema/intermediate_db/enums/post_hidden_reason.rb
+++ b/migrations/tooling/config/schema/intermediate_db/enums/post_hidden_reason.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Migrations::Tooling::Schema.enum :post_hidden_reason do
+  source { ::Post.hidden_reasons }
+end

--- a/migrations/tooling/config/schema/intermediate_db/enums/post_type.rb
+++ b/migrations/tooling/config/schema/intermediate_db/enums/post_type.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Migrations::Tooling::Schema.enum :post_type do
+  source { ::Post.types }
+end

--- a/migrations/tooling/config/schema/intermediate_db/ignored.rb
+++ b/migrations/tooling/config/schema/intermediate_db/ignored.rb
@@ -74,7 +74,6 @@ Migrations::Tooling::Schema.ignored do
          :post_search_data,
          :post_stats,
          :post_timings,
-         :posts,
          :quoted_posts,
          :shared_drafts
 

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_events.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_events.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Deferred event embeds. Entity-backed — `event_id` carries the source
+# `original_id` of an event converted by its own step (the `events` table), which
+# the importer renders into the post body once that entity is available. The
+# `placeholder` column holds the token spliced into `post.raw`; see
+# `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_events do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :event_id, :numeric
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_links.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_links.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Deferred internal/external links. Pure artifacts — they reference no Discourse
+# entity and exist only as raw substitutions that the importer finalizes once the
+# `original_id -> discourse_id` maps are available. `target_topic_id` /
+# `target_post_id` carry the source `original_id` of the linked entity, if any.
+# The `placeholder` column holds the token spliced into `post.raw`; see
+# `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_links do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :url, :text
+  add_column :text, :text
+  add_column :target_topic_id, :numeric
+  add_column :target_post_id, :numeric
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_mentions.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_mentions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Deferred `@mention` embeds. Pure artifacts — they reference no Discourse entity
+# and exist only as raw substitutions that the importer finalizes once the
+# `original_id -> discourse_id` maps are available. `mention_type` is one of
+# `user` / `group` / `here` / `all`; `target_id` carries the source `original_id`
+# of the mentioned user or group (nil for `here` / `all`). The `placeholder`
+# column holds the token spliced into `post.raw`; see `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_mentions do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :mention_type, :text
+  add_column :target_id, :numeric
+  add_column :name, :text
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_polls.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_polls.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Deferred poll embeds. Entity-backed — `poll_id` carries the source `original_id`
+# of a poll converted by its own step (the `polls` table), which the importer
+# renders into the post body once that entity is available. The `placeholder`
+# column holds the token spliced into `post.raw`; see `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_polls do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :poll_id, :numeric
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_quotes.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_quotes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Deferred `[quote]` embeds. Pure artifacts — they reference no Discourse entity
+# and exist only as raw substitutions that the importer finalizes once the
+# `original_id -> discourse_id` maps are available. The `placeholder` column holds
+# the token spliced into `post.raw`; see `Migrations::Placeholder`.
+Migrations::Tooling::Schema.table :post_quotes do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :quoted_post_id, :numeric
+  add_column :quoted_user_id, :numeric
+  add_column :quoted_username, :text
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/post_uploads.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/post_uploads.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Deferred upload embeds. Entity-backed — `upload_id` references a row in the
+# `uploads` table; the importer reads that upload's resolved `upload://…` markdown
+# from the uploads store and substitutes it into the post body. The `placeholder`
+# column holds the token spliced into `post.raw`; see `Migrations::Placeholder`.
+#
+# NOTE: `upload_id` is `:text`, not `:numeric`. Upload `original_id`s in the
+# IntermediateDB are content hashes (see `uploads.id`, also `:text`), matching the
+# global `.*upload.*_id$ => :text` convention, so the reference must be text too.
+Migrations::Tooling::Schema.table :post_uploads do
+  synthetic!
+
+  add_column :post_id, :numeric, required: true
+  add_column :placeholder, :text, required: true
+  add_column :upload_id, :text
+
+  index :post_id
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/posts.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/posts.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+Migrations::Tooling::Schema.table :posts do
+  index :topic_id, :post_number
+
+  # The cooked/finalized raw is rebuilt at import time; `original_raw` keeps the
+  # untouched source body alongside the placeholder-substituted `raw`.
+  add_column :original_raw, :text
+
+  # `reply_to_post_number` is resolved to the parent post's `original_id` in the
+  # converter, so it's stored as a post reference rather than a number.
+  column :reply_to_post_number, rename_to: :reply_to_post_id
+
+  column :post_type, :post_type
+  column :hidden_reason_id, :post_hidden_reason
+
+  # Post numbers are recomputed at import time, so the source value is optional.
+  column :post_number, required: false
+
+  ignore :baked_at,
+         :baked_version,
+         :bookmark_count,
+         :cook_method,
+         :cooked,
+         :edit_reason,
+         :illegal_count,
+         :image_upload_id,
+         :inappropriate_count,
+         :incoming_link_count,
+         :last_version_at,
+         :like_score,
+         :locale,
+         :notify_moderators_count,
+         :notify_user_count,
+         :off_topic_count,
+         :outbound_message_id,
+         :percent_rank,
+         :public_version,
+         :qa_vote_count,
+         :quote_count,
+         :raw_email,
+         :reads,
+         :reply_count,
+         :reply_quoted,
+         :score,
+         :self_edits,
+         :spam_count,
+         :version,
+         :via_email,
+         :word_count,
+         reason: "Calculated or unused columns"
+end

--- a/migrations/tooling/lib/migrations/tooling/coverage/converter_analyzer.rb
+++ b/migrations/tooling/lib/migrations/tooling/coverage/converter_analyzer.rb
@@ -10,8 +10,9 @@ module Migrations
       # only one branch of a conditional still counts as covered.
       class ConverterAnalyzer
         # `written_columns` per model name; `unknown_models` call site
-        # locations per non-resolving model name.
-        Result = Data.define(:written_columns, :unknown_models)
+        # locations per non-resolving model name; `delegates_post_embeds` whether
+        # any source drains its embeds through `PostEmbedWriter`.
+        Result = Data.define(:written_columns, :unknown_models, :delegates_post_embeds)
 
         # @param converter_path [String] the converter's root source directory
         def initialize(converter_path)
@@ -22,6 +23,7 @@ module Migrations
         def analyze
           written = {}
           unknown = {}
+          delegates_post_embeds = false
 
           source_files.each do |file|
             scan = CreateCallScanner.scan(File.read(file), path: display_path(file))
@@ -30,9 +32,10 @@ module Migrations
             scan.unknown_models.each do |model, locations|
               (unknown[model] ||= []).concat(locations)
             end
+            delegates_post_embeds ||= scan.delegates_post_embeds
           end
 
-          Result.new(written_columns: written, unknown_models: unknown)
+          Result.new(written_columns: written, unknown_models: unknown, delegates_post_embeds:)
         end
 
         private

--- a/migrations/tooling/lib/migrations/tooling/coverage/create_call_scanner.rb
+++ b/migrations/tooling/lib/migrations/tooling/coverage/create_call_scanner.rb
@@ -28,9 +28,19 @@ module Migrations
         INTERMEDIATE_DB = :IntermediateDB
         private_constant :INTERMEDIATE_DB
 
+        # The shared embed-drain helper. A converter that calls
+        # `PostEmbedWriter.write(post_id, embeds)` writes every column of the six
+        # `post_*` linkage tables through it rather than with literal `.create`
+        # call sites, so the scanner records the delegation and the coverage check
+        # credits those tables (see `ReferenceCheck::EMBED_LINKAGE_MODELS`).
+        POST_EMBED_WRITER = :PostEmbedWriter
+        private_constant :POST_EMBED_WRITER
+
         # `columns` are the written columns per model name; `unknown_models` are
-        # the call site locations per non-resolving model name.
-        Result = Data.define(:columns, :unknown_models)
+        # the call site locations per non-resolving model name;
+        # `delegates_post_embeds` is whether the source drains its embeds through
+        # `PostEmbedWriter`.
+        Result = Data.define(:columns, :unknown_models, :delegates_post_embeds)
 
         # @param source [String] Ruby source to analyse
         # @param path [String] source location, used in error messages and
@@ -46,7 +56,11 @@ module Migrations
 
           scanner = new(path)
           result.value.accept(scanner)
-          Result.new(columns: scanner.columns, unknown_models: scanner.unknown_models)
+          Result.new(
+            columns: scanner.columns,
+            unknown_models: scanner.unknown_models,
+            delegates_post_embeds: scanner.delegates_post_embeds?,
+          )
         end
 
         attr_reader :columns, :unknown_models
@@ -56,14 +70,27 @@ module Migrations
           @path = path
           @columns = Hash.new { |hash, key| hash[key] = Set.new }
           @unknown_models = Hash.new { |hash, key| hash[key] = [] }
+          @delegates_post_embeds = false
+        end
+
+        def delegates_post_embeds?
+          @delegates_post_embeds
         end
 
         def visit_call_node(node)
           record_create_call(node)
+          record_embed_writer_call(node)
           super
         end
 
         private
+
+        def record_embed_writer_call(node)
+          return unless node.name == :write
+          return unless const_name(node.receiver) == POST_EMBED_WRITER
+
+          @delegates_post_embeds = true
+        end
 
         def record_create_call(node)
           return unless node.name == :create

--- a/migrations/tooling/lib/migrations/tooling/coverage/reference_check.rb
+++ b/migrations/tooling/lib/migrations/tooling/coverage/reference_check.rb
@@ -19,6 +19,20 @@ module Migrations
         # structural, not a configurable role, so it is hardcoded.
         REFERENCE_CONVERTER = "discourse"
 
+        # The IntermediateDB linkage models that `PostEmbedWriter` writes. A
+        # converter that drains its embeds through that helper (rather than with
+        # literal `.create` call sites) covers every column of these tables; the
+        # scanner flags the delegation, and `covered_columns` credits them here.
+        # See `CreateCallScanner::POST_EMBED_WRITER`.
+        EMBED_LINKAGE_MODELS = %w[
+          PostUpload
+          PostQuote
+          PostMention
+          PostLink
+          PostPoll
+          PostEvent
+        ].freeze
+
         class Error < StandardError
           include Migrations::CLI::PresentableError
         end
@@ -40,7 +54,7 @@ module Migrations
           # just the reference: there is no legitimate reason to write
           # something the schema doesn't know.
           converters.each do |name|
-            unknown_columns = unknown_columns(expected, results.fetch(name).written_columns)
+            unknown_columns = unknown_columns(expected, covered_columns(results.fetch(name), expected))
             unknown_models = results.fetch(name).unknown_models
 
             if unknown_columns.any? || unknown_models.any?
@@ -51,7 +65,8 @@ module Migrations
 
           # Only the reference is asserted against the full schema; every
           # other converter writes a subset of the schema by design.
-          missing = missing_columns(expected, results.fetch(REFERENCE_CONVERTER).written_columns)
+          missing =
+            missing_columns(expected, covered_columns(results.fetch(REFERENCE_CONVERTER), expected))
           if missing.any?
             report_missing(expected, missing)
             passed = false
@@ -66,6 +81,23 @@ module Migrations
         end
 
         private
+
+        # The columns a converter covers: those written at literal `.create` call
+        # sites, plus — when it drains its embeds through `PostEmbedWriter` — every
+        # column of the linkage tables that helper writes.
+        #
+        # @return [Hash{String => Set<Symbol>}]
+        def covered_columns(result, expected)
+          written = result.written_columns
+          return written unless result.delegates_post_embeds
+
+          written = written.dup
+          EMBED_LINKAGE_MODELS.each do |model_name|
+            next unless (model = expected[model_name])
+            written[model_name] = (written[model_name] || Set.new) | model.columns
+          end
+          written
+        end
 
         # @return [Hash{String => Array<Symbol>}] uncovered columns per model,
         #   only for models that have at least one.

--- a/migrations/tooling/spec/lib/migrations/tooling/coverage/create_call_scanner_spec.rb
+++ b/migrations/tooling/spec/lib/migrations/tooling/coverage/create_call_scanner_spec.rb
@@ -83,6 +83,20 @@ RSpec.describe Migrations::Tooling::Coverage::CreateCallScanner do
       )
     end
 
+    it "flags delegation when a source calls PostEmbedWriter.write" do
+      bare = scan("PostEmbedWriter.write(item[:id], embeds)")
+      qualified = scan("Migrations::Converters::PostEmbedWriter.write(id, embeds)")
+
+      expect(bare.delegates_post_embeds).to be(true)
+      expect(qualified.delegates_post_embeds).to be(true)
+    end
+
+    it "does not flag delegation for unrelated .write calls or other receivers" do
+      expect(scan("PostEmbedWriter.flush(embeds)").delegates_post_embeds).to be(false)
+      expect(scan("file.write(data)").delegates_post_embeds).to be(false)
+      expect(scan("IntermediateDB::User.create(username: 'a')").delegates_post_embeds).to be(false)
+    end
+
     it "raises with the source path when the source cannot be parsed" do
       expect { described_class.scan("def broken(", path: "steps/users.rb") }.to raise_error(
         Migrations::Tooling::Coverage::AnalysisError,

--- a/migrations/tooling/spec/lib/migrations/tooling/coverage/reference_check_spec.rb
+++ b/migrations/tooling/spec/lib/migrations/tooling/coverage/reference_check_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe Migrations::Tooling::Coverage::ReferenceCheck do
     Migrations::Tooling::Coverage::SchemaColumns::Model.new(name:, required:, optional:)
   end
 
-  def analysis(written: {}, unknown: {})
+  def analysis(written: {}, unknown: {}, delegates_post_embeds: false)
     Migrations::Tooling::Coverage::ConverterAnalyzer::Result.new(
       written_columns: written.transform_values { |columns| Set.new(columns) },
       unknown_models: unknown,
+      delegates_post_embeds:,
     )
   end
 
@@ -105,6 +106,36 @@ RSpec.describe Migrations::Tooling::Coverage::ReferenceCheck do
 
     passed = nil
     expect { passed = check.run }.to output(/models that don't exist/).to_stdout
+    expect(passed).to be false
+  end
+
+  it "credits the linkage tables when the reference converter delegates to PostEmbedWriter" do
+    stub_coverage(
+      { "discourse" => analysis(written: { "User" => %i[id name] }, delegates_post_embeds: true) },
+      schema: {
+        "User" => model("User", required: [:id], optional: [:name]),
+        "PostUpload" =>
+          model("PostUpload", required: %i[post_id placeholder], optional: [:upload_id]),
+      },
+    )
+
+    passed = nil
+    expect { passed = check.run }.to output(/covers all/).to_stdout
+    expect(passed).to be true
+  end
+
+  it "still reports linkage columns missing when the converter does not delegate" do
+    stub_coverage(
+      { "discourse" => analysis(written: { "User" => %i[id name] }, delegates_post_embeds: false) },
+      schema: {
+        "User" => model("User", required: [:id], optional: [:name]),
+        "PostUpload" =>
+          model("PostUpload", required: %i[post_id placeholder], optional: [:upload_id]),
+      },
+    )
+
+    passed = nil
+    expect { passed = check.run }.to output(/does not write every/).to_stdout
     expect(passed).to be false
   end
 


### PR DESCRIPTION
Adds the Posts step to the Discourse converter, on top of the placeholder primitives that landed in discourse. It turns source posts into Discourse Markdown and defers the embeds (uploads, quotes, mentions) that can only be finalized once the import-time id maps exist.

This started as a stack on the early fork versions of those primitives. It shipped the final `EmbedBuffer`, the coverage holdout and `Migrations::MentionType`, so I rebased onto current `main`, dropped the old fork copies, and this PR is now just the Markbridge conversion and the posts step. It also sits on top of a small "ignore the new `access_control_lists` table" commit so `disco check coverage` stays green.

### Summary

- `Migrations::Converters::Content` wraps Markbridge to turn a source forum's post markup (BBCode, HTML, MediaWiki, TextFormatter XML) into Discourse Markdown. A Discourse source is already Markdown and skips it.
- The Posts step writes the `posts` table and then writes the recorded embeds through the shared `EmbedBuffer#write_for`. The six embed linkage tables are written there, not in the step, so the per-converter coverage check holds them out (`ReferenceCheck::EMBED_BUFFER_TABLES`) and stays green for every converter.
- Embed extraction for a Discourse source lives in the converter, not Markbridge, because a Discourse `raw` is already Markdown and Markbridge has no Markdown parser. A `MarkdownScanner` (vendored from Markbridge 0.2.0, code-block-aware) drives a regex-based `RawExtractor` that defers uploads, quote attributions and `@mentions` into placeholder tokens plus typed linkage rows. Polls and events are self-contained, so they stay in `raw`.
- `MentionResolver` classifies `@name` into the `Migrations::MentionType` values (`here` / `all` / `group` / `user`) — `here` from the source's `here_mention` setting, `group` from the source's group names. It returns the shared constants so the converter and the importer can't drift on the spelling.
- The `posts` schema adapts the closed discourse/discourse#35125 to the current schema DSL (per-table config plus the source/processor step split): the real `posts` columns minus the calculated ones, `reply_to_post_number` resolved to the parent post id, `post_number` made optional (recomputed at import), and `original_raw` kept next to the placeholder-substituted `raw`.

### Notes

- Links aren't deferred by default — most URLs are external and render fine; a converter that rewrites internal links opts in with `defer:`.
- `disco check coverage` is green: the reference converter covers all 328 columns across 32 tables, with the six embed tables held out. The full converters suite passes too.

This is the converter side; the importer-side Posts step and its mappings are a separate branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gschlager/discourse/207)
<!-- Reviewable:end -->
