### PR TITLE
DEV: Scaffold the phpBB converter

### DIFF
--- a/migrations/converters/lib/migrations/converters/phpbb/README.md
+++ b/migrations/converters/lib/migrations/converters/phpbb/README.md
@@ -1,0 +1,42 @@
+# phpBB converter
+
+Converts a phpBB 3.x forum (MySQL or PostgreSQL) into the IntermediateDB that the
+importer loads into Discourse.
+
+> **Status: skeleton.** The structure, step list, and contracts are in place, but
+> `Phpbb::Source` and every step's `process` still raise `NotImplementedError`.
+> It is built to be filled in slice by slice.
+
+## Layout
+
+```
+phpbb/
+├── converter.rb          # registration, setup, step_args
+├── settings.yml          # source DB connection + import options
+├── source/
+│   ├── source.rb         # Phpbb::Source — count_*/fetch_* row contract
+│   └── capabilities.rb   # probes the version-variable columns
+├── content/
+│   ├── content.rb        # per-row format sniff -> Markbridge Content
+│   └── legacy_cleaner.rb # phpBB pre-clean (only what Markbridge lacks)
+└── steps/
+    ├── users.rb anonymous_users.rb groups.rb group_members.rb
+    ├── categories.rb topics.rb posts.rb messages.rb permalinks.rb
+    └── polls/{polls,poll_options,poll_votes}.rb
+```
+
+## How it fits the framework
+
+- The **Source** runs in the parent process and yields plain, type-normalized
+  row-hashes; **processors** run in workers and are pure transforms — they never
+  touch the source DB. See `migrations/docs/converter-architecture.md`.
+- Post bodies convert through the shared `Migrations::Converters::Content`
+  (Markbridge); deferred embeds use `EmbedBuffer` + `PostEmbedWriter`.
+- Uploads (avatars, attachments) go through `Migrations::Converters::UploadCreator`.
+
+## Filling it in
+
+Each step and the Source carry `TODO` notes pointing at the legacy
+`script/import_scripts/phpbb3` importer (the data mapping) and the design doc (the
+architecture). Remaining framework prerequisites: the SQL Source toolkit and the
+`permalinks` / `polls` / `poll_options` / `poll_votes` IntermediateDB tables.

--- a/migrations/converters/lib/migrations/converters/phpbb/content/content.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/content/content.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # Converts a phpBB post body to Discourse Markdown. phpBB owns only two
+      # things on top of the shared engine: per-row format selection and a thin
+      # legacy pre-clean. The conversion itself goes through
+      # `Migrations::Converters::Content` (the Markbridge wrapper), which also
+      # records deferred embeds onto the `on_embed` sink.
+      #
+      # Format is sniffed per row, not inferred from the phpBB version: s9e
+      # TextFormatter stores its parsed form rooted at `<r>` (rich) or `<t>`
+      # (plain); anything else is legacy BBCode. This is robust to mixed content
+      # left behind by an in-place upgrade.
+      #
+      # TODO (fill-in): build the two `Content` instances and run the sniff +
+      # `LegacyCleaner`; resolve `[attachment=N]` markup into upload placeholders
+      # via the shared attachment seam.
+      class Content
+        # @param smilies [Hash] smiley code -> replacement, built once in setup.
+        # @param attachment_resolver [Object] resolves `[attachment=N]` to uploads.
+        def initialize(smilies:, attachment_resolver:)
+          @cleaner = LegacyCleaner.new(smilies:, attachment_resolver:)
+        end
+
+        # @param post_text [String]
+        # @param bbcode_uid [String] the per-post BBCode uid to strip.
+        # @param on_embed [#upload, #quote, #mention, nil] the embed sink.
+        # @return [String] Discourse Markdown.
+        def to_markdown(_post_text, bbcode_uid:, on_embed: nil)
+          raise NotImplementedError
+        end
+
+        private
+
+        def xml?(text)
+          text.start_with?("<r>", "<t>", "<r ", "<t ")
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/content/legacy_cleaner.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/content/legacy_cleaner.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # phpBB-specific pre-clean applied before Markbridge's BBCode parser — and
+      # only the subset Markbridge does not already cover. The legacy importer's
+      # `text_processor.rb` / `smiley_processor.rb` regexes are the conformance
+      # corpus: each is a spec test fed through `Migrations::Converters::Content`,
+      # and whatever already round-trips is deleted from here.
+      #
+      # Candidates to port (verify against Markbridge first):
+      #   * uid strip:        /:(?:\w{5,8})\]/
+      #   * smilies:          <!-- s:) --><img ...><!-- s:) -->
+      #   * magic-url links:  <!-- m -->/<!-- l --> wrappers
+      #   * lists:            [list]…[/list:u] / [*]…[/*:m]
+      #   * attachments:      [attachment=N]…  (routed to the upload seam)
+      #
+      # Smilies and attachment filenames are injected as plain lookups (built once
+      # in the worker's `setup`), never DB calls, so the processor stays pure.
+      class LegacyCleaner
+        def initialize(smilies:, attachment_resolver:)
+          @smilies = smilies
+          @attachment_resolver = attachment_resolver
+        end
+
+        # @param text [String]
+        # @param bbcode_uid [String]
+        # @return [String] cleaned BBCode ready for Markbridge.
+        def call(_text, bbcode_uid:)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/converter.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/converter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # Entry point for the phpBB converter. Opens the source database once in the
+      # main process and threads it — plus the static phpBB config — to every
+      # step's source/processor roles via `step_args`.
+      #
+      # Steps are discovered automatically from the constants in this module (every
+      # class that is a `Conversion::ProgressStep`); see `Conversion::Base#steps`.
+      #
+      # This is a skeleton: `Phpbb::Source` and each step's `process` still raise
+      # `NotImplementedError`. See `migrations/docs/converter-architecture.md` and
+      # the legacy `script/import_scripts/phpbb3` importer for the mapping to port.
+      class Converter < Conversion::Base
+        def setup
+          @source_db = Source.create(settings[:source_db])
+          @phpbb_config = @source_db.config
+        end
+
+        def step_args(_step_class)
+          { source_db: @source_db, phpbb_config: @phpbb_config }
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/settings.yml
+++ b/migrations/converters/lib/migrations/converters/phpbb/settings.yml
@@ -1,0 +1,36 @@
+intermediate_db:
+  path: "/shared/import/intermediate.db"
+
+# The phpBB source database. `type` selects the adapter; fill in the matching
+# block. `table_prefix` is the prefix on every phpBB table (default `phpbb_`).
+source_db:
+  type: mysql # mysql or postgres
+  table_prefix: "phpbb_"
+  mysql:
+    host: "127.0.0.1"
+    port: 3306
+    username: "root"
+    password: "password"
+    database: "phpbb"
+  postgres:
+    host: "127.0.0.1"
+    port: 5432
+    user: "username"
+    password: "password"
+    dbname: "phpbb"
+
+import:
+  site_url: "https://example.com"
+  # Prefix on the source forum's paths, e.g. "phpBB/" if installed in a
+  # subdirectory. Used when building permalinks.
+  url_prefix: ""
+  # Offsets so converted private-message topic/post ids can't collide with
+  # regular topic/post ids.
+  id_prefix:
+    message_topic_id: "10000000"
+    message_post_id: "11000000"
+  avatars:
+    uploaded: true
+    gallery: true
+    remote: true
+    gravatar: true

--- a/migrations/converters/lib/migrations/converters/phpbb/source/capabilities.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/source/capabilities.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # Targeted introspection of the handful of columns that move across phpBB
+      # versions, so the `Source` can resolve them through named seams instead of a
+      # version-keyed class hierarchy. The version string is logged, never branched
+      # on for schema shape.
+      #
+      # The one real delta across 3.0 -> 3.3 is `user_website` / `user_from`
+      # relocating into `profile_fields_data` in 3.1; probe for it rather than
+      # trusting the reported version.
+      #
+      # TODO (fill-in): probe via the SQL toolkit's introspector and return the
+      # resolved expressions / joins.
+      class Capabilities
+        # @param connection [Object] the source connection.
+        # @param prefix [String] the phpBB table prefix.
+        # @return [Capabilities]
+        def self.detect(_connection, _prefix)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/source/source.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/source/source.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # The phpBB source. A SQL-family Source that exposes each entity as a count
+      # and a lazy, type-normalized stream of plain row-hashes — the stable
+      # contract every step reads. The retrieval mechanism (mysql2 / pg, the
+      # dialect, capability probes for version drift) lives entirely here, in the
+      # parent process; workers never hold a handle to it.
+      #
+      # TODO (fill-in):
+      #   * Build on the SQL Source toolkit (`source/sql/{connection,dialect,
+      #     introspector}`) once it is extracted.
+      #   * Pick the adapter + dialect from `settings[:type]`; this replaces the
+      #     legacy `Database3` / `Database3Postgres` version×dialect class chain.
+      #   * Detect `Capabilities` once, and resolve the handful of version-variable
+      #     columns through named seams (see `capabilities.rb`).
+      #   * Port `count_*` / `fetch_*` from the legacy converter's `Database3`
+      #     family, emitting `dialect`-neutral SQL and type-normalized rows.
+      class Source
+        # Entities exposed to the steps. Each gets `count_<entity>` (Integer) and
+        # `fetch_<entity>` (lazy Enumerator of normalized row-hashes).
+        ENTITIES = %i[
+          users
+          anonymous_users
+          groups
+          group_members
+          categories
+          topics
+          posts
+          messages
+          polls
+          poll_options
+          poll_votes
+        ].freeze
+
+        # @param settings [Hash] the `source_db` settings block.
+        # @return [Source]
+        def self.create(_settings)
+          raise NotImplementedError, "phpBB Source is not implemented yet"
+        end
+
+        ENTITIES.each do |entity|
+          define_method(:"count_#{entity}") { raise NotImplementedError }
+          define_method(:"fetch_#{entity}") { raise NotImplementedError }
+        end
+
+        # Static phpBB config read once at setup (smilies path, attachment path,
+        # avatar paths, version, ...), passed to processors as `phpbb_config`.
+        def config
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/anonymous_users.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/anonymous_users.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # TODO: Port from the legacy phpBB converter and the design doc. Map each
+      # source row to `IntermediateDB::<Model>.create(...)`, acknowledging every
+      # IntermediateDB column (pass `column: nil` where phpBB has no value).
+      class AnonymousUsers < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_anonymous_users
+          end
+
+          def items
+            source_db.fetch_anonymous_users
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/categories.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/categories.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # TODO: Port from the legacy phpBB converter and the design doc. Map each
+      # source row to `IntermediateDB::<Model>.create(...)`, acknowledging every
+      # IntermediateDB column (pass `column: nil` where phpBB has no value).
+      class Categories < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_categories
+          end
+
+          def items
+            source_db.fetch_categories
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/group_members.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/group_members.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # TODO: Port from the legacy phpBB converter and the design doc. Map each
+      # source row to `IntermediateDB::<Model>.create(...)`, acknowledging every
+      # IntermediateDB column (pass `column: nil` where phpBB has no value).
+      class GroupMembers < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_group_members
+          end
+
+          def items
+            source_db.fetch_group_members
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/groups.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/groups.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # TODO: Port from the legacy phpBB converter and the design doc. Map each
+      # source row to `IntermediateDB::<Model>.create(...)`, acknowledging every
+      # IntermediateDB column (pass `column: nil` where phpBB has no value).
+      class Groups < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_groups
+          end
+
+          def items
+            source_db.fetch_groups
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/messages.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/messages.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # Private messages -> Discourse PM topics + posts.
+      #
+      # The legacy converter grouped messages that share a normalized subject +
+      # participant set into one PM topic by mutating a `@conversation_map` across
+      # items in a serial step. That cross-item state is incompatible with the pure,
+      # per-item processor model, so the grouping must move below the contract —
+      # into the Source. Two options (see the design doc):
+      #   1. Pre-group in SQL: emit one row per conversation (a `MessageTopics` step)
+      #      and one per message, each carrying its conversation key. Both stay
+      #      parallelizable. (Preferred.)
+      #   2. Group in the parent: the Source builds the conversation -> topic-id map
+      #      as it streams and stamps each yielded row.
+      #
+      # TODO (fill-in): pick an approach, then map rows to
+      # `IntermediateDB::Topic` (private_message) + `IntermediateDB::Post`.
+      class Messages < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_messages
+          end
+
+          def items
+            source_db.fetch_messages
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def setup
+            # @content = Phpbb::Content.new(...)
+          end
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/permalinks.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/permalinks.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # Permalink *normalization* rules (regex rewrites that collapse the many
+      # phpBB URL shapes onto a canonical form). The per-post `permalinks` rows
+      # (url -> post_id) are written by the `Posts` step; this step only seeds the
+      # normalization rules, which are a fixed, source-independent list rather than
+      # a query.
+      #
+      # TODO (fill-in): port the `viewtopic.php?t=`, `viewforum.php?f=`,
+      # `viewtopic.php?p=` normalizations from the legacy converter and write them
+      # via `IntermediateDB::PermalinkNormalization.create(...)`.
+      class Permalinks < Conversion::ProgressStep
+        source do
+          def max_progress
+            items.size
+          end
+
+          def items
+            [] # TODO: the static list of normalization rules.
+          end
+        end
+
+        processor do
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/polls/poll_options.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/polls/poll_options.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # TODO: Port from the legacy phpBB converter and the design doc. Map each
+      # source row to `IntermediateDB::<Model>.create(...)`, acknowledging every
+      # IntermediateDB column (pass `column: nil` where phpBB has no value).
+      class PollOptions < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_poll_options
+          end
+
+          def items
+            source_db.fetch_poll_options
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/polls/poll_votes.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/polls/poll_votes.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # TODO: Port from the legacy phpBB converter and the design doc. Map each
+      # source row to `IntermediateDB::<Model>.create(...)`, acknowledging every
+      # IntermediateDB column (pass `column: nil` where phpBB has no value).
+      class PollVotes < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_poll_votes
+          end
+
+          def items
+            source_db.fetch_poll_votes
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/polls/polls.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/polls/polls.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # TODO: Port from the legacy phpBB converter and the design doc. Map each
+      # source row to `IntermediateDB::<Model>.create(...)`, acknowledging every
+      # IntermediateDB column (pass `column: nil` where phpBB has no value).
+      class Polls < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_polls
+          end
+
+          def items
+            source_db.fetch_polls
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/posts.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/posts.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # The centrepiece: convert each phpBB post to Markdown, defer its embeds, and
+      # write the post + a permalink. Runs in parallel because `process` is
+      # CPU-bound (content conversion).
+      #
+      # TODO (fill-in), per migrations/docs/converter-architecture.md:
+      #   * setup: build `Phpbb::Content` (smilies + attachment resolver from
+      #     `phpbb_config`) once per worker.
+      #   * process:
+      #       embeds = EmbedBuffer.new
+      #       raw = @content.to_markdown(item[:post_text], bbcode_uid: item[:bbcode_uid], on_embed: embeds)
+      #       embeds.poll(poll_id: item[:topic_id]) if item[:has_poll]   # token spliced into raw
+      #       IntermediateDB::Post.create(original_id: item[:post_id], topic_id:, created_at:,
+      #                                   raw:, original_raw: item[:post_text], user_id: author_id(item), ...)
+      #       PostEmbedWriter.write(item[:post_id], embeds)
+      #       IntermediateDB::Permalink.create(url: "#{settings[:url_prefix]}viewtopic.php?p=#{item[:post_id]}",
+      #                                        post_id: item[:post_id])
+      #   * helpers: `author_id` maps an anonymous `post_username` to a stable id.
+      class Posts < Conversion::ProgressStep
+        run_in_parallel true
+
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_posts
+          end
+
+          def items
+            source_db.fetch_posts
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def setup
+            # @content = Phpbb::Content.new(...)
+          end
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+
+        helpers do
+          # def author_id(item)
+          #   item[:post_username].present? ? IdGenerator.short_id(item[:post_username]) : item[:poster_id]
+          # end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/topics.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/topics.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # TODO: Port from the legacy phpBB converter and the design doc. Map each
+      # source row to `IntermediateDB::<Model>.create(...)`, acknowledging every
+      # IntermediateDB column (pass `column: nil` where phpBB has no value).
+      class Topics < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_topics
+          end
+
+          def items
+            source_db.fetch_topics
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/phpbb/steps/users.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/steps/users.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # TODO: Port from the legacy phpBB converter and the design doc. Map each
+      # source row to `IntermediateDB::<Model>.create(...)`, acknowledging every
+      # IntermediateDB column (pass `column: nil` where phpBB has no value).
+      class Users < Conversion::ProgressStep
+        source do
+          attr_accessor :source_db
+
+          def max_progress
+            source_db.count_users
+          end
+
+          def items
+            source_db.fetch_users
+          end
+        end
+
+        processor do
+          attr_accessor :phpbb_config
+
+          def process(item)
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/spec/lib/migrations/converters/phpbb/converter_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/phpbb/converter_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Converters::Phpbb::Converter do
+  it "is a conversion base the framework can run" do
+    expect(described_class.ancestors).to include(Migrations::Conversion::Base)
+  end
+
+  it "loads every step as a discoverable ProgressStep" do
+    step_names = %i[
+      Users
+      AnonymousUsers
+      Groups
+      GroupMembers
+      Categories
+      Topics
+      Posts
+      Messages
+      Permalinks
+      Polls
+      PollOptions
+      PollVotes
+    ]
+
+    step_names.each do |name|
+      klass = Migrations::Converters::Phpbb.const_get(name)
+      expect(klass.ancestors).to include(Migrations::Conversion::ProgressStep),
+      "expected Phpbb::#{name} to be a ProgressStep"
+    end
+  end
+
+  it "loads the source and content collaborators (not as steps)" do
+    %i[Source Capabilities Content LegacyCleaner].each do |name|
+      klass = Migrations::Converters::Phpbb.const_get(name)
+      expect(klass).to be_a(Class)
+      expect(klass.ancestors).not_to include(Migrations::Conversion::StepBase)
+    end
+  end
+end


### PR DESCRIPTION
Stacked on #208 (→ #207 → #206 → #205 → #204). Review/merge the foundation first; this retargets as the stack lands.

Starts the **phpBB converter** as a loadable, discoverable **skeleton** on the new converter framework — the whole shape first, to be filled in slice by slice.

### What's here
`converters/phpbb/`:
- `converter.rb` — `Conversion::Base` subclass: opens the source once in `setup`, threads `source_db` + `phpbb_config` to every role via `step_args`.
- `source/source.rb` — `Phpbb::Source` exposing the `count_*` / `fetch_*` row contract for each entity; `capabilities.rb` for the version-variable columns.
- `content/{content,legacy_cleaner}.rb` — per-row format sniff (`<r>`/`<t>` ⇒ TextFormatter XML, else BBCode) routing through the shared `Migrations::Converters::Content` (Markbridge), plus a thin phpBB pre-clean.
- `steps/` — stubs for every entity: users, anonymous_users, groups, group_members, categories, topics, posts, messages, permalinks, polls/poll_options/poll_votes.
- `settings.yml`, `README.md`.

### Deliberately not implemented yet
`Source.create` and each processor's `process` raise `NotImplementedError`, with `TODO`s pointing at the legacy `script/import_scripts/phpbb3` importer (the data mapping) and `migrations/docs/converter-architecture.md` (the architecture). The **Posts** step shows the intended `Content` + `EmbedBuffer` + `PostEmbedWriter` wiring; **Messages** documents the source-side conversation-grouping rework the pure-processor model requires.

### Safe by construction
It adds no schema and writes no IntermediateDB columns, so the coverage gate is undisturbed — verified `ConverterAnalyzer` returns clean (no parse/splat errors, no unknown models) on the new directory.

### Tests
Smoke spec (3): the converter is a `Conversion::Base`; all twelve steps load as discoverable `ProgressStep`s; the source/content collaborators load and are *not* picked up as steps. Full converters suite green (61).

### Still ahead before it runs
The SQL Source toolkit, and the `permalinks` / `polls` / `poll_options` / `poll_votes` IntermediateDB tables.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4txyRXARPmFxYUANLd8W3)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gschlager/discourse/209)
<!-- Reviewable:end -->
