### PR TITLE
DEV: Add the phpBB SQL dialect

### DIFF
--- a/migrations/converters/lib/migrations/converters/phpbb/source/dialect.rb
+++ b/migrations/converters/lib/migrations/converters/phpbb/source/dialect.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Phpbb
+      # Named SQL fragments that genuinely differ between the source backends, so
+      # the `Source` can author one canonical query and drop a `dialect.<fragment>`
+      # at each divergent spot — instead of writing MySQL and regex-substituting
+      # for Postgres (which fails on the aggregate-building constructs below) or
+      # maintaining a `Database3` / `Database3Postgres` class per backend.
+      #
+      # The set is deliberately small: it covers every divergence in the real
+      # phpBB queries (`epoch_now` for the banlist check; JSON / id-array
+      # aggregation for attachments and PM recipients; identifier quoting) and
+      # nothing speculative.
+      #
+      # `id_array_agg` is the load-bearing case: on MySQL it builds a fake-JSON
+      # string (`"[1,2,3]"`), on Postgres a real JSON array. The connection
+      # normalizes both to parsed Ruby before the row leaves the parent, so a step
+      # always receives `item[:recipients] == [1, 2, 3]`.
+      #
+      # This lives in the phpBB converter for now; promote it to a shared SQL
+      # Source toolkit once a second SQL converter needs it.
+      class Dialect
+        UnknownDialect = Class.new(ArgumentError)
+
+        # @param type [Symbol, String] `:mysql` or `:postgres`.
+        # @return [Dialect]
+        def self.for(type)
+          case type.to_sym
+          when :mysql
+            MySQL.new
+          when :postgres
+            Postgres.new
+          else
+            raise UnknownDialect, "Unknown SQL dialect: #{type.inspect}"
+          end
+        end
+
+        # Current Unix timestamp, for comparing against phpBB's integer time
+        # columns (e.g. `ban_end`).
+        def epoch_now
+          raise NotImplementedError
+        end
+
+        # Aggregate `expr` across a group into a JSON array.
+        def json_array_agg(_expr)
+          raise NotImplementedError
+        end
+
+        # Build a JSON object from `pairs` (a `'key', value, ...` fragment).
+        def json_object(_pairs)
+          raise NotImplementedError
+        end
+
+        # Aggregate the distinct ids in `expr` into something the connection
+        # normalizes to a Ruby array of integers.
+        def id_array_agg(_expr)
+          raise NotImplementedError
+        end
+
+        # Quote `name` as an identifier for this backend.
+        def quote_identifier(_name)
+          raise NotImplementedError
+        end
+
+        class MySQL < Dialect
+          def epoch_now
+            "UNIX_TIMESTAMP()"
+          end
+
+          def json_array_agg(expr)
+            "JSON_ARRAYAGG(#{expr})"
+          end
+
+          def json_object(pairs)
+            "JSON_OBJECT(#{pairs})"
+          end
+
+          def id_array_agg(expr)
+            "CONCAT('[', GROUP_CONCAT(DISTINCT #{expr}), ']')"
+          end
+
+          def quote_identifier(name)
+            "`#{name.to_s.gsub("`", "``")}`"
+          end
+        end
+
+        class Postgres < Dialect
+          def epoch_now
+            "EXTRACT(EPOCH FROM NOW())::bigint"
+          end
+
+          def json_array_agg(expr)
+            "json_agg(#{expr})"
+          end
+
+          def json_object(pairs)
+            "jsonb_build_object(#{pairs})"
+          end
+
+          def id_array_agg(expr)
+            "json_agg(DISTINCT #{expr})"
+          end
+
+          def quote_identifier(name)
+            %("#{name.to_s.gsub('"', '""')}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/spec/lib/migrations/converters/phpbb/dialect_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/phpbb/dialect_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Converters::Phpbb::Dialect do
+  describe ".for" do
+    it "returns the MySQL dialect" do
+      expect(described_class.for(:mysql)).to be_a(described_class::MySQL)
+    end
+
+    it "returns the Postgres dialect" do
+      expect(described_class.for(:postgres)).to be_a(described_class::Postgres)
+    end
+
+    it "accepts a string type" do
+      expect(described_class.for("mysql")).to be_a(described_class::MySQL)
+    end
+
+    it "raises on an unknown dialect" do
+      expect { described_class.for(:sqlite) }.to raise_error(
+        described_class::UnknownDialect,
+        /sqlite/,
+      )
+    end
+  end
+
+  describe described_class::MySQL do
+    subject(:dialect) { described_class.new }
+
+    it { expect(dialect.epoch_now).to eq("UNIX_TIMESTAMP()") }
+
+    it "builds a JSON array aggregate" do
+      expect(dialect.json_array_agg("x")).to eq("JSON_ARRAYAGG(x)")
+    end
+
+    it "builds a JSON object" do
+      expect(dialect.json_object("'a', b")).to eq("JSON_OBJECT('a', b)")
+    end
+
+    it "aggregates distinct ids into a fake-JSON string" do
+      expect(dialect.id_array_agg("pt.user_id")).to eq(
+        "CONCAT('[', GROUP_CONCAT(DISTINCT pt.user_id), ']')",
+      )
+    end
+
+    it "quotes identifiers with backticks and escapes them" do
+      expect(dialect.quote_identifier("phpbb_users")).to eq("`phpbb_users`")
+      expect(dialect.quote_identifier("a`b")).to eq("`a``b`")
+    end
+  end
+
+  describe described_class::Postgres do
+    subject(:dialect) { described_class.new }
+
+    it { expect(dialect.epoch_now).to eq("EXTRACT(EPOCH FROM NOW())::bigint") }
+
+    it "builds a JSON array aggregate" do
+      expect(dialect.json_array_agg("x")).to eq("json_agg(x)")
+    end
+
+    it "builds a JSON object" do
+      expect(dialect.json_object("'a', b")).to eq("jsonb_build_object('a', b)")
+    end
+
+    it "aggregates distinct ids into a real JSON array" do
+      expect(dialect.id_array_agg("pt.user_id")).to eq("json_agg(DISTINCT pt.user_id)")
+    end
+
+    it "quotes identifiers with double quotes and escapes them" do
+      expect(dialect.quote_identifier("phpbb_users")).to eq('"phpbb_users"')
+      expect(dialect.quote_identifier('a"b')).to eq('"a""b"')
+    end
+  end
+
+  it "diverges on exactly the fragments the phpBB queries need" do
+    mysql = described_class::MySQL.new
+    postgres = described_class::Postgres.new
+
+    expect(mysql.epoch_now).not_to eq(postgres.epoch_now)
+    expect(mysql.id_array_agg("x")).not_to eq(postgres.id_array_agg("x"))
+    expect(mysql.json_object("a, b")).not_to eq(postgres.json_object("a, b"))
+  end
+end


### PR DESCRIPTION
Stacked on #209. First fill-in slice for the phpBB converter.

### Why
The legacy converter expressed `version × dialect` as a class chain (`Database3` / `Database3_1` / `Database3Postgres`) and only wired Postgres for 3.0 — so a Postgres install on 3.1+ fell back to the MySQL-flavoured class and died on `UNIX_TIMESTAMP()`. And the genuinely divergent constructs can't be bridged by regex-substituting MySQL → Postgres:

| | MySQL | Postgres |
|---|---|---|
| `epoch_now` | `UNIX_TIMESTAMP()` | `EXTRACT(EPOCH FROM NOW())::bigint` |
| `id_array_agg(x)` | `CONCAT('[', GROUP_CONCAT(DISTINCT x), ']')` (fake-JSON string) | `json_agg(DISTINCT x)` (real JSON) |
| `json_object` | `JSON_OBJECT(…)` | `jsonb_build_object(…)` |

### What
`Phpbb::Dialect` is a small set of named fragments — `epoch_now`, `json_array_agg`, `json_object`, `id_array_agg`, `quote_identifier` — with one instance per backend, selected by `Dialect.for(type)`. The `Source` authors **one** canonical query and drops `dialect.<fragment>` at each divergent spot; the connection later normalizes the `id_array_agg` result (string on MySQL, array on Postgres) to parsed Ruby so steps always see `[1, 2, 3]`.

### Scope note
Kept **inside** the phpBB converter (`Phpbb::Dialect`) for now rather than a framework `source/sql/` toolkit — promote it to the shared toolkit when a second SQL converter (vBulletin) validates the shape. (`Source` consumes it once its `fetch_*` queries are filled in; the connection/introspector and the source-DB wiring follow.)

### Tests
`dialect_spec` (15): every fragment for both backends, the `.for` factory (incl. unknown-dialect error), identifier-escaping, and that the two backends diverge on exactly the fragments the phpBB queries need. Full converters suite green (76).


---
_Generated by [Claude Code](https://claude.ai/code/session_01K4txyRXARPmFxYUANLd8W3)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gschlager/discourse/210)
<!-- Reviewable:end -->
