### PR TITLE
DEV: Add the phpBB schema-fixture generator

### DIFF
--- a/migrations/converters/spec/fixtures/phpbb/README.md
+++ b/migrations/converters/spec/fixtures/phpbb/README.md
@@ -1,0 +1,40 @@
+# phpBB schema fixtures
+
+Real phpBB *source* schemas (no data) used by the converter's retrieval-lint
+spec (`spec/lib/migrations/converters/phpbb/source_spec.rb`), which runs every
+`count_*`/`fetch_*` query against each version × backend to catch dialect/version
+mismatches — e.g. Postgres 3.1+ dying on `UNIX_TIMESTAMP`, or an introspection
+probe leaking across databases.
+
+```
+schemas/<version>/{mysql,postgres}.sql   # schema-only, table prefix phpbb_
+```
+
+The converter's schema surface is `{3.0, 3.1}` — `Database3_1` overrides only
+`fetch_users` (the `user_website`/`user_from` → `profile_fields_data` relocation)
+and `Database3_3` adds nothing — but we keep 3.2 and 3.3 too, to be safe.
+
+## Why these are committed (not generated in CI)
+
+A given phpBB release's schema is **immutable**, so it's a fixture, not something
+to rebuild on every run. CI just loads these `.sql` files into MariaDB + Postgres
+service containers — no PHP, no phpBB, no network in the test path.
+
+## Regenerating (only when bumping supported versions)
+
+phpBB stopped shipping per-DBMS schema SQL after 3.0; 3.1+ ship only `schema.json`
+and materialize it through phpBB's own `db_tools` at install time. Worse, the
+legacy drivers don't run on modern PHP (3.1 tops out at PHP 7.1), so generation
+needs an **older PHP**, which `generate/` provides via Docker.
+
+```
+cd generate && ./generate.sh        # writes ../schemas/<version>/{mysql,postgres}.sql
+```
+
+`generate.sh` brings up throwaway MariaDB + Postgres, then for each version runs a
+container pinned to a compatible PHP (3.0/3.1 → 7.1, 3.2 → 7.4, 3.3 → 8.x),
+materializes the schema with phpBB's `db_tools`, and dumps it schema-only. See
+`generate/README.md` for the per-version matrix.
+
+> The Docker image only exists for generation, run by a maintainer when adding a
+> version — never in CI or the normal test path.

--- a/migrations/converters/spec/fixtures/phpbb/generate/Dockerfile
+++ b/migrations/converters/spec/fixtures/phpbb/generate/Dockerfile
@@ -1,0 +1,20 @@
+# Generator image for phpBB schema fixtures. The PHP version is a build arg
+# because phpBB's legacy DB drivers don't run on modern PHP — each phpBB release
+# needs a compatible interpreter (see generate.sh for the matrix). Used only to
+# (re)generate the committed fixtures, never in CI or the test path.
+ARG PHP_VERSION=7.4
+FROM php:${PHP_VERSION}-cli
+
+# `mysqli` + `pgsql` so phpBB's db_tools can materialize into both backends;
+# `git`/`unzip` for composer.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends git unzip libpq-dev default-mysql-client postgresql-client; \
+    docker-php-ext-install mysqli pdo_mysql pgsql pdo_pgsql; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+WORKDIR /work
+COPY materialize.php /work/materialize.php

--- a/migrations/converters/spec/fixtures/phpbb/generate/Dockerfile
+++ b/migrations/converters/spec/fixtures/phpbb/generate/Dockerfile
@@ -6,10 +6,23 @@ ARG PHP_VERSION=7.4
 FROM php:${PHP_VERSION}-cli
 
 # `mysqli` + `pgsql` so phpBB's db_tools can materialize into both backends;
-# `git`/`unzip` for composer.
+# `git`/`unzip` for composer. (The schema dumps run inside the DB containers, so
+# this image needs no MySQL/Postgres client.)
+#
+# The older PHP images are built on EOL Debian (e.g. 7.1 on buster), whose apt
+# repos have moved to archive.debian.org — repoint at the archive before
+# installing.
 RUN set -eux; \
+    for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do \
+      [ -f "$f" ] || continue; \
+      sed -i -e 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' \
+             -e 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
+             -e 's|http://deb.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
+             -e '/-updates/d' "$f"; \
+    done; \
+    printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99archive; \
     apt-get update; \
-    apt-get install -y --no-install-recommends git unzip libpq-dev default-mysql-client postgresql-client; \
+    apt-get install -y --no-install-recommends ca-certificates curl git unzip libpq-dev; \
     docker-php-ext-install mysqli pdo_mysql pgsql pdo_pgsql; \
     rm -rf /var/lib/apt/lists/*
 

--- a/migrations/converters/spec/fixtures/phpbb/generate/Dockerfile
+++ b/migrations/converters/spec/fixtures/phpbb/generate/Dockerfile
@@ -26,7 +26,9 @@ RUN set -eux; \
     docker-php-ext-install mysqli pdo_mysql pgsql pdo_pgsql; \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+# Composer 2.2 LTS is the last line supporting PHP 7.1 (which phpBB 3.0/3.1
+# need); it also runs on 7.4/8.x, so it covers the whole version matrix.
+COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 WORKDIR /work

--- a/migrations/converters/spec/fixtures/phpbb/generate/Dockerfile
+++ b/migrations/converters/spec/fixtures/phpbb/generate/Dockerfile
@@ -9,15 +9,15 @@ FROM php:${PHP_VERSION}-cli
 # `git`/`unzip` for composer. (The schema dumps run inside the DB containers, so
 # this image needs no MySQL/Postgres client.)
 #
-# The older PHP images are built on EOL Debian (e.g. 7.1 on buster), whose apt
-# repos have moved to archive.debian.org — repoint at the archive before
-# installing.
+# The older PHP images are built on EOL Debian (7.1 on buster, 7.4/8.1 on
+# bullseye), whose apt repos have moved to archive.debian.org. Repoint the main
+# suite at the archive and drop the security/updates suites (not on the archive
+# for every release, and the base packages below all live in main).
 RUN set -eux; \
     for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do \
       [ -f "$f" ] || continue; \
       sed -i -e 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' \
-             -e 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
-             -e 's|http://deb.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
+             -e '/security/d' \
              -e '/-updates/d' "$f"; \
     done; \
     printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99archive; \

--- a/migrations/converters/spec/fixtures/phpbb/generate/README.md
+++ b/migrations/converters/spec/fixtures/phpbb/generate/README.md
@@ -1,0 +1,47 @@
+# phpBB fixture generator
+
+Regenerates `../schemas/<version>/{mysql,postgres}.sql` from phpBB's own schema
+definitions, using phpBB's `db_tools` so the DDL is exactly what phpBB installs.
+Run only when adding/bumping a supported version; the output is committed.
+
+```
+./generate.sh          # needs Docker with registry access (~1GB of pulls)
+```
+
+## Why Docker / older PHP
+
+phpBB stopped shipping per-DBMS schema SQL after 3.0 (3.1+ ship only
+`schema.json`, materialized by `db_tools` at install). Its legacy DB drivers
+don't run on modern PHP — phpBB 3.1's `mysqli` driver fails on PHP 8.x — so each
+release is materialized under a PHP it supports:
+
+| phpBB | release tag      | PHP |
+|-------|------------------|-----|
+| 3.0   | `release-3.0.14` | 7.1 |
+| 3.1   | `release-3.1.12` | 7.1 |
+| 3.2   | `release-3.2.11` | 7.4 |
+| 3.3   | `release-3.3.14` | 8.1 |
+
+`db_tools`' bootstrap also changed across versions (the `filesystem` namespace,
+the `sqlite` driver name, and the `db_tools` factory); `materialize.php` detects
+the right variant at runtime.
+
+## Pipeline (per version)
+
+1. Bring up throwaway MariaDB + Postgres (`docker-compose.yml`, tmpfs — no data
+   kept).
+2. In a PHP-pinned container: download the phpBB tag, `composer install`.
+3. For Postgres, install phpBB's `varchar_ci` domain preamble (taken from 3.0's
+   committed `postgres_schema.sql`, which `db_tools` assumes exists).
+4. `materialize.php` builds the schema from the migrations and creates the tables
+   via `db_tools`.
+5. Dump schema-only (`mariadb-dump --no-data` / `pg_dump --schema-only`) into
+   `../schemas/<version>/`.
+
+## Status
+
+The individual steps are validated against real phpBB sources (the
+`create_schema_files.php` → `schema.json` → `db_tools` materialize flow produces
+real 3.0/3.2/3.3 schemas). The Dockerized orchestration here packages them for
+the older-PHP versions; run it in an environment with container-registry access
+and review the diff before committing the regenerated fixtures.

--- a/migrations/converters/spec/fixtures/phpbb/generate/docker-compose.yml
+++ b/migrations/converters/spec/fixtures/phpbb/generate/docker-compose.yml
@@ -1,0 +1,33 @@
+# Throwaway MariaDB + Postgres that phpBB's db_tools materializes into, plus a
+# generator service whose PHP version is chosen per phpBB release. Only used to
+# (re)generate the committed fixtures — see generate.sh and ../README.md.
+services:
+  mariadb:
+    image: mariadb:10.11
+    environment:
+      MARIADB_ROOT_PASSWORD: phpbb
+      MARIADB_DATABASE: phpbb
+    tmpfs:
+      - /var/lib/mysql # schema-only generation, no durability needed
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: phpbb
+      POSTGRES_DB: phpbb
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  generate:
+    build:
+      context: .
+      args:
+        PHP_VERSION: ${PHP_VERSION:-7.4}
+    depends_on:
+      - mariadb
+      - postgres
+    environment:
+      DB_HOST_MYSQL: mariadb
+      DB_HOST_PG: postgres
+    volumes:
+      - ./out:/out # generated fixtures land here

--- a/migrations/converters/spec/fixtures/phpbb/generate/docker-compose.yml
+++ b/migrations/converters/spec/fixtures/phpbb/generate/docker-compose.yml
@@ -7,12 +7,15 @@ services:
     environment:
       MARIADB_ROOT_PASSWORD: phpbb
       MARIADB_DATABASE: phpbb
+      MARIADB_USER: phpbb # gets ALL on the phpbb database (enough to create tables)
+      MARIADB_PASSWORD: phpbb
     tmpfs:
       - /var/lib/mysql # schema-only generation, no durability needed
 
   postgres:
     image: postgres:16
     environment:
+      POSTGRES_USER: phpbb # becomes the superuser
       POSTGRES_PASSWORD: phpbb
       POSTGRES_DB: phpbb
     tmpfs:

--- a/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
+++ b/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
@@ -32,13 +32,12 @@ pg_cli() { compose exec -T postgres psql -q -U phpbb -d phpbb; }
 
 # phpBB's Postgres schema needs the `varchar_ci` domain (+ operators), which
 # `db_tools` assumes exists; it's defined in 3.0's committed postgres_schema.sql
-# preamble. Emit just that preamble (no tables) for the materialized versions.
-# Download fully before `awk` — `awk … {exit}` would close the pipe early and,
-# under `pipefail`, fail curl with a broken-pipe error.
+# preamble. Emit just that preamble (everything before the first CREATE TABLE,
+# minus the sequences). The awk reads the whole input rather than `exit`ing early,
+# so it can't close the pipe mid-write and trip SIGPIPE under `pipefail`.
 pg_preamble_sql() {
-  local schema
-  schema="$(curl -fsSL "${RAW}/release-3.0.14/phpBB/install/schemas/postgres_schema.sql")"
-  printf '%s\n' "$schema" | awk '/CREATE TABLE/{exit} !/CREATE SEQUENCE/{print}'
+  curl -fsSL "${RAW}/release-3.0.14/phpBB/install/schemas/postgres_schema.sql" \
+    | awk '/CREATE TABLE/{stop = 1} !stop && !/CREATE SEQUENCE/{print}'
   echo "COMMIT;"
 }
 

--- a/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
+++ b/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
@@ -3,14 +3,17 @@
 # Regenerates the committed phpBB schema fixtures (../schemas/<version>/*.sql).
 # Run by a maintainer when adding/bumping a supported phpBB version — not in CI.
 #
-# For each version it spins up throwaway MariaDB + Postgres, then runs a
-# generator container pinned to a PHP the release supports, downloads the phpBB
-# tag, `composer install`s it, materializes the schema with phpBB's own
-# `db_tools`, and dumps it schema-only. See ../README.md.
+# Spins up throwaway MariaDB + Postgres, populates a phpBB schema into each, and
+# dumps it schema-only. 3.0 ships static schema SQL (it predates migrations and
+# composer); 3.1+ are materialized from their migrations with phpBB's own
+# `db_tools`, which needs an older PHP — hence the per-version container. See
+# ../README.md.
 #
 # Requires Docker (with registry access) and ~1GB of pulls.
 set -euo pipefail
 cd "$(dirname "$0")"
+
+RAW="https://raw.githubusercontent.com/phpbb/phpbb"
 
 # version | release tag | PHP (legacy drivers cap the interpreter: 3.1 <= 7.1)
 MATRIX=(
@@ -20,65 +23,76 @@ MATRIX=(
   "3.3|release-3.3.14|8.1"
 )
 
-compose() { docker compose "$@"; }
+compose() { PHP_VERSION="${PHP_VERSION:-7.4}" docker compose "$@"; }
 
-# phpBB's Postgres schema needs the `varchar_ci` domain (+ its operators), which
+mysql_cli() { compose exec -T mariadb mariadb -uphpbb -pphpbb phpbb; }
+pg_cli() { compose exec -T postgres psql -q -U phpbb -d phpbb; }
+
+# phpBB's Postgres schema needs the `varchar_ci` domain (+ operators), which
 # `db_tools` assumes exists; it's defined in 3.0's committed postgres_schema.sql
-# preamble. Install just that preamble (no tables) before materializing.
-pg_preamble() {
-  local tag="$1"
-  curl -fsSL "https://raw.githubusercontent.com/phpbb/phpbb/release-3.0.14/phpBB/install/schemas/postgres_schema.sql" \
+# preamble. Emit just that preamble (no tables) for the materialized versions.
+pg_preamble_sql() {
+  curl -fsSL "${RAW}/release-3.0.14/phpBB/install/schemas/postgres_schema.sql" \
     | awk '/CREATE TABLE/{exit} !/CREATE SEQUENCE/{print}'
   echo "COMMIT;"
 }
 
+wait_for_dbs() {
+  echo "waiting for databases..."
+  until compose exec -T postgres pg_isready -U phpbb -q; do sleep 1; done
+  until compose exec -T mariadb mariadb-admin ping -uphpbb -pphpbb --silent 2>/dev/null; do sleep 1; done
+}
+
+populate_3_0() {
+  local tag="$1" base="${RAW}/${1}/phpBB/install/schemas"
+  curl -fsSL "${base}/mysql_41_schema.sql" | mysql_cli
+  curl -fsSL "${base}/postgres_schema.sql" | pg_cli >/dev/null
+}
+
+populate_materialized() {
+  local tag="$1"
+  compose build generate
+  pg_preamble_sql | pg_cli >/dev/null
+
+  # Download, composer install, and materialize both engines in ONE container
+  # (each `compose run` is ephemeral, so it must all happen together).
+  compose run --rm -T generate sh -euxc "
+    curl -fsSL 'https://codeload.github.com/phpbb/phpbb/tar.gz/refs/tags/${tag}' | tar xz -C /tmp
+    src=/tmp/phpbb-${tag}/phpBB
+    (cd \"\$src\" && composer install --no-dev --no-scripts --ignore-platform-reqs --no-progress)
+    for engine in mysql postgres; do
+      if [ \"\$engine\" = mysql ]; then host=mariadb port=3306; else host=postgres port=5432; fi
+      PHPBB_ROOT=\"\$src\" TARGET_ENGINE=\"\$engine\" DB_HOST=\"\$host\" DB_PORT=\"\$port\" \
+        DB_NAME=phpbb DB_USER=phpbb DB_PASS=phpbb php /work/materialize.php
+    done
+  "
+}
+
 generate_one() {
-  local ver="$1" tag="$2" php="$3"
-  echo ">>> phpBB ${ver} (${tag}) on PHP ${php}"
+  local ver="$1" tag="$2"
+  echo ">>> phpBB ${ver} (${tag}) on PHP ${PHP_VERSION}"
   mkdir -p "../schemas/${ver}"
 
-  PHP_VERSION="${php}" compose up -d --build mariadb postgres
-  PHP_VERSION="${php}" compose build generate
+  compose up -d --build mariadb postgres
+  wait_for_dbs
 
-  # Fetch + composer install the phpBB source inside the generator container.
-  PHP_VERSION="${php}" compose run --rm -T generate sh -euxc "
-    rm -rf /work/phpbb && mkdir -p /work/phpbb
-    curl -fsSL 'https://codeload.github.com/phpbb/phpbb/tar.gz/refs/tags/${tag}' \
-      | tar xz -C /work/phpbb --strip-components=1
-    cd /work/phpbb/phpBB
-    composer install --no-dev --no-scripts --ignore-platform-reqs --no-progress
-  "
+  if [ "$ver" = "3.0" ]; then
+    populate_3_0 "$tag"
+  else
+    populate_materialized "$tag"
+  fi
 
-  # Materialize into both engines, then dump schema-only.
-  for engine in mysql postgres; do
-    if [ "$engine" = "postgres" ]; then
-      pg_preamble "$tag" | PHP_VERSION="${php}" compose exec -T postgres psql -U phpbb -d phpbb >/dev/null
-    fi
-    PHP_VERSION="${php}" compose run --rm -T \
-      -e PHPBB_ROOT=/work/phpbb/phpBB \
-      -e TARGET_ENGINE="$engine" \
-      -e DB_NAME=phpbb -e DB_USER=phpbb -e DB_PASS=phpbb \
-      -e DB_HOST="$([ "$engine" = mysql ] && echo mariadb || echo postgres)" \
-      -e DB_PORT="$([ "$engine" = mysql ] && echo 3306 || echo 5432)" \
-      generate php /work/materialize.php
-  done
+  compose exec -T mariadb mariadb-dump --no-data --skip-comments --compact -uphpbb -pphpbb phpbb \
+    >"../schemas/${ver}/mysql.sql"
+  compose exec -T postgres pg_dump --schema-only --no-owner --no-privileges -U phpbb phpbb \
+    >"../schemas/${ver}/postgres.sql"
 
-  dump_mysql "$ver"
-  dump_postgres "$ver"
-  PHP_VERSION="${php}" compose down -v
-}
-
-dump_mysql() {
-  compose exec -T mariadb mariadb-dump --no-data --skip-comments --compact phpbb \
-    >"../schemas/$1/mysql.sql"
-}
-dump_postgres() {
-  compose exec -T postgres pg_dump --schema-only --no-owner --no-privileges phpbb \
-    >"../schemas/$1/postgres.sql"
+  compose down -v
 }
 
 for row in "${MATRIX[@]}"; do
-  IFS='|' read -r ver tag php <<<"$row"
-  generate_one "$ver" "$tag" "$php"
+  IFS='|' read -r ver tag PHP_VERSION <<<"$row"
+  export PHP_VERSION
+  generate_one "$ver" "$tag"
 done
 echo "Done. Review and commit ../schemas/*/*.sql"

--- a/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
+++ b/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
@@ -33,9 +33,12 @@ pg_cli() { compose exec -T postgres psql -q -U phpbb -d phpbb; }
 # phpBB's Postgres schema needs the `varchar_ci` domain (+ operators), which
 # `db_tools` assumes exists; it's defined in 3.0's committed postgres_schema.sql
 # preamble. Emit just that preamble (no tables) for the materialized versions.
+# Download fully before `awk` — `awk … {exit}` would close the pipe early and,
+# under `pipefail`, fail curl with a broken-pipe error.
 pg_preamble_sql() {
-  curl -fsSL "${RAW}/release-3.0.14/phpBB/install/schemas/postgres_schema.sql" \
-    | awk '/CREATE TABLE/{exit} !/CREATE SEQUENCE/{print}'
+  local schema
+  schema="$(curl -fsSL "${RAW}/release-3.0.14/phpBB/install/schemas/postgres_schema.sql")"
+  printf '%s\n' "$schema" | awk '/CREATE TABLE/{exit} !/CREATE SEQUENCE/{print}'
   echo "COMMIT;"
 }
 

--- a/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
+++ b/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
@@ -15,12 +15,14 @@ cd "$(dirname "$0")"
 
 RAW="https://raw.githubusercontent.com/phpbb/phpbb"
 
-# version | release tag | PHP (legacy drivers cap the interpreter: 3.1 <= 7.1)
+# version | release tag | PHP (legacy drivers cap the interpreter: 3.1 <= 7.1).
+# Pinned to the final release of each EOL branch (3.0/3.1/3.2) and the latest
+# 3.3; bump these when regenerating against a newer phpBB.
 MATRIX=(
   "3.0|release-3.0.14|7.1"
   "3.1|release-3.1.12|7.1"
   "3.2|release-3.2.11|7.4"
-  "3.3|release-3.3.14|8.1"
+  "3.3|release-3.3.17|8.1"
 )
 
 compose() { PHP_VERSION="${PHP_VERSION:-7.4}" docker compose "$@"; }

--- a/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
+++ b/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
@@ -25,7 +25,9 @@ MATRIX=(
 
 compose() { PHP_VERSION="${PHP_VERSION:-7.4}" docker compose "$@"; }
 
-mysql_cli() { compose exec -T mariadb mariadb -uphpbb -pphpbb phpbb; }
+# Force TCP (-h127.0.0.1) on the MariaDB client: MARIADB_USER is created as
+# phpbb@'%', which a socket connection (phpbb@'localhost') doesn't match.
+mysql_cli() { compose exec -T mariadb mariadb -h127.0.0.1 -uphpbb -pphpbb phpbb; }
 pg_cli() { compose exec -T postgres psql -q -U phpbb -d phpbb; }
 
 # phpBB's Postgres schema needs the `varchar_ci` domain (+ operators), which
@@ -40,7 +42,7 @@ pg_preamble_sql() {
 wait_for_dbs() {
   echo "waiting for databases..."
   until compose exec -T postgres pg_isready -U phpbb -q; do sleep 1; done
-  until compose exec -T mariadb mariadb-admin ping -uphpbb -pphpbb --silent 2>/dev/null; do sleep 1; done
+  until compose exec -T mariadb mariadb-admin -h127.0.0.1 -uphpbb -pphpbb ping --silent 2>/dev/null; do sleep 1; done
 }
 
 populate_3_0() {
@@ -82,7 +84,7 @@ generate_one() {
     populate_materialized "$tag"
   fi
 
-  compose exec -T mariadb mariadb-dump --no-data --skip-comments --compact -uphpbb -pphpbb phpbb \
+  compose exec -T mariadb mariadb-dump -h127.0.0.1 --no-data --skip-comments --compact -uphpbb -pphpbb phpbb \
     >"../schemas/${ver}/mysql.sql"
   compose exec -T postgres pg_dump --schema-only --no-owner --no-privileges -U phpbb phpbb \
     >"../schemas/${ver}/postgres.sql"

--- a/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
+++ b/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
@@ -78,6 +78,7 @@ generate_one() {
   echo ">>> phpBB ${ver} (${tag}) on PHP ${PHP_VERSION}"
   mkdir -p "../schemas/${ver}"
 
+  compose down -v >/dev/null 2>&1 || true # clean slate, in case a prior run was interrupted
   compose up -d --build mariadb postgres
   wait_for_dbs
 

--- a/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
+++ b/migrations/converters/spec/fixtures/phpbb/generate/generate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Regenerates the committed phpBB schema fixtures (../schemas/<version>/*.sql).
+# Run by a maintainer when adding/bumping a supported phpBB version — not in CI.
+#
+# For each version it spins up throwaway MariaDB + Postgres, then runs a
+# generator container pinned to a PHP the release supports, downloads the phpBB
+# tag, `composer install`s it, materializes the schema with phpBB's own
+# `db_tools`, and dumps it schema-only. See ../README.md.
+#
+# Requires Docker (with registry access) and ~1GB of pulls.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# version | release tag | PHP (legacy drivers cap the interpreter: 3.1 <= 7.1)
+MATRIX=(
+  "3.0|release-3.0.14|7.1"
+  "3.1|release-3.1.12|7.1"
+  "3.2|release-3.2.11|7.4"
+  "3.3|release-3.3.14|8.1"
+)
+
+compose() { docker compose "$@"; }
+
+# phpBB's Postgres schema needs the `varchar_ci` domain (+ its operators), which
+# `db_tools` assumes exists; it's defined in 3.0's committed postgres_schema.sql
+# preamble. Install just that preamble (no tables) before materializing.
+pg_preamble() {
+  local tag="$1"
+  curl -fsSL "https://raw.githubusercontent.com/phpbb/phpbb/release-3.0.14/phpBB/install/schemas/postgres_schema.sql" \
+    | awk '/CREATE TABLE/{exit} !/CREATE SEQUENCE/{print}'
+  echo "COMMIT;"
+}
+
+generate_one() {
+  local ver="$1" tag="$2" php="$3"
+  echo ">>> phpBB ${ver} (${tag}) on PHP ${php}"
+  mkdir -p "../schemas/${ver}"
+
+  PHP_VERSION="${php}" compose up -d --build mariadb postgres
+  PHP_VERSION="${php}" compose build generate
+
+  # Fetch + composer install the phpBB source inside the generator container.
+  PHP_VERSION="${php}" compose run --rm -T generate sh -euxc "
+    rm -rf /work/phpbb && mkdir -p /work/phpbb
+    curl -fsSL 'https://codeload.github.com/phpbb/phpbb/tar.gz/refs/tags/${tag}' \
+      | tar xz -C /work/phpbb --strip-components=1
+    cd /work/phpbb/phpBB
+    composer install --no-dev --no-scripts --ignore-platform-reqs --no-progress
+  "
+
+  # Materialize into both engines, then dump schema-only.
+  for engine in mysql postgres; do
+    if [ "$engine" = "postgres" ]; then
+      pg_preamble "$tag" | PHP_VERSION="${php}" compose exec -T postgres psql -U phpbb -d phpbb >/dev/null
+    fi
+    PHP_VERSION="${php}" compose run --rm -T \
+      -e PHPBB_ROOT=/work/phpbb/phpBB \
+      -e TARGET_ENGINE="$engine" \
+      -e DB_NAME=phpbb -e DB_USER=phpbb -e DB_PASS=phpbb \
+      -e DB_HOST="$([ "$engine" = mysql ] && echo mariadb || echo postgres)" \
+      -e DB_PORT="$([ "$engine" = mysql ] && echo 3306 || echo 5432)" \
+      generate php /work/materialize.php
+  done
+
+  dump_mysql "$ver"
+  dump_postgres "$ver"
+  PHP_VERSION="${php}" compose down -v
+}
+
+dump_mysql() {
+  compose exec -T mariadb mariadb-dump --no-data --skip-comments --compact phpbb \
+    >"../schemas/$1/mysql.sql"
+}
+dump_postgres() {
+  compose exec -T postgres pg_dump --schema-only --no-owner --no-privileges phpbb \
+    >"../schemas/$1/postgres.sql"
+}
+
+for row in "${MATRIX[@]}"; do
+  IFS='|' read -r ver tag php <<<"$row"
+  generate_one "$ver" "$tag" "$php"
+done
+echo "Done. Review and commit ../schemas/*/*.sql"

--- a/migrations/converters/spec/fixtures/phpbb/generate/materialize.php
+++ b/migrations/converters/spec/fixtures/phpbb/generate/materialize.php
@@ -45,7 +45,7 @@ $generator = new \phpbb\db\migration\schema_generator(
     $build_tools($sqlite, true),
     $root,
     $phpEx,
-    $table_prefix,
+    $table_prefix
 );
 $schema = $generator->get_schema();
 
@@ -58,7 +58,7 @@ $db->sql_connect(
     getenv('DB_NAME'),
     (int) getenv('DB_PORT'),
     false,
-    false,
+    false
 );
 
 $tools = $build_tools($db);

--- a/migrations/converters/spec/fixtures/phpbb/generate/materialize.php
+++ b/migrations/converters/spec/fixtures/phpbb/generate/materialize.php
@@ -1,0 +1,72 @@
+<?php
+// Materializes a phpBB version's schema (from its migration definitions) into a
+// live MySQL or Postgres database using phpBB's own `db_tools`, so the dumped
+// DDL is exactly what phpBB would create. Reads a checked-out phpBB tree and the
+// target connection from the environment; bootstrap differs across versions
+// (the filesystem namespace, the sqlite driver name, and the db_tools factory
+// all changed between 3.1 and 3.2), so the right variant is detected at runtime.
+//
+//   PHPBB_ROOT, TARGET_ENGINE (mysql|postgres),
+//   DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME
+
+define('IN_PHPBB', true);
+$root = rtrim(getenv('PHPBB_ROOT'), '/') . '/';
+$phpEx = 'php';
+$table_prefix = 'phpbb_';
+
+require $root . 'vendor/autoload.php';
+include $root . 'includes/constants.php';
+require $root . 'phpbb/class_loader.php';
+(new \phpbb\class_loader('phpbb\\', "{$root}phpbb/", $phpEx))->register();
+
+// `\phpbb\filesystem` (<= 3.1) became `\phpbb\filesystem\filesystem` (>= 3.2).
+$filesystem = class_exists('\phpbb\filesystem\filesystem')
+    ? new \phpbb\filesystem\filesystem()
+    : new \phpbb\filesystem();
+
+$finder = new \phpbb\finder($filesystem, $root);
+$classes = $finder->core_path('phpbb/')->directory('/db/migration/data')->get_classes();
+
+// The `sqlite` driver became `sqlite3`, and db_tools moved behind a factory.
+$has_factory = class_exists('\phpbb\db\tools\factory');
+$sqlite_class = class_exists('\phpbb\db\driver\sqlite3') ? '\phpbb\db\driver\sqlite3' : '\phpbb\db\driver\sqlite';
+$sqlite = new $sqlite_class();
+
+$build_tools = static function ($db, $return_statements = false) use ($has_factory) {
+    return $has_factory
+        ? (new \phpbb\db\tools\factory())->get($db, $return_statements)
+        : new \phpbb\db\tools($db, $return_statements);
+};
+
+$generator = new \phpbb\db\migration\schema_generator(
+    $classes,
+    new \phpbb\config\config([]),
+    $sqlite,
+    $build_tools($sqlite, true),
+    $root,
+    $phpEx,
+    $table_prefix,
+);
+$schema = $generator->get_schema();
+
+$engine = getenv('TARGET_ENGINE');
+$db = $engine === 'mysql' ? new \phpbb\db\driver\mysqli() : new \phpbb\db\driver\postgres();
+$db->sql_connect(
+    getenv('DB_HOST'),
+    getenv('DB_USER'),
+    getenv('DB_PASS'),
+    getenv('DB_NAME'),
+    (int) getenv('DB_PORT'),
+    false,
+    false,
+);
+
+$tools = $build_tools($db);
+$created = 0;
+foreach ($schema as $table => $table_data) {
+    if (!$tools->sql_table_exists($table)) {
+        $tools->sql_create_table($table, $table_data);
+        $created++;
+    }
+}
+fwrite(STDERR, "materialized {$created} tables into {$engine}/" . getenv('DB_NAME') . "\n");

--- a/migrations/converters/spec/fixtures/phpbb/schemas/3.0/mysql.sql
+++ b/migrations/converters/spec/fixtures/phpbb/schemas/3.0/mysql.sql
@@ -1,0 +1,1030 @@
+/*M!999999\- enable the sandbox mode */ 
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  KEY `group_id` (`group_id`),
+  KEY `auth_opt_id` (`auth_option_id`),
+  KEY `auth_role_id` (`auth_role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_options` (
+  `auth_option_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `auth_option` varchar(50) NOT NULL DEFAULT '',
+  `is_global` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `is_local` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `founder_only` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`auth_option_id`),
+  UNIQUE KEY `auth_option` (`auth_option`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_roles` (
+  `role_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `role_name` varchar(255) NOT NULL DEFAULT '',
+  `role_description` text NOT NULL,
+  `role_type` varchar(10) NOT NULL DEFAULT '',
+  `role_order` smallint(4) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`role_id`),
+  KEY `role_type` (`role_type`),
+  KEY `role_order` (`role_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_roles_data` (
+  `role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`role_id`,`auth_option_id`),
+  KEY `ath_op_id` (`auth_option_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_users` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  KEY `user_id` (`user_id`),
+  KEY `auth_option_id` (`auth_option_id`),
+  KEY `auth_role_id` (`auth_role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_attachments` (
+  `attach_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `post_msg_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `in_message` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `poster_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `is_orphan` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `physical_filename` varchar(255) NOT NULL DEFAULT '',
+  `real_filename` varchar(255) NOT NULL DEFAULT '',
+  `download_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `attach_comment` text NOT NULL,
+  `extension` varchar(100) NOT NULL DEFAULT '',
+  `mimetype` varchar(100) NOT NULL DEFAULT '',
+  `filesize` int(20) unsigned NOT NULL DEFAULT 0,
+  `filetime` int(11) unsigned NOT NULL DEFAULT 0,
+  `thumbnail` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`attach_id`),
+  KEY `filetime` (`filetime`),
+  KEY `post_msg_id` (`post_msg_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `poster_id` (`poster_id`),
+  KEY `is_orphan` (`is_orphan`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_banlist` (
+  `ban_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `ban_userid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `ban_ip` varchar(40) NOT NULL DEFAULT '',
+  `ban_email` varchar(100) NOT NULL DEFAULT '',
+  `ban_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `ban_end` int(11) unsigned NOT NULL DEFAULT 0,
+  `ban_exclude` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `ban_reason` varchar(255) NOT NULL DEFAULT '',
+  `ban_give_reason` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`ban_id`),
+  KEY `ban_end` (`ban_end`),
+  KEY `ban_user` (`ban_userid`,`ban_exclude`),
+  KEY `ban_email` (`ban_email`,`ban_exclude`),
+  KEY `ban_ip` (`ban_ip`,`ban_exclude`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bbcodes` (
+  `bbcode_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `bbcode_tag` varchar(16) NOT NULL DEFAULT '',
+  `bbcode_helpline` varchar(255) NOT NULL DEFAULT '',
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_match` text NOT NULL,
+  `bbcode_tpl` mediumtext NOT NULL,
+  `first_pass_match` mediumtext NOT NULL,
+  `first_pass_replace` mediumtext NOT NULL,
+  `second_pass_match` mediumtext NOT NULL,
+  `second_pass_replace` mediumtext NOT NULL,
+  PRIMARY KEY (`bbcode_id`),
+  KEY `display_on_post` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bookmarks` (
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`topic_id`,`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bots` (
+  `bot_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `bot_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `bot_name` varchar(255) NOT NULL DEFAULT '',
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `bot_agent` varchar(255) NOT NULL DEFAULT '',
+  `bot_ip` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`bot_id`),
+  KEY `bot_active` (`bot_active`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_config` (
+  `config_name` varchar(255) NOT NULL DEFAULT '',
+  `config_value` varchar(255) NOT NULL DEFAULT '',
+  `is_dynamic` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`config_name`),
+  KEY `is_dynamic` (`is_dynamic`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_confirm` (
+  `confirm_id` char(32) NOT NULL DEFAULT '',
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `confirm_type` tinyint(3) NOT NULL DEFAULT 0,
+  `code` varchar(8) NOT NULL DEFAULT '',
+  `seed` int(10) unsigned NOT NULL DEFAULT 0,
+  `attempts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`session_id`,`confirm_id`),
+  KEY `confirm_type` (`confirm_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_disallow` (
+  `disallow_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `disallow_username` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`disallow_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_drafts` (
+  `draft_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `save_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `draft_subject` varchar(255) NOT NULL DEFAULT '',
+  `draft_message` mediumtext NOT NULL,
+  PRIMARY KEY (`draft_id`),
+  KEY `save_time` (`save_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_extension_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `cat_id` tinyint(2) NOT NULL DEFAULT 0,
+  `allow_group` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `download_mode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `upload_icon` varchar(255) NOT NULL DEFAULT '',
+  `max_filesize` int(20) unsigned NOT NULL DEFAULT 0,
+  `allowed_forums` text NOT NULL,
+  `allow_in_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_extensions` (
+  `extension_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `extension` varchar(100) NOT NULL DEFAULT '',
+  PRIMARY KEY (`extension_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums` (
+  `forum_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `left_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `right_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_parents` mediumtext NOT NULL,
+  `forum_name` varchar(255) NOT NULL DEFAULT '',
+  `forum_desc` text NOT NULL,
+  `forum_desc_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `forum_desc_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `forum_desc_uid` varchar(8) NOT NULL DEFAULT '',
+  `forum_link` varchar(255) NOT NULL DEFAULT '',
+  `forum_password` varchar(40) NOT NULL DEFAULT '',
+  `forum_style` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_image` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules` text NOT NULL,
+  `forum_rules_link` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `forum_rules_uid` varchar(8) NOT NULL DEFAULT '',
+  `forum_topics_per_page` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_type` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_status` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_posts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_real` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_last_post_subject` varchar(255) NOT NULL DEFAULT '',
+  `forum_last_post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `forum_last_poster_name` varchar(255) NOT NULL DEFAULT '',
+  `forum_last_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `forum_flags` tinyint(4) NOT NULL DEFAULT 32,
+  `forum_options` int(20) unsigned NOT NULL DEFAULT 0,
+  `display_subforum_list` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_indexing` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_icons` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_prune` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `prune_next` int(11) unsigned NOT NULL DEFAULT 0,
+  `prune_days` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `prune_viewed` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `prune_freq` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`forum_id`),
+  KEY `left_right_id` (`left_id`,`right_id`),
+  KEY `forum_lastpost_id` (`forum_last_post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_access` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `session_id` char(32) NOT NULL DEFAULT '',
+  PRIMARY KEY (`forum_id`,`user_id`,`session_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_track` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `mark_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_watch` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `notify_status` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  KEY `forum_id` (`forum_id`),
+  KEY `user_id` (`user_id`),
+  KEY `notify_stat` (`notify_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_type` tinyint(4) NOT NULL DEFAULT 1,
+  `group_founder_manage` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_skip_auth` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `group_desc` text NOT NULL,
+  `group_desc_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `group_desc_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `group_desc_uid` varchar(8) NOT NULL DEFAULT '',
+  `group_display` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_avatar` varchar(255) NOT NULL DEFAULT '',
+  `group_avatar_type` tinyint(2) NOT NULL DEFAULT 0,
+  `group_avatar_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `group_avatar_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `group_rank` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_colour` varchar(6) NOT NULL DEFAULT '',
+  `group_sig_chars` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_receive_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_message_limit` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_max_recipients` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_legend` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`group_id`),
+  KEY `group_legend_name` (`group_legend`,`group_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_icons` (
+  `icons_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `icons_url` varchar(255) NOT NULL DEFAULT '',
+  `icons_width` tinyint(4) NOT NULL DEFAULT 0,
+  `icons_height` tinyint(4) NOT NULL DEFAULT 0,
+  `icons_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`icons_id`),
+  KEY `display_on_posting` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_lang` (
+  `lang_id` tinyint(4) NOT NULL AUTO_INCREMENT,
+  `lang_iso` varchar(30) NOT NULL DEFAULT '',
+  `lang_dir` varchar(30) NOT NULL DEFAULT '',
+  `lang_english_name` varchar(100) NOT NULL DEFAULT '',
+  `lang_local_name` varchar(255) NOT NULL DEFAULT '',
+  `lang_author` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`lang_id`),
+  KEY `lang_iso` (`lang_iso`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_log` (
+  `log_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `log_type` tinyint(4) NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `reportee_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `log_ip` varchar(40) NOT NULL DEFAULT '',
+  `log_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `log_operation` text NOT NULL,
+  `log_data` mediumtext NOT NULL,
+  PRIMARY KEY (`log_id`),
+  KEY `log_type` (`log_type`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `reportee_id` (`reportee_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_login_attempts` (
+  `attempt_ip` varchar(40) NOT NULL DEFAULT '',
+  `attempt_browser` varchar(150) NOT NULL DEFAULT '',
+  `attempt_forwarded_for` varchar(255) NOT NULL DEFAULT '',
+  `attempt_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '0',
+  `username_clean` varchar(255) NOT NULL DEFAULT '0',
+  KEY `att_ip` (`attempt_ip`,`attempt_time`),
+  KEY `att_for` (`attempt_forwarded_for`,`attempt_time`),
+  KEY `att_time` (`attempt_time`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_moderator_cache` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '',
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  KEY `disp_idx` (`display_on_index`),
+  KEY `forum_id` (`forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_modules` (
+  `module_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `module_enabled` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `module_display` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `module_basename` varchar(255) NOT NULL DEFAULT '',
+  `module_class` varchar(10) NOT NULL DEFAULT '',
+  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `left_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `right_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `module_langname` varchar(255) NOT NULL DEFAULT '',
+  `module_mode` varchar(255) NOT NULL DEFAULT '',
+  `module_auth` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`module_id`),
+  KEY `left_right_id` (`left_id`,`right_id`),
+  KEY `module_enabled` (`module_enabled`),
+  KEY `class_left_id` (`module_class`,`left_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_poll_options` (
+  `poll_option_id` tinyint(4) NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poll_option_text` text NOT NULL,
+  `poll_option_total` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  KEY `poll_opt_id` (`poll_option_id`),
+  KEY `topic_id` (`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_poll_votes` (
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poll_option_id` tinyint(4) NOT NULL DEFAULT 0,
+  `vote_user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `vote_user_ip` varchar(40) NOT NULL DEFAULT '',
+  KEY `topic_id` (`topic_id`),
+  KEY `vote_user_id` (`vote_user_id`),
+  KEY `vote_user_ip` (`vote_user_ip`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_posts` (
+  `post_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poster_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poster_ip` varchar(40) NOT NULL DEFAULT '',
+  `post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_approved` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `post_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `post_username` varchar(255) NOT NULL DEFAULT '',
+  `post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `post_text` mediumtext NOT NULL,
+  `post_checksum` varchar(32) NOT NULL DEFAULT '',
+  `post_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `post_postcount` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `post_edit_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_edit_reason` varchar(255) NOT NULL DEFAULT '',
+  `post_edit_user` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `post_edit_count` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `post_edit_locked` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`post_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `poster_ip` (`poster_ip`),
+  KEY `poster_id` (`poster_id`),
+  KEY `post_approved` (`post_approved`),
+  KEY `post_username` (`post_username`),
+  KEY `tid_post_time` (`topic_id`,`post_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs` (
+  `msg_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `root_level` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_ip` varchar(40) NOT NULL DEFAULT '',
+  `message_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `message_subject` varchar(255) NOT NULL DEFAULT '',
+  `message_text` mediumtext NOT NULL,
+  `message_edit_reason` varchar(255) NOT NULL DEFAULT '',
+  `message_edit_user` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `message_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `message_edit_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `message_edit_count` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `to_address` text NOT NULL,
+  `bcc_address` text NOT NULL,
+  `message_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`msg_id`),
+  KEY `author_ip` (`author_ip`),
+  KEY `message_time` (`message_time`),
+  KEY `author_id` (`author_id`),
+  KEY `root_level` (`root_level`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_folder` (
+  `folder_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `folder_name` varchar(255) NOT NULL DEFAULT '',
+  `pm_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`folder_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_rules` (
+  `rule_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_check` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_connection` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_string` varchar(255) NOT NULL DEFAULT '',
+  `rule_user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_action` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_folder_id` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`rule_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_to` (
+  `msg_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `pm_deleted` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_new` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `pm_unread` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `pm_replied` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_marked` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_forwarded` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `folder_id` int(11) NOT NULL DEFAULT 0,
+  KEY `msg_id` (`msg_id`),
+  KEY `author_id` (`author_id`),
+  KEY `usr_flder_id` (`user_id`,`folder_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields` (
+  `field_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `field_name` varchar(255) NOT NULL DEFAULT '',
+  `field_type` tinyint(4) NOT NULL DEFAULT 0,
+  `field_ident` varchar(20) NOT NULL DEFAULT '',
+  `field_length` varchar(20) NOT NULL DEFAULT '',
+  `field_minlen` varchar(255) NOT NULL DEFAULT '',
+  `field_maxlen` varchar(255) NOT NULL DEFAULT '',
+  `field_novalue` varchar(255) NOT NULL DEFAULT '',
+  `field_default_value` varchar(255) NOT NULL DEFAULT '',
+  `field_validation` varchar(20) NOT NULL DEFAULT '',
+  `field_required` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_novalue` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_reg` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_vt` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_profile` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_hide` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_no_view` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_active` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`field_id`),
+  KEY `fld_type` (`field_type`),
+  KEY `fld_ordr` (`field_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields_data` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields_lang` (
+  `field_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `field_type` tinyint(4) NOT NULL DEFAULT 0,
+  `lang_value` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`,`lang_id`,`option_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_lang` (
+  `field_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_name` varchar(255) NOT NULL DEFAULT '',
+  `lang_explain` text NOT NULL,
+  `lang_default_value` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`,`lang_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_ranks` (
+  `rank_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `rank_title` varchar(255) NOT NULL DEFAULT '',
+  `rank_min` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rank_special` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `rank_image` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`rank_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_reports` (
+  `report_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `reason_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `pm_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `report_closed` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `report_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `report_text` mediumtext NOT NULL,
+  PRIMARY KEY (`report_id`),
+  KEY `post_id` (`post_id`),
+  KEY `pm_id` (`pm_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_reports_reasons` (
+  `reason_id` smallint(4) unsigned NOT NULL AUTO_INCREMENT,
+  `reason_title` varchar(255) NOT NULL DEFAULT '',
+  `reason_description` mediumtext NOT NULL,
+  `reason_order` smallint(4) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`reason_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_results` (
+  `search_key` varchar(32) NOT NULL DEFAULT '',
+  `search_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `search_keywords` mediumtext NOT NULL,
+  `search_authors` mediumtext NOT NULL,
+  PRIMARY KEY (`search_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_wordlist` (
+  `word_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `word_text` varchar(255) NOT NULL DEFAULT '',
+  `word_common` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `word_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`word_id`),
+  UNIQUE KEY `wrd_txt` (`word_text`),
+  KEY `wrd_cnt` (`word_count`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_wordmatch` (
+  `post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `word_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `title_match` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  UNIQUE KEY `unq_mtch` (`word_id`,`post_id`,`title_match`),
+  KEY `word_id` (`word_id`),
+  KEY `post_id` (`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sessions` (
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `session_user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `session_forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `session_last_visit` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_ip` varchar(40) NOT NULL DEFAULT '',
+  `session_browser` varchar(150) NOT NULL DEFAULT '',
+  `session_forwarded_for` varchar(255) NOT NULL DEFAULT '',
+  `session_page` varchar(255) NOT NULL DEFAULT '',
+  `session_viewonline` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `session_autologin` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `session_admin` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`session_id`),
+  KEY `session_time` (`session_time`),
+  KEY `session_user_id` (`session_user_id`),
+  KEY `session_fid` (`session_forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sessions_keys` (
+  `key_id` char(32) NOT NULL DEFAULT '',
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `last_ip` varchar(40) NOT NULL DEFAULT '',
+  `last_login` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`key_id`,`user_id`),
+  KEY `last_login` (`last_login`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sitelist` (
+  `site_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `site_ip` varchar(40) NOT NULL DEFAULT '',
+  `site_hostname` varchar(255) NOT NULL DEFAULT '',
+  `ip_exclude` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`site_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_smilies` (
+  `smiley_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(50) NOT NULL DEFAULT '',
+  `emotion` varchar(50) NOT NULL DEFAULT '',
+  `smiley_url` varchar(50) NOT NULL DEFAULT '',
+  `smiley_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `smiley_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `smiley_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`smiley_id`),
+  KEY `display_on_post` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_styles` (
+  `style_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `style_name` varchar(255) NOT NULL DEFAULT '',
+  `style_copyright` varchar(255) NOT NULL DEFAULT '',
+  `style_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `template_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `theme_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `imageset_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`style_id`),
+  UNIQUE KEY `style_name` (`style_name`),
+  KEY `template_id` (`template_id`),
+  KEY `theme_id` (`theme_id`),
+  KEY `imageset_id` (`imageset_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_styles_imageset` (
+  `imageset_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `imageset_name` varchar(255) NOT NULL DEFAULT '',
+  `imageset_copyright` varchar(255) NOT NULL DEFAULT '',
+  `imageset_path` varchar(100) NOT NULL DEFAULT '',
+  PRIMARY KEY (`imageset_id`),
+  UNIQUE KEY `imgset_nm` (`imageset_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_styles_imageset_data` (
+  `image_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `image_name` varchar(200) NOT NULL DEFAULT '',
+  `image_filename` varchar(200) NOT NULL DEFAULT '',
+  `image_lang` varchar(30) NOT NULL DEFAULT '',
+  `image_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `image_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `imageset_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`image_id`),
+  KEY `i_d` (`imageset_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_styles_template` (
+  `template_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `template_name` varchar(255) NOT NULL DEFAULT '',
+  `template_copyright` varchar(255) NOT NULL DEFAULT '',
+  `template_path` varchar(100) NOT NULL DEFAULT '',
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT 'kNg=',
+  `template_storedb` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `template_inherits_id` int(4) unsigned NOT NULL DEFAULT 0,
+  `template_inherit_path` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`template_id`),
+  UNIQUE KEY `tmplte_nm` (`template_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_styles_template_data` (
+  `template_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `template_filename` varchar(100) NOT NULL DEFAULT '',
+  `template_included` text NOT NULL,
+  `template_mtime` int(11) unsigned NOT NULL DEFAULT 0,
+  `template_data` mediumtext NOT NULL,
+  KEY `tid` (`template_id`),
+  KEY `tfn` (`template_filename`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_styles_theme` (
+  `theme_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `theme_name` varchar(255) NOT NULL DEFAULT '',
+  `theme_copyright` varchar(255) NOT NULL DEFAULT '',
+  `theme_path` varchar(100) NOT NULL DEFAULT '',
+  `theme_storedb` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `theme_mtime` int(11) unsigned NOT NULL DEFAULT 0,
+  `theme_data` mediumtext NOT NULL,
+  PRIMARY KEY (`theme_id`),
+  UNIQUE KEY `theme_name` (`theme_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics` (
+  `topic_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_approved` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `topic_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_title` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `topic_poster` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_time_limit` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_views` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_replies` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_replies_real` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_status` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_type` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_first_post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_first_poster_name` varchar(255) NOT NULL DEFAULT '',
+  `topic_first_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `topic_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_last_poster_name` varchar(255) NOT NULL DEFAULT '',
+  `topic_last_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `topic_last_post_subject` varchar(255) NOT NULL DEFAULT '',
+  `topic_last_post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_last_view_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_moved_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_bumped` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_bumper` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poll_title` varchar(255) NOT NULL DEFAULT '',
+  `poll_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_length` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_max_options` tinyint(4) NOT NULL DEFAULT 1,
+  `poll_last_vote` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_vote_change` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`topic_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `forum_id_type` (`forum_id`,`topic_type`),
+  KEY `last_post_time` (`topic_last_post_time`),
+  KEY `topic_approved` (`topic_approved`),
+  KEY `forum_appr_last` (`forum_id`,`topic_approved`,`topic_last_post_id`),
+  KEY `fid_time_moved` (`forum_id`,`topic_last_post_time`,`topic_moved_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_posted` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_posted` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_track` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `mark_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`topic_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `forum_id` (`forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_watch` (
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `notify_status` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  KEY `topic_id` (`topic_id`),
+  KEY `user_id` (`user_id`),
+  KEY `notify_stat` (`notify_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_user_group` (
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_leader` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_pending` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  KEY `group_id` (`group_id`),
+  KEY `user_id` (`user_id`),
+  KEY `group_leader` (`group_leader`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_users` (
+  `user_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_type` tinyint(2) NOT NULL DEFAULT 0,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 3,
+  `user_permissions` mediumtext NOT NULL,
+  `user_perm_from` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_ip` varchar(40) NOT NULL DEFAULT '',
+  `user_regdate` int(11) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '',
+  `username_clean` varchar(255) NOT NULL DEFAULT '',
+  `user_password` varchar(40) NOT NULL DEFAULT '',
+  `user_passchg` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_pass_convert` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_email` varchar(100) NOT NULL DEFAULT '',
+  `user_email_hash` bigint(20) NOT NULL DEFAULT 0,
+  `user_birthday` varchar(10) NOT NULL DEFAULT '',
+  `user_lastvisit` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastmark` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastpost_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastpage` varchar(200) NOT NULL DEFAULT '',
+  `user_last_confirm_key` varchar(10) NOT NULL DEFAULT '',
+  `user_last_search` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_warnings` tinyint(4) NOT NULL DEFAULT 0,
+  `user_last_warning` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_login_attempts` tinyint(4) NOT NULL DEFAULT 0,
+  `user_inactive_reason` tinyint(2) NOT NULL DEFAULT 0,
+  `user_inactive_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_posts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_lang` varchar(30) NOT NULL DEFAULT '',
+  `user_timezone` decimal(5,2) NOT NULL DEFAULT 0.00,
+  `user_dst` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_dateformat` varchar(30) NOT NULL DEFAULT 'd M Y H:i',
+  `user_style` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_rank` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_colour` varchar(6) NOT NULL DEFAULT '',
+  `user_new_privmsg` int(4) NOT NULL DEFAULT 0,
+  `user_unread_privmsg` int(4) NOT NULL DEFAULT 0,
+  `user_last_privmsg` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_message_rules` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_full_folder` int(11) NOT NULL DEFAULT -3,
+  `user_emailtime` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_topic_show_days` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_topic_sortby_type` varchar(1) NOT NULL DEFAULT 't',
+  `user_topic_sortby_dir` varchar(1) NOT NULL DEFAULT 'd',
+  `user_post_show_days` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_post_sortby_type` varchar(1) NOT NULL DEFAULT 't',
+  `user_post_sortby_dir` varchar(1) NOT NULL DEFAULT 'a',
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_notify_pm` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_notify_type` tinyint(4) NOT NULL DEFAULT 0,
+  `user_allow_pm` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_viewonline` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_viewemail` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_massemail` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_options` int(11) unsigned NOT NULL DEFAULT 230271,
+  `user_avatar` varchar(255) NOT NULL DEFAULT '',
+  `user_avatar_type` tinyint(2) NOT NULL DEFAULT 0,
+  `user_avatar_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_avatar_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_sig` mediumtext NOT NULL,
+  `user_sig_bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `user_sig_bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `user_from` varchar(100) NOT NULL DEFAULT '',
+  `user_icq` varchar(15) NOT NULL DEFAULT '',
+  `user_aim` varchar(255) NOT NULL DEFAULT '',
+  `user_yim` varchar(255) NOT NULL DEFAULT '',
+  `user_msnm` varchar(255) NOT NULL DEFAULT '',
+  `user_jabber` varchar(255) NOT NULL DEFAULT '',
+  `user_website` varchar(200) NOT NULL DEFAULT '',
+  `user_occ` text NOT NULL,
+  `user_interests` text NOT NULL,
+  `user_actkey` varchar(32) NOT NULL DEFAULT '',
+  `user_newpasswd` varchar(40) NOT NULL DEFAULT '',
+  `user_form_salt` varchar(32) NOT NULL DEFAULT '',
+  `user_new` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_reminded` tinyint(4) NOT NULL DEFAULT 0,
+  `user_reminded_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`),
+  UNIQUE KEY `username_clean` (`username_clean`),
+  KEY `user_birthday` (`user_birthday`),
+  KEY `user_email_hash` (`user_email_hash`),
+  KEY `user_type` (`user_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_warnings` (
+  `warning_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `log_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `warning_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`warning_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_words` (
+  `word_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `word` varchar(255) NOT NULL DEFAULT '',
+  `replacement` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`word_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_zebra` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `zebra_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `friend` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `foe` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`zebra_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;

--- a/migrations/converters/spec/fixtures/phpbb/schemas/3.0/postgres.sql
+++ b/migrations/converters/spec/fixtures/phpbb/schemas/3.0/postgres.sql
@@ -1,0 +1,3123 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict rpMjxEK4taQXqqlA5qoz75dgnjI6qbpNRFTqUwPb5fmmqmZRGD4NcAx8r6swPEq
+
+-- Dumped from database version 16.14 (Debian 16.14-1.pgdg13+1)
+-- Dumped by pg_dump version 16.14 (Debian 16.14-1.pgdg13+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: varchar_ci; Type: DOMAIN; Schema: public; Owner: -
+--
+
+CREATE DOMAIN public.varchar_ci AS character varying(255) NOT NULL DEFAULT ''::character varying;
+
+
+--
+-- Name: _varchar_ci_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) = LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_greater_equals(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_greater_equals(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) >= LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_greater_than(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_greater_than(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) > LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_less_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_less_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) <= LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_less_than(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_less_than(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) < LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_not_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_not_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) != LOWER($2)$_$;
+
+
+--
+-- Name: <; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.< (
+    FUNCTION = public._varchar_ci_less_than,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.>),
+    NEGATOR = OPERATOR(public.>=),
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+--
+-- Name: <=; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.<= (
+    FUNCTION = public._varchar_ci_less_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.>=),
+    NEGATOR = OPERATOR(public.>),
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+--
+-- Name: <>; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.<> (
+    FUNCTION = public._varchar_ci_not_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<>),
+    NEGATOR = OPERATOR(public.=),
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+
+
+--
+-- Name: =; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.= (
+    FUNCTION = public._varchar_ci_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.=),
+    NEGATOR = OPERATOR(public.<>),
+    MERGES,
+    HASHES,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel
+);
+
+
+--
+-- Name: >; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.> (
+    FUNCTION = public._varchar_ci_greater_than,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<),
+    NEGATOR = OPERATOR(public.<=),
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+--
+-- Name: >=; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.>= (
+    FUNCTION = public._varchar_ci_greater_equals,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<=),
+    NEGATOR = OPERATOR(public.<),
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: phpbb_acl_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_groups (
+    group_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_role_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_groups_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_auth_role_id_check CHECK ((auth_role_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_group_id_check CHECK ((group_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_options_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_acl_options_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_acl_options; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_options (
+    auth_option_id integer DEFAULT nextval('public.phpbb_acl_options_seq'::regclass) NOT NULL,
+    auth_option character varying(50) DEFAULT ''::character varying NOT NULL,
+    is_global smallint DEFAULT '0'::smallint NOT NULL,
+    is_local smallint DEFAULT '0'::smallint NOT NULL,
+    founder_only smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_options_founder_only_check CHECK ((founder_only >= 0)),
+    CONSTRAINT phpbb_acl_options_is_global_check CHECK ((is_global >= 0)),
+    CONSTRAINT phpbb_acl_options_is_local_check CHECK ((is_local >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_roles_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_acl_roles_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_acl_roles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_roles (
+    role_id integer DEFAULT nextval('public.phpbb_acl_roles_seq'::regclass) NOT NULL,
+    role_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    role_description character varying(4000) DEFAULT ''::character varying NOT NULL,
+    role_type character varying(10) DEFAULT ''::character varying NOT NULL,
+    role_order smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_roles_role_order_check CHECK ((role_order >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_roles_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_roles_data (
+    role_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_roles_data_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_roles_data_role_id_check CHECK ((role_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_users (
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_role_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_users_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_users_auth_role_id_check CHECK ((auth_role_id >= 0)),
+    CONSTRAINT phpbb_acl_users_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_acl_users_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_attachments_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_attachments_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_attachments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_attachments (
+    attach_id integer DEFAULT nextval('public.phpbb_attachments_seq'::regclass) NOT NULL,
+    post_msg_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    in_message smallint DEFAULT '0'::smallint NOT NULL,
+    poster_id integer DEFAULT 0 NOT NULL,
+    is_orphan smallint DEFAULT '1'::smallint NOT NULL,
+    physical_filename character varying(255) DEFAULT ''::character varying NOT NULL,
+    real_filename character varying(255) DEFAULT ''::character varying NOT NULL,
+    download_count integer DEFAULT 0 NOT NULL,
+    attach_comment character varying(4000) DEFAULT ''::character varying NOT NULL,
+    extension character varying(100) DEFAULT ''::character varying NOT NULL,
+    mimetype character varying(100) DEFAULT ''::character varying NOT NULL,
+    filesize integer DEFAULT 0 NOT NULL,
+    filetime integer DEFAULT 0 NOT NULL,
+    thumbnail smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_attachments_download_count_check CHECK ((download_count >= 0)),
+    CONSTRAINT phpbb_attachments_filesize_check CHECK ((filesize >= 0)),
+    CONSTRAINT phpbb_attachments_filetime_check CHECK ((filetime >= 0)),
+    CONSTRAINT phpbb_attachments_in_message_check CHECK ((in_message >= 0)),
+    CONSTRAINT phpbb_attachments_is_orphan_check CHECK ((is_orphan >= 0)),
+    CONSTRAINT phpbb_attachments_post_msg_id_check CHECK ((post_msg_id >= 0)),
+    CONSTRAINT phpbb_attachments_poster_id_check CHECK ((poster_id >= 0)),
+    CONSTRAINT phpbb_attachments_thumbnail_check CHECK ((thumbnail >= 0)),
+    CONSTRAINT phpbb_attachments_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_banlist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_banlist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_banlist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_banlist (
+    ban_id integer DEFAULT nextval('public.phpbb_banlist_seq'::regclass) NOT NULL,
+    ban_userid integer DEFAULT 0 NOT NULL,
+    ban_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    ban_email character varying(100) DEFAULT ''::character varying NOT NULL,
+    ban_start integer DEFAULT 0 NOT NULL,
+    ban_end integer DEFAULT 0 NOT NULL,
+    ban_exclude smallint DEFAULT '0'::smallint NOT NULL,
+    ban_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    ban_give_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_banlist_ban_end_check CHECK ((ban_end >= 0)),
+    CONSTRAINT phpbb_banlist_ban_exclude_check CHECK ((ban_exclude >= 0)),
+    CONSTRAINT phpbb_banlist_ban_start_check CHECK ((ban_start >= 0)),
+    CONSTRAINT phpbb_banlist_ban_userid_check CHECK ((ban_userid >= 0))
+);
+
+
+--
+-- Name: phpbb_bbcodes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bbcodes (
+    bbcode_id smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_tag character varying(16) DEFAULT ''::character varying NOT NULL,
+    bbcode_helpline character varying(255) DEFAULT ''::character varying NOT NULL,
+    display_on_posting smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_match character varying(4000) DEFAULT ''::character varying NOT NULL,
+    bbcode_tpl text DEFAULT ''::text NOT NULL,
+    first_pass_match text DEFAULT ''::text NOT NULL,
+    first_pass_replace text DEFAULT ''::text NOT NULL,
+    second_pass_match text DEFAULT ''::text NOT NULL,
+    second_pass_replace text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_bbcodes_bbcode_id_check CHECK ((bbcode_id >= 0)),
+    CONSTRAINT phpbb_bbcodes_display_on_posting_check CHECK ((display_on_posting >= 0))
+);
+
+
+--
+-- Name: phpbb_bookmarks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bookmarks (
+    topic_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_bookmarks_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_bookmarks_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_bots_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_bots_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_bots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bots (
+    bot_id integer DEFAULT nextval('public.phpbb_bots_seq'::regclass) NOT NULL,
+    bot_active smallint DEFAULT '1'::smallint NOT NULL,
+    bot_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    bot_agent character varying(255) DEFAULT ''::character varying NOT NULL,
+    bot_ip character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_bots_bot_active_check CHECK ((bot_active >= 0)),
+    CONSTRAINT phpbb_bots_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_config; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_config (
+    config_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    config_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    is_dynamic smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_config_is_dynamic_check CHECK ((is_dynamic >= 0))
+);
+
+
+--
+-- Name: phpbb_confirm; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_confirm (
+    confirm_id character(32) DEFAULT ''::bpchar NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    confirm_type smallint DEFAULT '0'::smallint NOT NULL,
+    code character varying(8) DEFAULT ''::character varying NOT NULL,
+    seed integer DEFAULT 0 NOT NULL,
+    attempts integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_confirm_attempts_check CHECK ((attempts >= 0)),
+    CONSTRAINT phpbb_confirm_seed_check CHECK ((seed >= 0))
+);
+
+
+--
+-- Name: phpbb_disallow_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_disallow_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_disallow; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_disallow (
+    disallow_id integer DEFAULT nextval('public.phpbb_disallow_seq'::regclass) NOT NULL,
+    disallow_username character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+--
+-- Name: phpbb_drafts_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_drafts_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_drafts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_drafts (
+    draft_id integer DEFAULT nextval('public.phpbb_drafts_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    save_time integer DEFAULT 0 NOT NULL,
+    draft_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    draft_message text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_drafts_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_drafts_save_time_check CHECK ((save_time >= 0)),
+    CONSTRAINT phpbb_drafts_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_drafts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_extension_groups_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_extension_groups_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_extension_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_extension_groups (
+    group_id integer DEFAULT nextval('public.phpbb_extension_groups_seq'::regclass) NOT NULL,
+    group_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    cat_id smallint DEFAULT '0'::smallint NOT NULL,
+    allow_group smallint DEFAULT '0'::smallint NOT NULL,
+    download_mode smallint DEFAULT '1'::smallint NOT NULL,
+    upload_icon character varying(255) DEFAULT ''::character varying NOT NULL,
+    max_filesize integer DEFAULT 0 NOT NULL,
+    allowed_forums character varying(8000) DEFAULT ''::character varying NOT NULL,
+    allow_in_pm smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_extension_groups_allow_group_check CHECK ((allow_group >= 0)),
+    CONSTRAINT phpbb_extension_groups_allow_in_pm_check CHECK ((allow_in_pm >= 0)),
+    CONSTRAINT phpbb_extension_groups_download_mode_check CHECK ((download_mode >= 0)),
+    CONSTRAINT phpbb_extension_groups_max_filesize_check CHECK ((max_filesize >= 0))
+);
+
+
+--
+-- Name: phpbb_extensions_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_extensions_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_extensions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_extensions (
+    extension_id integer DEFAULT nextval('public.phpbb_extensions_seq'::regclass) NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    extension character varying(100) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_extensions_group_id_check CHECK ((group_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_forums_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_forums; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums (
+    forum_id integer DEFAULT nextval('public.phpbb_forums_seq'::regclass) NOT NULL,
+    parent_id integer DEFAULT 0 NOT NULL,
+    left_id integer DEFAULT 0 NOT NULL,
+    right_id integer DEFAULT 0 NOT NULL,
+    forum_parents text DEFAULT ''::text NOT NULL,
+    forum_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_desc character varying(4000) DEFAULT ''::character varying NOT NULL,
+    forum_desc_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_desc_options integer DEFAULT 7 NOT NULL,
+    forum_desc_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    forum_link character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_password character varying(40) DEFAULT ''::character varying NOT NULL,
+    forum_style integer DEFAULT 0 NOT NULL,
+    forum_image character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules character varying(4000) DEFAULT ''::character varying NOT NULL,
+    forum_rules_link character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules_options integer DEFAULT 7 NOT NULL,
+    forum_rules_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    forum_topics_per_page smallint DEFAULT '0'::smallint NOT NULL,
+    forum_type smallint DEFAULT '0'::smallint NOT NULL,
+    forum_status smallint DEFAULT '0'::smallint NOT NULL,
+    forum_posts integer DEFAULT 0 NOT NULL,
+    forum_topics integer DEFAULT 0 NOT NULL,
+    forum_topics_real integer DEFAULT 0 NOT NULL,
+    forum_last_post_id integer DEFAULT 0 NOT NULL,
+    forum_last_poster_id integer DEFAULT 0 NOT NULL,
+    forum_last_post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_last_post_time integer DEFAULT 0 NOT NULL,
+    forum_last_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_last_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    forum_flags smallint DEFAULT '32'::smallint NOT NULL,
+    forum_options integer DEFAULT 0 NOT NULL,
+    display_subforum_list smallint DEFAULT '1'::smallint NOT NULL,
+    display_on_index smallint DEFAULT '1'::smallint NOT NULL,
+    enable_indexing smallint DEFAULT '1'::smallint NOT NULL,
+    enable_icons smallint DEFAULT '1'::smallint NOT NULL,
+    enable_prune smallint DEFAULT '0'::smallint NOT NULL,
+    prune_next integer DEFAULT 0 NOT NULL,
+    prune_days integer DEFAULT 0 NOT NULL,
+    prune_viewed integer DEFAULT 0 NOT NULL,
+    prune_freq integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_forums_display_on_index_check CHECK ((display_on_index >= 0)),
+    CONSTRAINT phpbb_forums_display_subforum_list_check CHECK ((display_subforum_list >= 0)),
+    CONSTRAINT phpbb_forums_enable_icons_check CHECK ((enable_icons >= 0)),
+    CONSTRAINT phpbb_forums_enable_indexing_check CHECK ((enable_indexing >= 0)),
+    CONSTRAINT phpbb_forums_enable_prune_check CHECK ((enable_prune >= 0)),
+    CONSTRAINT phpbb_forums_forum_desc_options_check CHECK ((forum_desc_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_post_id_check CHECK ((forum_last_post_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_post_time_check CHECK ((forum_last_post_time >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_poster_id_check CHECK ((forum_last_poster_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_options_check CHECK ((forum_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_check CHECK ((forum_posts >= 0)),
+    CONSTRAINT phpbb_forums_forum_rules_options_check CHECK ((forum_rules_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_style_check CHECK ((forum_style >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_check CHECK ((forum_topics >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_real_check CHECK ((forum_topics_real >= 0)),
+    CONSTRAINT phpbb_forums_left_id_check CHECK ((left_id >= 0)),
+    CONSTRAINT phpbb_forums_parent_id_check CHECK ((parent_id >= 0)),
+    CONSTRAINT phpbb_forums_prune_days_check CHECK ((prune_days >= 0)),
+    CONSTRAINT phpbb_forums_prune_freq_check CHECK ((prune_freq >= 0)),
+    CONSTRAINT phpbb_forums_prune_next_check CHECK ((prune_next >= 0)),
+    CONSTRAINT phpbb_forums_prune_viewed_check CHECK ((prune_viewed >= 0)),
+    CONSTRAINT phpbb_forums_right_id_check CHECK ((right_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_access; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_access (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    CONSTRAINT phpbb_forums_access_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_access_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_track; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_track (
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    mark_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_forums_track_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_track_mark_time_check CHECK ((mark_time >= 0)),
+    CONSTRAINT phpbb_forums_track_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_watch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_watch (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notify_status smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_forums_watch_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_watch_notify_status_check CHECK ((notify_status >= 0)),
+    CONSTRAINT phpbb_forums_watch_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_groups_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_groups_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_groups (
+    group_id integer DEFAULT nextval('public.phpbb_groups_seq'::regclass) NOT NULL,
+    group_type smallint DEFAULT '1'::smallint NOT NULL,
+    group_founder_manage smallint DEFAULT '0'::smallint NOT NULL,
+    group_skip_auth smallint DEFAULT '0'::smallint NOT NULL,
+    group_name public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    group_desc character varying(4000) DEFAULT ''::character varying NOT NULL,
+    group_desc_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_desc_options integer DEFAULT 7 NOT NULL,
+    group_desc_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    group_display smallint DEFAULT '0'::smallint NOT NULL,
+    group_avatar character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_avatar_type smallint DEFAULT '0'::smallint NOT NULL,
+    group_avatar_width smallint DEFAULT '0'::smallint NOT NULL,
+    group_avatar_height smallint DEFAULT '0'::smallint NOT NULL,
+    group_rank integer DEFAULT 0 NOT NULL,
+    group_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    group_sig_chars integer DEFAULT 0 NOT NULL,
+    group_receive_pm smallint DEFAULT '0'::smallint NOT NULL,
+    group_message_limit integer DEFAULT 0 NOT NULL,
+    group_max_recipients integer DEFAULT 0 NOT NULL,
+    group_legend smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_groups_group_avatar_height_check CHECK ((group_avatar_height >= 0)),
+    CONSTRAINT phpbb_groups_group_avatar_width_check CHECK ((group_avatar_width >= 0)),
+    CONSTRAINT phpbb_groups_group_desc_options_check CHECK ((group_desc_options >= 0)),
+    CONSTRAINT phpbb_groups_group_display_check CHECK ((group_display >= 0)),
+    CONSTRAINT phpbb_groups_group_founder_manage_check CHECK ((group_founder_manage >= 0)),
+    CONSTRAINT phpbb_groups_group_legend_check CHECK ((group_legend >= 0)),
+    CONSTRAINT phpbb_groups_group_max_recipients_check CHECK ((group_max_recipients >= 0)),
+    CONSTRAINT phpbb_groups_group_message_limit_check CHECK ((group_message_limit >= 0)),
+    CONSTRAINT phpbb_groups_group_rank_check CHECK ((group_rank >= 0)),
+    CONSTRAINT phpbb_groups_group_receive_pm_check CHECK ((group_receive_pm >= 0)),
+    CONSTRAINT phpbb_groups_group_sig_chars_check CHECK ((group_sig_chars >= 0)),
+    CONSTRAINT phpbb_groups_group_skip_auth_check CHECK ((group_skip_auth >= 0))
+);
+
+
+--
+-- Name: phpbb_icons_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_icons_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_icons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_icons (
+    icons_id integer DEFAULT nextval('public.phpbb_icons_seq'::regclass) NOT NULL,
+    icons_url character varying(255) DEFAULT ''::character varying NOT NULL,
+    icons_width smallint DEFAULT '0'::smallint NOT NULL,
+    icons_height smallint DEFAULT '0'::smallint NOT NULL,
+    icons_order integer DEFAULT 0 NOT NULL,
+    display_on_posting smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_icons_display_on_posting_check CHECK ((display_on_posting >= 0)),
+    CONSTRAINT phpbb_icons_icons_order_check CHECK ((icons_order >= 0))
+);
+
+
+--
+-- Name: phpbb_lang_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_lang_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_lang (
+    lang_id smallint DEFAULT nextval('public.phpbb_lang_seq'::regclass) NOT NULL,
+    lang_iso character varying(30) DEFAULT ''::character varying NOT NULL,
+    lang_dir character varying(30) DEFAULT ''::character varying NOT NULL,
+    lang_english_name character varying(100) DEFAULT ''::character varying NOT NULL,
+    lang_local_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    lang_author character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+--
+-- Name: phpbb_log_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_log_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_log (
+    log_id integer DEFAULT nextval('public.phpbb_log_seq'::regclass) NOT NULL,
+    log_type smallint DEFAULT '0'::smallint NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    reportee_id integer DEFAULT 0 NOT NULL,
+    log_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    log_time integer DEFAULT 0 NOT NULL,
+    log_operation character varying(4000) DEFAULT ''::character varying NOT NULL,
+    log_data text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_log_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_log_log_time_check CHECK ((log_time >= 0)),
+    CONSTRAINT phpbb_log_reportee_id_check CHECK ((reportee_id >= 0)),
+    CONSTRAINT phpbb_log_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_log_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_login_attempts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_login_attempts (
+    attempt_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    attempt_browser character varying(150) DEFAULT ''::character varying NOT NULL,
+    attempt_forwarded_for character varying(255) DEFAULT ''::character varying NOT NULL,
+    attempt_time integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    username character varying(255) DEFAULT '0'::character varying NOT NULL,
+    username_clean public.varchar_ci DEFAULT '0'::character varying NOT NULL,
+    CONSTRAINT phpbb_login_attempts_attempt_time_check CHECK ((attempt_time >= 0)),
+    CONSTRAINT phpbb_login_attempts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_moderator_cache; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_moderator_cache (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    username character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    group_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    display_on_index smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_moderator_cache_display_on_index_check CHECK ((display_on_index >= 0)),
+    CONSTRAINT phpbb_moderator_cache_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_moderator_cache_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_moderator_cache_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_modules_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_modules_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_modules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_modules (
+    module_id integer DEFAULT nextval('public.phpbb_modules_seq'::regclass) NOT NULL,
+    module_enabled smallint DEFAULT '1'::smallint NOT NULL,
+    module_display smallint DEFAULT '1'::smallint NOT NULL,
+    module_basename character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_class character varying(10) DEFAULT ''::character varying NOT NULL,
+    parent_id integer DEFAULT 0 NOT NULL,
+    left_id integer DEFAULT 0 NOT NULL,
+    right_id integer DEFAULT 0 NOT NULL,
+    module_langname character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_mode character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_auth character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_modules_left_id_check CHECK ((left_id >= 0)),
+    CONSTRAINT phpbb_modules_module_display_check CHECK ((module_display >= 0)),
+    CONSTRAINT phpbb_modules_module_enabled_check CHECK ((module_enabled >= 0)),
+    CONSTRAINT phpbb_modules_parent_id_check CHECK ((parent_id >= 0)),
+    CONSTRAINT phpbb_modules_right_id_check CHECK ((right_id >= 0))
+);
+
+
+--
+-- Name: phpbb_poll_options; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_poll_options (
+    poll_option_id smallint DEFAULT '0'::smallint NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    poll_option_text character varying(4000) DEFAULT ''::character varying NOT NULL,
+    poll_option_total integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_poll_options_poll_option_total_check CHECK ((poll_option_total >= 0)),
+    CONSTRAINT phpbb_poll_options_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_poll_votes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_poll_votes (
+    topic_id integer DEFAULT 0 NOT NULL,
+    poll_option_id smallint DEFAULT '0'::smallint NOT NULL,
+    vote_user_id integer DEFAULT 0 NOT NULL,
+    vote_user_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_poll_votes_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_poll_votes_vote_user_id_check CHECK ((vote_user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_posts_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_posts_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_posts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_posts (
+    post_id integer DEFAULT nextval('public.phpbb_posts_seq'::regclass) NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    poster_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    poster_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    post_time integer DEFAULT 0 NOT NULL,
+    post_approved smallint DEFAULT '1'::smallint NOT NULL,
+    post_reported smallint DEFAULT '0'::smallint NOT NULL,
+    enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    enable_sig smallint DEFAULT '1'::smallint NOT NULL,
+    post_username character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_text text DEFAULT ''::text NOT NULL,
+    post_checksum character varying(32) DEFAULT ''::character varying NOT NULL,
+    post_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    post_postcount smallint DEFAULT '1'::smallint NOT NULL,
+    post_edit_time integer DEFAULT 0 NOT NULL,
+    post_edit_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_edit_user integer DEFAULT 0 NOT NULL,
+    post_edit_count smallint DEFAULT '0'::smallint NOT NULL,
+    post_edit_locked smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_posts_enable_bbcode_check CHECK ((enable_bbcode >= 0)),
+    CONSTRAINT phpbb_posts_enable_magic_url_check CHECK ((enable_magic_url >= 0)),
+    CONSTRAINT phpbb_posts_enable_sig_check CHECK ((enable_sig >= 0)),
+    CONSTRAINT phpbb_posts_enable_smilies_check CHECK ((enable_smilies >= 0)),
+    CONSTRAINT phpbb_posts_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_posts_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_posts_post_approved_check CHECK ((post_approved >= 0)),
+    CONSTRAINT phpbb_posts_post_attachment_check CHECK ((post_attachment >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_count_check CHECK ((post_edit_count >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_locked_check CHECK ((post_edit_locked >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_time_check CHECK ((post_edit_time >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_user_check CHECK ((post_edit_user >= 0)),
+    CONSTRAINT phpbb_posts_post_postcount_check CHECK ((post_postcount >= 0)),
+    CONSTRAINT phpbb_posts_post_reported_check CHECK ((post_reported >= 0)),
+    CONSTRAINT phpbb_posts_post_time_check CHECK ((post_time >= 0)),
+    CONSTRAINT phpbb_posts_poster_id_check CHECK ((poster_id >= 0)),
+    CONSTRAINT phpbb_posts_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs (
+    msg_id integer DEFAULT nextval('public.phpbb_privmsgs_seq'::regclass) NOT NULL,
+    root_level integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    author_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    message_time integer DEFAULT 0 NOT NULL,
+    enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    enable_sig smallint DEFAULT '1'::smallint NOT NULL,
+    message_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    message_text text DEFAULT ''::text NOT NULL,
+    message_edit_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    message_edit_user integer DEFAULT 0 NOT NULL,
+    message_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    message_edit_time integer DEFAULT 0 NOT NULL,
+    message_edit_count smallint DEFAULT '0'::smallint NOT NULL,
+    to_address character varying(4000) DEFAULT ''::character varying NOT NULL,
+    bcc_address character varying(4000) DEFAULT ''::character varying NOT NULL,
+    message_reported smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_privmsgs_author_id_check CHECK ((author_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_bbcode_check CHECK ((enable_bbcode >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_magic_url_check CHECK ((enable_magic_url >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_sig_check CHECK ((enable_sig >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_smilies_check CHECK ((enable_smilies >= 0)),
+    CONSTRAINT phpbb_privmsgs_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_attachment_check CHECK ((message_attachment >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_count_check CHECK ((message_edit_count >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_time_check CHECK ((message_edit_time >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_user_check CHECK ((message_edit_user >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_reported_check CHECK ((message_reported >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_time_check CHECK ((message_time >= 0)),
+    CONSTRAINT phpbb_privmsgs_root_level_check CHECK ((root_level >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_folder_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_folder_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs_folder; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_folder (
+    folder_id integer DEFAULT nextval('public.phpbb_privmsgs_folder_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    folder_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    pm_count integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_folder_pm_count_check CHECK ((pm_count >= 0)),
+    CONSTRAINT phpbb_privmsgs_folder_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_rules_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_rules_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs_rules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_rules (
+    rule_id integer DEFAULT nextval('public.phpbb_privmsgs_rules_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    rule_check integer DEFAULT 0 NOT NULL,
+    rule_connection integer DEFAULT 0 NOT NULL,
+    rule_string character varying(255) DEFAULT ''::character varying NOT NULL,
+    rule_user_id integer DEFAULT 0 NOT NULL,
+    rule_group_id integer DEFAULT 0 NOT NULL,
+    rule_action integer DEFAULT 0 NOT NULL,
+    rule_folder_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_rules_rule_action_check CHECK ((rule_action >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_check_check CHECK ((rule_check >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_connection_check CHECK ((rule_connection >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_group_id_check CHECK ((rule_group_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_user_id_check CHECK ((rule_user_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_to; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_to (
+    msg_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    pm_deleted smallint DEFAULT '0'::smallint NOT NULL,
+    pm_new smallint DEFAULT '1'::smallint NOT NULL,
+    pm_unread smallint DEFAULT '1'::smallint NOT NULL,
+    pm_replied smallint DEFAULT '0'::smallint NOT NULL,
+    pm_marked smallint DEFAULT '0'::smallint NOT NULL,
+    pm_forwarded smallint DEFAULT '0'::smallint NOT NULL,
+    folder_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_to_author_id_check CHECK ((author_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_msg_id_check CHECK ((msg_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_deleted_check CHECK ((pm_deleted >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_forwarded_check CHECK ((pm_forwarded >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_marked_check CHECK ((pm_marked >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_new_check CHECK ((pm_new >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_replied_check CHECK ((pm_replied >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_unread_check CHECK ((pm_unread >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_profile_fields_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_profile_fields; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields (
+    field_id integer DEFAULT nextval('public.phpbb_profile_fields_seq'::regclass) NOT NULL,
+    field_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_type smallint DEFAULT '0'::smallint NOT NULL,
+    field_ident character varying(20) DEFAULT ''::character varying NOT NULL,
+    field_length character varying(20) DEFAULT ''::character varying NOT NULL,
+    field_minlen character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_maxlen character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_novalue character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_default_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_validation character varying(20) DEFAULT ''::character varying NOT NULL,
+    field_required smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_novalue smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_reg smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_vt smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_profile smallint DEFAULT '0'::smallint NOT NULL,
+    field_hide smallint DEFAULT '0'::smallint NOT NULL,
+    field_no_view smallint DEFAULT '0'::smallint NOT NULL,
+    field_active smallint DEFAULT '0'::smallint NOT NULL,
+    field_order integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_profile_fields_field_active_check CHECK ((field_active >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_hide_check CHECK ((field_hide >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_no_view_check CHECK ((field_no_view >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_order_check CHECK ((field_order >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_required_check CHECK ((field_required >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_novalue_check CHECK ((field_show_novalue >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_reg_check CHECK ((field_show_on_reg >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_vt_check CHECK ((field_show_on_vt >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_profile_check CHECK ((field_show_profile >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields_data (
+    user_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_profile_fields_data_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields_lang (
+    field_id integer DEFAULT 0 NOT NULL,
+    lang_id integer DEFAULT 0 NOT NULL,
+    option_id integer DEFAULT 0 NOT NULL,
+    field_type smallint DEFAULT '0'::smallint NOT NULL,
+    lang_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_lang_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_lang_lang_id_check CHECK ((lang_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_lang_option_id_check CHECK ((option_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_lang (
+    field_id integer DEFAULT 0 NOT NULL,
+    lang_id integer DEFAULT 0 NOT NULL,
+    lang_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    lang_explain character varying(4000) DEFAULT ''::character varying NOT NULL,
+    lang_default_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_lang_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_lang_lang_id_check CHECK ((lang_id >= 0))
+);
+
+
+--
+-- Name: phpbb_ranks_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_ranks_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_ranks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_ranks (
+    rank_id integer DEFAULT nextval('public.phpbb_ranks_seq'::regclass) NOT NULL,
+    rank_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    rank_min integer DEFAULT 0 NOT NULL,
+    rank_special smallint DEFAULT '0'::smallint NOT NULL,
+    rank_image character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_ranks_rank_min_check CHECK ((rank_min >= 0)),
+    CONSTRAINT phpbb_ranks_rank_special_check CHECK ((rank_special >= 0))
+);
+
+
+--
+-- Name: phpbb_reports_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_reports_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_reports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_reports (
+    report_id integer DEFAULT nextval('public.phpbb_reports_seq'::regclass) NOT NULL,
+    reason_id smallint DEFAULT '0'::smallint NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    pm_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    user_notify smallint DEFAULT '0'::smallint NOT NULL,
+    report_closed smallint DEFAULT '0'::smallint NOT NULL,
+    report_time integer DEFAULT 0 NOT NULL,
+    report_text text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_reports_pm_id_check CHECK ((pm_id >= 0)),
+    CONSTRAINT phpbb_reports_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_reports_reason_id_check CHECK ((reason_id >= 0)),
+    CONSTRAINT phpbb_reports_report_closed_check CHECK ((report_closed >= 0)),
+    CONSTRAINT phpbb_reports_report_time_check CHECK ((report_time >= 0)),
+    CONSTRAINT phpbb_reports_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_reports_user_notify_check CHECK ((user_notify >= 0))
+);
+
+
+--
+-- Name: phpbb_reports_reasons_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_reports_reasons_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_reports_reasons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_reports_reasons (
+    reason_id smallint DEFAULT nextval('public.phpbb_reports_reasons_seq'::regclass) NOT NULL,
+    reason_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    reason_description text DEFAULT ''::text NOT NULL,
+    reason_order smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_reports_reasons_reason_order_check CHECK ((reason_order >= 0))
+);
+
+
+--
+-- Name: phpbb_search_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_results (
+    search_key character varying(32) DEFAULT ''::character varying NOT NULL,
+    search_time integer DEFAULT 0 NOT NULL,
+    search_keywords text DEFAULT ''::text NOT NULL,
+    search_authors text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_search_results_search_time_check CHECK ((search_time >= 0))
+);
+
+
+--
+-- Name: phpbb_search_wordlist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_search_wordlist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_search_wordlist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_wordlist (
+    word_id integer DEFAULT nextval('public.phpbb_search_wordlist_seq'::regclass) NOT NULL,
+    word_text character varying(255) DEFAULT ''::character varying NOT NULL,
+    word_common smallint DEFAULT '0'::smallint NOT NULL,
+    word_count integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_search_wordlist_word_common_check CHECK ((word_common >= 0)),
+    CONSTRAINT phpbb_search_wordlist_word_count_check CHECK ((word_count >= 0))
+);
+
+
+--
+-- Name: phpbb_search_wordmatch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_wordmatch (
+    post_id integer DEFAULT 0 NOT NULL,
+    word_id integer DEFAULT 0 NOT NULL,
+    title_match smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_search_wordmatch_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_search_wordmatch_title_match_check CHECK ((title_match >= 0)),
+    CONSTRAINT phpbb_search_wordmatch_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sessions (
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    session_user_id integer DEFAULT 0 NOT NULL,
+    session_forum_id integer DEFAULT 0 NOT NULL,
+    session_last_visit integer DEFAULT 0 NOT NULL,
+    session_start integer DEFAULT 0 NOT NULL,
+    session_time integer DEFAULT 0 NOT NULL,
+    session_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    session_browser character varying(150) DEFAULT ''::character varying NOT NULL,
+    session_forwarded_for character varying(255) DEFAULT ''::character varying NOT NULL,
+    session_page character varying(255) DEFAULT ''::character varying NOT NULL,
+    session_viewonline smallint DEFAULT '1'::smallint NOT NULL,
+    session_autologin smallint DEFAULT '0'::smallint NOT NULL,
+    session_admin smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_sessions_session_admin_check CHECK ((session_admin >= 0)),
+    CONSTRAINT phpbb_sessions_session_autologin_check CHECK ((session_autologin >= 0)),
+    CONSTRAINT phpbb_sessions_session_forum_id_check CHECK ((session_forum_id >= 0)),
+    CONSTRAINT phpbb_sessions_session_last_visit_check CHECK ((session_last_visit >= 0)),
+    CONSTRAINT phpbb_sessions_session_start_check CHECK ((session_start >= 0)),
+    CONSTRAINT phpbb_sessions_session_time_check CHECK ((session_time >= 0)),
+    CONSTRAINT phpbb_sessions_session_user_id_check CHECK ((session_user_id >= 0)),
+    CONSTRAINT phpbb_sessions_session_viewonline_check CHECK ((session_viewonline >= 0))
+);
+
+
+--
+-- Name: phpbb_sessions_keys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sessions_keys (
+    key_id character(32) DEFAULT ''::bpchar NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    last_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    last_login integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_sessions_keys_last_login_check CHECK ((last_login >= 0)),
+    CONSTRAINT phpbb_sessions_keys_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_sitelist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_sitelist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_sitelist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sitelist (
+    site_id integer DEFAULT nextval('public.phpbb_sitelist_seq'::regclass) NOT NULL,
+    site_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    site_hostname character varying(255) DEFAULT ''::character varying NOT NULL,
+    ip_exclude smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_sitelist_ip_exclude_check CHECK ((ip_exclude >= 0))
+);
+
+
+--
+-- Name: phpbb_smilies_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_smilies_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_smilies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_smilies (
+    smiley_id integer DEFAULT nextval('public.phpbb_smilies_seq'::regclass) NOT NULL,
+    code character varying(50) DEFAULT ''::character varying NOT NULL,
+    emotion character varying(50) DEFAULT ''::character varying NOT NULL,
+    smiley_url character varying(50) DEFAULT ''::character varying NOT NULL,
+    smiley_width smallint DEFAULT '0'::smallint NOT NULL,
+    smiley_height smallint DEFAULT '0'::smallint NOT NULL,
+    smiley_order integer DEFAULT 0 NOT NULL,
+    display_on_posting smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_smilies_display_on_posting_check CHECK ((display_on_posting >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_height_check CHECK ((smiley_height >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_order_check CHECK ((smiley_order >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_width_check CHECK ((smiley_width >= 0))
+);
+
+
+--
+-- Name: phpbb_styles_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_styles_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_styles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_styles (
+    style_id integer DEFAULT nextval('public.phpbb_styles_seq'::regclass) NOT NULL,
+    style_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    style_copyright character varying(255) DEFAULT ''::character varying NOT NULL,
+    style_active smallint DEFAULT '1'::smallint NOT NULL,
+    template_id integer DEFAULT 0 NOT NULL,
+    theme_id integer DEFAULT 0 NOT NULL,
+    imageset_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_styles_imageset_id_check CHECK ((imageset_id >= 0)),
+    CONSTRAINT phpbb_styles_style_active_check CHECK ((style_active >= 0)),
+    CONSTRAINT phpbb_styles_template_id_check CHECK ((template_id >= 0)),
+    CONSTRAINT phpbb_styles_theme_id_check CHECK ((theme_id >= 0))
+);
+
+
+--
+-- Name: phpbb_styles_imageset_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_styles_imageset_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_styles_imageset; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_styles_imageset (
+    imageset_id integer DEFAULT nextval('public.phpbb_styles_imageset_seq'::regclass) NOT NULL,
+    imageset_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    imageset_copyright character varying(255) DEFAULT ''::character varying NOT NULL,
+    imageset_path character varying(100) DEFAULT ''::character varying NOT NULL
+);
+
+
+--
+-- Name: phpbb_styles_imageset_data_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_styles_imageset_data_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_styles_imageset_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_styles_imageset_data (
+    image_id integer DEFAULT nextval('public.phpbb_styles_imageset_data_seq'::regclass) NOT NULL,
+    image_name character varying(200) DEFAULT ''::character varying NOT NULL,
+    image_filename character varying(200) DEFAULT ''::character varying NOT NULL,
+    image_lang character varying(30) DEFAULT ''::character varying NOT NULL,
+    image_height smallint DEFAULT '0'::smallint NOT NULL,
+    image_width smallint DEFAULT '0'::smallint NOT NULL,
+    imageset_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_styles_imageset_data_image_height_check CHECK ((image_height >= 0)),
+    CONSTRAINT phpbb_styles_imageset_data_image_width_check CHECK ((image_width >= 0)),
+    CONSTRAINT phpbb_styles_imageset_data_imageset_id_check CHECK ((imageset_id >= 0))
+);
+
+
+--
+-- Name: phpbb_styles_template_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_styles_template_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_styles_template; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_styles_template (
+    template_id integer DEFAULT nextval('public.phpbb_styles_template_seq'::regclass) NOT NULL,
+    template_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    template_copyright character varying(255) DEFAULT ''::character varying NOT NULL,
+    template_path character varying(100) DEFAULT ''::character varying NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT 'kNg='::character varying NOT NULL,
+    template_storedb smallint DEFAULT '0'::smallint NOT NULL,
+    template_inherits_id integer DEFAULT 0 NOT NULL,
+    template_inherit_path character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_styles_template_template_inherits_id_check CHECK ((template_inherits_id >= 0)),
+    CONSTRAINT phpbb_styles_template_template_storedb_check CHECK ((template_storedb >= 0))
+);
+
+
+--
+-- Name: phpbb_styles_template_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_styles_template_data (
+    template_id integer DEFAULT 0 NOT NULL,
+    template_filename character varying(100) DEFAULT ''::character varying NOT NULL,
+    template_included character varying(8000) DEFAULT ''::character varying NOT NULL,
+    template_mtime integer DEFAULT 0 NOT NULL,
+    template_data text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_styles_template_data_template_id_check CHECK ((template_id >= 0)),
+    CONSTRAINT phpbb_styles_template_data_template_mtime_check CHECK ((template_mtime >= 0))
+);
+
+
+--
+-- Name: phpbb_styles_theme_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_styles_theme_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_styles_theme; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_styles_theme (
+    theme_id integer DEFAULT nextval('public.phpbb_styles_theme_seq'::regclass) NOT NULL,
+    theme_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    theme_copyright character varying(255) DEFAULT ''::character varying NOT NULL,
+    theme_path character varying(100) DEFAULT ''::character varying NOT NULL,
+    theme_storedb smallint DEFAULT '0'::smallint NOT NULL,
+    theme_mtime integer DEFAULT 0 NOT NULL,
+    theme_data text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_styles_theme_theme_mtime_check CHECK ((theme_mtime >= 0)),
+    CONSTRAINT phpbb_styles_theme_theme_storedb_check CHECK ((theme_storedb >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_topics_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_topics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics (
+    topic_id integer DEFAULT nextval('public.phpbb_topics_seq'::regclass) NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    topic_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    topic_approved smallint DEFAULT '1'::smallint NOT NULL,
+    topic_reported smallint DEFAULT '0'::smallint NOT NULL,
+    topic_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_poster integer DEFAULT 0 NOT NULL,
+    topic_time integer DEFAULT 0 NOT NULL,
+    topic_time_limit integer DEFAULT 0 NOT NULL,
+    topic_views integer DEFAULT 0 NOT NULL,
+    topic_replies integer DEFAULT 0 NOT NULL,
+    topic_replies_real integer DEFAULT 0 NOT NULL,
+    topic_status smallint DEFAULT '0'::smallint NOT NULL,
+    topic_type smallint DEFAULT '0'::smallint NOT NULL,
+    topic_first_post_id integer DEFAULT 0 NOT NULL,
+    topic_first_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_first_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_id integer DEFAULT 0 NOT NULL,
+    topic_last_poster_id integer DEFAULT 0 NOT NULL,
+    topic_last_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_last_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_time integer DEFAULT 0 NOT NULL,
+    topic_last_view_time integer DEFAULT 0 NOT NULL,
+    topic_moved_id integer DEFAULT 0 NOT NULL,
+    topic_bumped smallint DEFAULT '0'::smallint NOT NULL,
+    topic_bumper integer DEFAULT 0 NOT NULL,
+    poll_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    poll_start integer DEFAULT 0 NOT NULL,
+    poll_length integer DEFAULT 0 NOT NULL,
+    poll_max_options smallint DEFAULT '1'::smallint NOT NULL,
+    poll_last_vote integer DEFAULT 0 NOT NULL,
+    poll_vote_change smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_topics_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_topics_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_topics_poll_last_vote_check CHECK ((poll_last_vote >= 0)),
+    CONSTRAINT phpbb_topics_poll_length_check CHECK ((poll_length >= 0)),
+    CONSTRAINT phpbb_topics_poll_start_check CHECK ((poll_start >= 0)),
+    CONSTRAINT phpbb_topics_poll_vote_change_check CHECK ((poll_vote_change >= 0)),
+    CONSTRAINT phpbb_topics_topic_approved_check CHECK ((topic_approved >= 0)),
+    CONSTRAINT phpbb_topics_topic_attachment_check CHECK ((topic_attachment >= 0)),
+    CONSTRAINT phpbb_topics_topic_bumped_check CHECK ((topic_bumped >= 0)),
+    CONSTRAINT phpbb_topics_topic_bumper_check CHECK ((topic_bumper >= 0)),
+    CONSTRAINT phpbb_topics_topic_first_post_id_check CHECK ((topic_first_post_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_post_id_check CHECK ((topic_last_post_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_post_time_check CHECK ((topic_last_post_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_poster_id_check CHECK ((topic_last_poster_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_view_time_check CHECK ((topic_last_view_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_moved_id_check CHECK ((topic_moved_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_poster_check CHECK ((topic_poster >= 0)),
+    CONSTRAINT phpbb_topics_topic_replies_check CHECK ((topic_replies >= 0)),
+    CONSTRAINT phpbb_topics_topic_replies_real_check CHECK ((topic_replies_real >= 0)),
+    CONSTRAINT phpbb_topics_topic_reported_check CHECK ((topic_reported >= 0)),
+    CONSTRAINT phpbb_topics_topic_time_check CHECK ((topic_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_time_limit_check CHECK ((topic_time_limit >= 0)),
+    CONSTRAINT phpbb_topics_topic_views_check CHECK ((topic_views >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_posted; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_posted (
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    topic_posted smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_topics_posted_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_posted_topic_posted_check CHECK ((topic_posted >= 0)),
+    CONSTRAINT phpbb_topics_posted_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_track; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_track (
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    mark_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_topics_track_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_topics_track_mark_time_check CHECK ((mark_time >= 0)),
+    CONSTRAINT phpbb_topics_track_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_track_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_watch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_watch (
+    topic_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notify_status smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_topics_watch_notify_status_check CHECK ((notify_status >= 0)),
+    CONSTRAINT phpbb_topics_watch_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_watch_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_user_group; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_user_group (
+    group_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    group_leader smallint DEFAULT '0'::smallint NOT NULL,
+    user_pending smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_user_group_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_user_group_group_leader_check CHECK ((group_leader >= 0)),
+    CONSTRAINT phpbb_user_group_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_user_group_user_pending_check CHECK ((user_pending >= 0))
+);
+
+
+--
+-- Name: phpbb_users_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_users_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_users (
+    user_id integer DEFAULT nextval('public.phpbb_users_seq'::regclass) NOT NULL,
+    user_type smallint DEFAULT '0'::smallint NOT NULL,
+    group_id integer DEFAULT 3 NOT NULL,
+    user_permissions text DEFAULT ''::text NOT NULL,
+    user_perm_from integer DEFAULT 0 NOT NULL,
+    user_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    user_regdate integer DEFAULT 0 NOT NULL,
+    username public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    username_clean public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    user_password character varying(40) DEFAULT ''::character varying NOT NULL,
+    user_passchg integer DEFAULT 0 NOT NULL,
+    user_pass_convert smallint DEFAULT '0'::smallint NOT NULL,
+    user_email character varying(100) DEFAULT ''::character varying NOT NULL,
+    user_email_hash bigint DEFAULT '0'::bigint NOT NULL,
+    user_birthday character varying(10) DEFAULT ''::character varying NOT NULL,
+    user_lastvisit integer DEFAULT 0 NOT NULL,
+    user_lastmark integer DEFAULT 0 NOT NULL,
+    user_lastpost_time integer DEFAULT 0 NOT NULL,
+    user_lastpage character varying(200) DEFAULT ''::character varying NOT NULL,
+    user_last_confirm_key character varying(10) DEFAULT ''::character varying NOT NULL,
+    user_last_search integer DEFAULT 0 NOT NULL,
+    user_warnings smallint DEFAULT '0'::smallint NOT NULL,
+    user_last_warning integer DEFAULT 0 NOT NULL,
+    user_login_attempts smallint DEFAULT '0'::smallint NOT NULL,
+    user_inactive_reason smallint DEFAULT '0'::smallint NOT NULL,
+    user_inactive_time integer DEFAULT 0 NOT NULL,
+    user_posts integer DEFAULT 0 NOT NULL,
+    user_lang character varying(30) DEFAULT ''::character varying NOT NULL,
+    user_timezone numeric(5,2) DEFAULT '0'::numeric NOT NULL,
+    user_dst smallint DEFAULT '0'::smallint NOT NULL,
+    user_dateformat character varying(30) DEFAULT 'd M Y H:i'::character varying NOT NULL,
+    user_style integer DEFAULT 0 NOT NULL,
+    user_rank integer DEFAULT 0 NOT NULL,
+    user_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    user_new_privmsg integer DEFAULT 0 NOT NULL,
+    user_unread_privmsg integer DEFAULT 0 NOT NULL,
+    user_last_privmsg integer DEFAULT 0 NOT NULL,
+    user_message_rules smallint DEFAULT '0'::smallint NOT NULL,
+    user_full_folder integer DEFAULT '-3'::integer NOT NULL,
+    user_emailtime integer DEFAULT 0 NOT NULL,
+    user_topic_show_days smallint DEFAULT '0'::smallint NOT NULL,
+    user_topic_sortby_type character varying(1) DEFAULT 't'::character varying NOT NULL,
+    user_topic_sortby_dir character varying(1) DEFAULT 'd'::character varying NOT NULL,
+    user_post_show_days smallint DEFAULT '0'::smallint NOT NULL,
+    user_post_sortby_type character varying(1) DEFAULT 't'::character varying NOT NULL,
+    user_post_sortby_dir character varying(1) DEFAULT 'a'::character varying NOT NULL,
+    user_notify smallint DEFAULT '0'::smallint NOT NULL,
+    user_notify_pm smallint DEFAULT '1'::smallint NOT NULL,
+    user_notify_type smallint DEFAULT '0'::smallint NOT NULL,
+    user_allow_pm smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_viewonline smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_viewemail smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_massemail smallint DEFAULT '1'::smallint NOT NULL,
+    user_options integer DEFAULT 230271 NOT NULL,
+    user_avatar character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_avatar_type smallint DEFAULT '0'::smallint NOT NULL,
+    user_avatar_width smallint DEFAULT '0'::smallint NOT NULL,
+    user_avatar_height smallint DEFAULT '0'::smallint NOT NULL,
+    user_sig text DEFAULT ''::text NOT NULL,
+    user_sig_bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    user_sig_bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_from character varying(100) DEFAULT ''::character varying NOT NULL,
+    user_icq character varying(15) DEFAULT ''::character varying NOT NULL,
+    user_aim character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_yim character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_msnm character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_jabber character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_website character varying(200) DEFAULT ''::character varying NOT NULL,
+    user_occ character varying(4000) DEFAULT ''::character varying NOT NULL,
+    user_interests character varying(4000) DEFAULT ''::character varying NOT NULL,
+    user_actkey character varying(32) DEFAULT ''::character varying NOT NULL,
+    user_newpasswd character varying(40) DEFAULT ''::character varying NOT NULL,
+    user_form_salt character varying(32) DEFAULT ''::character varying NOT NULL,
+    user_new smallint DEFAULT '1'::smallint NOT NULL,
+    user_reminded smallint DEFAULT '0'::smallint NOT NULL,
+    user_reminded_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_users_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_users_user_allow_massemail_check CHECK ((user_allow_massemail >= 0)),
+    CONSTRAINT phpbb_users_user_allow_pm_check CHECK ((user_allow_pm >= 0)),
+    CONSTRAINT phpbb_users_user_allow_viewemail_check CHECK ((user_allow_viewemail >= 0)),
+    CONSTRAINT phpbb_users_user_allow_viewonline_check CHECK ((user_allow_viewonline >= 0)),
+    CONSTRAINT phpbb_users_user_avatar_height_check CHECK ((user_avatar_height >= 0)),
+    CONSTRAINT phpbb_users_user_avatar_width_check CHECK ((user_avatar_width >= 0)),
+    CONSTRAINT phpbb_users_user_dst_check CHECK ((user_dst >= 0)),
+    CONSTRAINT phpbb_users_user_emailtime_check CHECK ((user_emailtime >= 0)),
+    CONSTRAINT phpbb_users_user_inactive_time_check CHECK ((user_inactive_time >= 0)),
+    CONSTRAINT phpbb_users_user_last_privmsg_check CHECK ((user_last_privmsg >= 0)),
+    CONSTRAINT phpbb_users_user_last_search_check CHECK ((user_last_search >= 0)),
+    CONSTRAINT phpbb_users_user_last_warning_check CHECK ((user_last_warning >= 0)),
+    CONSTRAINT phpbb_users_user_lastmark_check CHECK ((user_lastmark >= 0)),
+    CONSTRAINT phpbb_users_user_lastpost_time_check CHECK ((user_lastpost_time >= 0)),
+    CONSTRAINT phpbb_users_user_lastvisit_check CHECK ((user_lastvisit >= 0)),
+    CONSTRAINT phpbb_users_user_message_rules_check CHECK ((user_message_rules >= 0)),
+    CONSTRAINT phpbb_users_user_new_check CHECK ((user_new >= 0)),
+    CONSTRAINT phpbb_users_user_notify_check CHECK ((user_notify >= 0)),
+    CONSTRAINT phpbb_users_user_notify_pm_check CHECK ((user_notify_pm >= 0)),
+    CONSTRAINT phpbb_users_user_options_check CHECK ((user_options >= 0)),
+    CONSTRAINT phpbb_users_user_pass_convert_check CHECK ((user_pass_convert >= 0)),
+    CONSTRAINT phpbb_users_user_passchg_check CHECK ((user_passchg >= 0)),
+    CONSTRAINT phpbb_users_user_perm_from_check CHECK ((user_perm_from >= 0)),
+    CONSTRAINT phpbb_users_user_post_show_days_check CHECK ((user_post_show_days >= 0)),
+    CONSTRAINT phpbb_users_user_posts_check CHECK ((user_posts >= 0)),
+    CONSTRAINT phpbb_users_user_rank_check CHECK ((user_rank >= 0)),
+    CONSTRAINT phpbb_users_user_regdate_check CHECK ((user_regdate >= 0)),
+    CONSTRAINT phpbb_users_user_reminded_time_check CHECK ((user_reminded_time >= 0)),
+    CONSTRAINT phpbb_users_user_style_check CHECK ((user_style >= 0)),
+    CONSTRAINT phpbb_users_user_topic_show_days_check CHECK ((user_topic_show_days >= 0))
+);
+
+
+--
+-- Name: phpbb_warnings_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_warnings_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_warnings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_warnings (
+    warning_id integer DEFAULT nextval('public.phpbb_warnings_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    log_id integer DEFAULT 0 NOT NULL,
+    warning_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_warnings_log_id_check CHECK ((log_id >= 0)),
+    CONSTRAINT phpbb_warnings_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_warnings_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_warnings_warning_time_check CHECK ((warning_time >= 0))
+);
+
+
+--
+-- Name: phpbb_words_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_words_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_words; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_words (
+    word_id integer DEFAULT nextval('public.phpbb_words_seq'::regclass) NOT NULL,
+    word character varying(255) DEFAULT ''::character varying NOT NULL,
+    replacement character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+--
+-- Name: phpbb_zebra; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_zebra (
+    user_id integer DEFAULT 0 NOT NULL,
+    zebra_id integer DEFAULT 0 NOT NULL,
+    friend smallint DEFAULT '0'::smallint NOT NULL,
+    foe smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_zebra_foe_check CHECK ((foe >= 0)),
+    CONSTRAINT phpbb_zebra_friend_check CHECK ((friend >= 0)),
+    CONSTRAINT phpbb_zebra_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_zebra_zebra_id_check CHECK ((zebra_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_options phpbb_acl_options_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_options
+    ADD CONSTRAINT phpbb_acl_options_pkey PRIMARY KEY (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles_data phpbb_acl_roles_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_roles_data
+    ADD CONSTRAINT phpbb_acl_roles_data_pkey PRIMARY KEY (role_id, auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles phpbb_acl_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_roles
+    ADD CONSTRAINT phpbb_acl_roles_pkey PRIMARY KEY (role_id);
+
+
+--
+-- Name: phpbb_attachments phpbb_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_attachments
+    ADD CONSTRAINT phpbb_attachments_pkey PRIMARY KEY (attach_id);
+
+
+--
+-- Name: phpbb_banlist phpbb_banlist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_banlist
+    ADD CONSTRAINT phpbb_banlist_pkey PRIMARY KEY (ban_id);
+
+
+--
+-- Name: phpbb_bbcodes phpbb_bbcodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bbcodes
+    ADD CONSTRAINT phpbb_bbcodes_pkey PRIMARY KEY (bbcode_id);
+
+
+--
+-- Name: phpbb_bookmarks phpbb_bookmarks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bookmarks
+    ADD CONSTRAINT phpbb_bookmarks_pkey PRIMARY KEY (topic_id, user_id);
+
+
+--
+-- Name: phpbb_bots phpbb_bots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bots
+    ADD CONSTRAINT phpbb_bots_pkey PRIMARY KEY (bot_id);
+
+
+--
+-- Name: phpbb_config phpbb_config_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_config
+    ADD CONSTRAINT phpbb_config_pkey PRIMARY KEY (config_name);
+
+
+--
+-- Name: phpbb_confirm phpbb_confirm_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_confirm
+    ADD CONSTRAINT phpbb_confirm_pkey PRIMARY KEY (session_id, confirm_id);
+
+
+--
+-- Name: phpbb_disallow phpbb_disallow_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_disallow
+    ADD CONSTRAINT phpbb_disallow_pkey PRIMARY KEY (disallow_id);
+
+
+--
+-- Name: phpbb_drafts phpbb_drafts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_drafts
+    ADD CONSTRAINT phpbb_drafts_pkey PRIMARY KEY (draft_id);
+
+
+--
+-- Name: phpbb_extension_groups phpbb_extension_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_extension_groups
+    ADD CONSTRAINT phpbb_extension_groups_pkey PRIMARY KEY (group_id);
+
+
+--
+-- Name: phpbb_extensions phpbb_extensions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_extensions
+    ADD CONSTRAINT phpbb_extensions_pkey PRIMARY KEY (extension_id);
+
+
+--
+-- Name: phpbb_forums_access phpbb_forums_access_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums_access
+    ADD CONSTRAINT phpbb_forums_access_pkey PRIMARY KEY (forum_id, user_id, session_id);
+
+
+--
+-- Name: phpbb_forums phpbb_forums_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums
+    ADD CONSTRAINT phpbb_forums_pkey PRIMARY KEY (forum_id);
+
+
+--
+-- Name: phpbb_forums_track phpbb_forums_track_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums_track
+    ADD CONSTRAINT phpbb_forums_track_pkey PRIMARY KEY (user_id, forum_id);
+
+
+--
+-- Name: phpbb_groups phpbb_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_groups
+    ADD CONSTRAINT phpbb_groups_pkey PRIMARY KEY (group_id);
+
+
+--
+-- Name: phpbb_icons phpbb_icons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_icons
+    ADD CONSTRAINT phpbb_icons_pkey PRIMARY KEY (icons_id);
+
+
+--
+-- Name: phpbb_lang phpbb_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_lang
+    ADD CONSTRAINT phpbb_lang_pkey PRIMARY KEY (lang_id);
+
+
+--
+-- Name: phpbb_log phpbb_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_log
+    ADD CONSTRAINT phpbb_log_pkey PRIMARY KEY (log_id);
+
+
+--
+-- Name: phpbb_modules phpbb_modules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_modules
+    ADD CONSTRAINT phpbb_modules_pkey PRIMARY KEY (module_id);
+
+
+--
+-- Name: phpbb_posts phpbb_posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_posts
+    ADD CONSTRAINT phpbb_posts_pkey PRIMARY KEY (post_id);
+
+
+--
+-- Name: phpbb_privmsgs_folder phpbb_privmsgs_folder_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs_folder
+    ADD CONSTRAINT phpbb_privmsgs_folder_pkey PRIMARY KEY (folder_id);
+
+
+--
+-- Name: phpbb_privmsgs phpbb_privmsgs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs
+    ADD CONSTRAINT phpbb_privmsgs_pkey PRIMARY KEY (msg_id);
+
+
+--
+-- Name: phpbb_privmsgs_rules phpbb_privmsgs_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs_rules
+    ADD CONSTRAINT phpbb_privmsgs_rules_pkey PRIMARY KEY (rule_id);
+
+
+--
+-- Name: phpbb_profile_fields_data phpbb_profile_fields_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields_data
+    ADD CONSTRAINT phpbb_profile_fields_data_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: phpbb_profile_fields_lang phpbb_profile_fields_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields_lang
+    ADD CONSTRAINT phpbb_profile_fields_lang_pkey PRIMARY KEY (field_id, lang_id, option_id);
+
+
+--
+-- Name: phpbb_profile_fields phpbb_profile_fields_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields
+    ADD CONSTRAINT phpbb_profile_fields_pkey PRIMARY KEY (field_id);
+
+
+--
+-- Name: phpbb_profile_lang phpbb_profile_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_lang
+    ADD CONSTRAINT phpbb_profile_lang_pkey PRIMARY KEY (field_id, lang_id);
+
+
+--
+-- Name: phpbb_ranks phpbb_ranks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_ranks
+    ADD CONSTRAINT phpbb_ranks_pkey PRIMARY KEY (rank_id);
+
+
+--
+-- Name: phpbb_reports phpbb_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_reports
+    ADD CONSTRAINT phpbb_reports_pkey PRIMARY KEY (report_id);
+
+
+--
+-- Name: phpbb_reports_reasons phpbb_reports_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_reports_reasons
+    ADD CONSTRAINT phpbb_reports_reasons_pkey PRIMARY KEY (reason_id);
+
+
+--
+-- Name: phpbb_search_results phpbb_search_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_search_results
+    ADD CONSTRAINT phpbb_search_results_pkey PRIMARY KEY (search_key);
+
+
+--
+-- Name: phpbb_search_wordlist phpbb_search_wordlist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_search_wordlist
+    ADD CONSTRAINT phpbb_search_wordlist_pkey PRIMARY KEY (word_id);
+
+
+--
+-- Name: phpbb_sessions_keys phpbb_sessions_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sessions_keys
+    ADD CONSTRAINT phpbb_sessions_keys_pkey PRIMARY KEY (key_id, user_id);
+
+
+--
+-- Name: phpbb_sessions phpbb_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sessions
+    ADD CONSTRAINT phpbb_sessions_pkey PRIMARY KEY (session_id);
+
+
+--
+-- Name: phpbb_sitelist phpbb_sitelist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sitelist
+    ADD CONSTRAINT phpbb_sitelist_pkey PRIMARY KEY (site_id);
+
+
+--
+-- Name: phpbb_smilies phpbb_smilies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_smilies
+    ADD CONSTRAINT phpbb_smilies_pkey PRIMARY KEY (smiley_id);
+
+
+--
+-- Name: phpbb_styles_imageset_data phpbb_styles_imageset_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_styles_imageset_data
+    ADD CONSTRAINT phpbb_styles_imageset_data_pkey PRIMARY KEY (image_id);
+
+
+--
+-- Name: phpbb_styles_imageset phpbb_styles_imageset_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_styles_imageset
+    ADD CONSTRAINT phpbb_styles_imageset_pkey PRIMARY KEY (imageset_id);
+
+
+--
+-- Name: phpbb_styles phpbb_styles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_styles
+    ADD CONSTRAINT phpbb_styles_pkey PRIMARY KEY (style_id);
+
+
+--
+-- Name: phpbb_styles_template phpbb_styles_template_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_styles_template
+    ADD CONSTRAINT phpbb_styles_template_pkey PRIMARY KEY (template_id);
+
+
+--
+-- Name: phpbb_styles_theme phpbb_styles_theme_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_styles_theme
+    ADD CONSTRAINT phpbb_styles_theme_pkey PRIMARY KEY (theme_id);
+
+
+--
+-- Name: phpbb_topics phpbb_topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics
+    ADD CONSTRAINT phpbb_topics_pkey PRIMARY KEY (topic_id);
+
+
+--
+-- Name: phpbb_topics_posted phpbb_topics_posted_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics_posted
+    ADD CONSTRAINT phpbb_topics_posted_pkey PRIMARY KEY (user_id, topic_id);
+
+
+--
+-- Name: phpbb_topics_track phpbb_topics_track_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics_track
+    ADD CONSTRAINT phpbb_topics_track_pkey PRIMARY KEY (user_id, topic_id);
+
+
+--
+-- Name: phpbb_users phpbb_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_users
+    ADD CONSTRAINT phpbb_users_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: phpbb_warnings phpbb_warnings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_warnings
+    ADD CONSTRAINT phpbb_warnings_pkey PRIMARY KEY (warning_id);
+
+
+--
+-- Name: phpbb_words phpbb_words_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_words
+    ADD CONSTRAINT phpbb_words_pkey PRIMARY KEY (word_id);
+
+
+--
+-- Name: phpbb_zebra phpbb_zebra_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_zebra
+    ADD CONSTRAINT phpbb_zebra_pkey PRIMARY KEY (user_id, zebra_id);
+
+
+--
+-- Name: phpbb_acl_groups_auth_opt_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_auth_opt_id ON public.phpbb_acl_groups USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_groups_auth_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_auth_role_id ON public.phpbb_acl_groups USING btree (auth_role_id);
+
+
+--
+-- Name: phpbb_acl_groups_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_group_id ON public.phpbb_acl_groups USING btree (group_id);
+
+
+--
+-- Name: phpbb_acl_options_auth_option; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_acl_options_auth_option ON public.phpbb_acl_options USING btree (auth_option);
+
+
+--
+-- Name: phpbb_acl_roles_data_ath_op_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_data_ath_op_id ON public.phpbb_acl_roles_data USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles_role_order; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_role_order ON public.phpbb_acl_roles USING btree (role_order);
+
+
+--
+-- Name: phpbb_acl_roles_role_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_role_type ON public.phpbb_acl_roles USING btree (role_type);
+
+
+--
+-- Name: phpbb_acl_users_auth_option_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_auth_option_id ON public.phpbb_acl_users USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_users_auth_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_auth_role_id ON public.phpbb_acl_users USING btree (auth_role_id);
+
+
+--
+-- Name: phpbb_acl_users_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_user_id ON public.phpbb_acl_users USING btree (user_id);
+
+
+--
+-- Name: phpbb_attachments_filetime; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_filetime ON public.phpbb_attachments USING btree (filetime);
+
+
+--
+-- Name: phpbb_attachments_is_orphan; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_is_orphan ON public.phpbb_attachments USING btree (is_orphan);
+
+
+--
+-- Name: phpbb_attachments_post_msg_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_post_msg_id ON public.phpbb_attachments USING btree (post_msg_id);
+
+
+--
+-- Name: phpbb_attachments_poster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_poster_id ON public.phpbb_attachments USING btree (poster_id);
+
+
+--
+-- Name: phpbb_attachments_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_topic_id ON public.phpbb_attachments USING btree (topic_id);
+
+
+--
+-- Name: phpbb_banlist_ban_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_email ON public.phpbb_banlist USING btree (ban_email, ban_exclude);
+
+
+--
+-- Name: phpbb_banlist_ban_end; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_end ON public.phpbb_banlist USING btree (ban_end);
+
+
+--
+-- Name: phpbb_banlist_ban_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_ip ON public.phpbb_banlist USING btree (ban_ip, ban_exclude);
+
+
+--
+-- Name: phpbb_banlist_ban_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_user ON public.phpbb_banlist USING btree (ban_userid, ban_exclude);
+
+
+--
+-- Name: phpbb_bbcodes_display_on_post; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_bbcodes_display_on_post ON public.phpbb_bbcodes USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_bots_bot_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_bots_bot_active ON public.phpbb_bots USING btree (bot_active);
+
+
+--
+-- Name: phpbb_config_is_dynamic; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_config_is_dynamic ON public.phpbb_config USING btree (is_dynamic);
+
+
+--
+-- Name: phpbb_confirm_confirm_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_confirm_confirm_type ON public.phpbb_confirm USING btree (confirm_type);
+
+
+--
+-- Name: phpbb_drafts_save_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_drafts_save_time ON public.phpbb_drafts USING btree (save_time);
+
+
+--
+-- Name: phpbb_forums_forum_lastpost_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_forum_lastpost_id ON public.phpbb_forums USING btree (forum_last_post_id);
+
+
+--
+-- Name: phpbb_forums_left_right_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_left_right_id ON public.phpbb_forums USING btree (left_id, right_id);
+
+
+--
+-- Name: phpbb_forums_watch_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_forum_id ON public.phpbb_forums_watch USING btree (forum_id);
+
+
+--
+-- Name: phpbb_forums_watch_notify_stat; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_notify_stat ON public.phpbb_forums_watch USING btree (notify_status);
+
+
+--
+-- Name: phpbb_forums_watch_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_user_id ON public.phpbb_forums_watch USING btree (user_id);
+
+
+--
+-- Name: phpbb_groups_group_legend_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_groups_group_legend_name ON public.phpbb_groups USING btree (group_legend, group_name);
+
+
+--
+-- Name: phpbb_icons_display_on_posting; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_icons_display_on_posting ON public.phpbb_icons USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_lang_lang_iso; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_lang_lang_iso ON public.phpbb_lang USING btree (lang_iso);
+
+
+--
+-- Name: phpbb_log_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_forum_id ON public.phpbb_log USING btree (forum_id);
+
+
+--
+-- Name: phpbb_log_log_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_log_type ON public.phpbb_log USING btree (log_type);
+
+
+--
+-- Name: phpbb_log_reportee_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_reportee_id ON public.phpbb_log USING btree (reportee_id);
+
+
+--
+-- Name: phpbb_log_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_topic_id ON public.phpbb_log USING btree (topic_id);
+
+
+--
+-- Name: phpbb_log_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_user_id ON public.phpbb_log USING btree (user_id);
+
+
+--
+-- Name: phpbb_login_attempts_att_for; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_for ON public.phpbb_login_attempts USING btree (attempt_forwarded_for, attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_att_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_ip ON public.phpbb_login_attempts USING btree (attempt_ip, attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_att_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_time ON public.phpbb_login_attempts USING btree (attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_user_id ON public.phpbb_login_attempts USING btree (user_id);
+
+
+--
+-- Name: phpbb_moderator_cache_disp_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_moderator_cache_disp_idx ON public.phpbb_moderator_cache USING btree (display_on_index);
+
+
+--
+-- Name: phpbb_moderator_cache_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_moderator_cache_forum_id ON public.phpbb_moderator_cache USING btree (forum_id);
+
+
+--
+-- Name: phpbb_modules_class_left_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_class_left_id ON public.phpbb_modules USING btree (module_class, left_id);
+
+
+--
+-- Name: phpbb_modules_left_right_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_left_right_id ON public.phpbb_modules USING btree (left_id, right_id);
+
+
+--
+-- Name: phpbb_modules_module_enabled; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_module_enabled ON public.phpbb_modules USING btree (module_enabled);
+
+
+--
+-- Name: phpbb_poll_options_poll_opt_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_options_poll_opt_id ON public.phpbb_poll_options USING btree (poll_option_id);
+
+
+--
+-- Name: phpbb_poll_options_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_options_topic_id ON public.phpbb_poll_options USING btree (topic_id);
+
+
+--
+-- Name: phpbb_poll_votes_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_topic_id ON public.phpbb_poll_votes USING btree (topic_id);
+
+
+--
+-- Name: phpbb_poll_votes_vote_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_vote_user_id ON public.phpbb_poll_votes USING btree (vote_user_id);
+
+
+--
+-- Name: phpbb_poll_votes_vote_user_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_vote_user_ip ON public.phpbb_poll_votes USING btree (vote_user_ip);
+
+
+--
+-- Name: phpbb_posts_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_forum_id ON public.phpbb_posts USING btree (forum_id);
+
+
+--
+-- Name: phpbb_posts_post_approved; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_post_approved ON public.phpbb_posts USING btree (post_approved);
+
+
+--
+-- Name: phpbb_posts_post_username; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_post_username ON public.phpbb_posts USING btree (post_username);
+
+
+--
+-- Name: phpbb_posts_poster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_poster_id ON public.phpbb_posts USING btree (poster_id);
+
+
+--
+-- Name: phpbb_posts_poster_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_poster_ip ON public.phpbb_posts USING btree (poster_ip);
+
+
+--
+-- Name: phpbb_posts_tid_post_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_tid_post_time ON public.phpbb_posts USING btree (topic_id, post_time);
+
+
+--
+-- Name: phpbb_posts_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_topic_id ON public.phpbb_posts USING btree (topic_id);
+
+
+--
+-- Name: phpbb_privmsgs_author_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_author_id ON public.phpbb_privmsgs USING btree (author_id);
+
+
+--
+-- Name: phpbb_privmsgs_author_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_author_ip ON public.phpbb_privmsgs USING btree (author_ip);
+
+
+--
+-- Name: phpbb_privmsgs_folder_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_folder_user_id ON public.phpbb_privmsgs_folder USING btree (user_id);
+
+
+--
+-- Name: phpbb_privmsgs_message_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_message_time ON public.phpbb_privmsgs USING btree (message_time);
+
+
+--
+-- Name: phpbb_privmsgs_root_level; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_root_level ON public.phpbb_privmsgs USING btree (root_level);
+
+
+--
+-- Name: phpbb_privmsgs_rules_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_rules_user_id ON public.phpbb_privmsgs_rules USING btree (user_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_author_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_author_id ON public.phpbb_privmsgs_to USING btree (author_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_msg_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_msg_id ON public.phpbb_privmsgs_to USING btree (msg_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_usr_flder_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_usr_flder_id ON public.phpbb_privmsgs_to USING btree (user_id, folder_id);
+
+
+--
+-- Name: phpbb_profile_fields_fld_ordr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_profile_fields_fld_ordr ON public.phpbb_profile_fields USING btree (field_order);
+
+
+--
+-- Name: phpbb_profile_fields_fld_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_profile_fields_fld_type ON public.phpbb_profile_fields USING btree (field_type);
+
+
+--
+-- Name: phpbb_reports_pm_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_reports_pm_id ON public.phpbb_reports USING btree (pm_id);
+
+
+--
+-- Name: phpbb_reports_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_reports_post_id ON public.phpbb_reports USING btree (post_id);
+
+
+--
+-- Name: phpbb_search_wordlist_wrd_cnt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordlist_wrd_cnt ON public.phpbb_search_wordlist USING btree (word_count);
+
+
+--
+-- Name: phpbb_search_wordlist_wrd_txt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_search_wordlist_wrd_txt ON public.phpbb_search_wordlist USING btree (word_text);
+
+
+--
+-- Name: phpbb_search_wordmatch_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordmatch_post_id ON public.phpbb_search_wordmatch USING btree (post_id);
+
+
+--
+-- Name: phpbb_search_wordmatch_unq_mtch; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_search_wordmatch_unq_mtch ON public.phpbb_search_wordmatch USING btree (word_id, post_id, title_match);
+
+
+--
+-- Name: phpbb_search_wordmatch_word_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordmatch_word_id ON public.phpbb_search_wordmatch USING btree (word_id);
+
+
+--
+-- Name: phpbb_sessions_keys_last_login; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_keys_last_login ON public.phpbb_sessions_keys USING btree (last_login);
+
+
+--
+-- Name: phpbb_sessions_session_fid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_fid ON public.phpbb_sessions USING btree (session_forum_id);
+
+
+--
+-- Name: phpbb_sessions_session_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_time ON public.phpbb_sessions USING btree (session_time);
+
+
+--
+-- Name: phpbb_sessions_session_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_user_id ON public.phpbb_sessions USING btree (session_user_id);
+
+
+--
+-- Name: phpbb_smilies_display_on_post; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_smilies_display_on_post ON public.phpbb_smilies USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_styles_imageset_data_i_d; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_styles_imageset_data_i_d ON public.phpbb_styles_imageset_data USING btree (imageset_id);
+
+
+--
+-- Name: phpbb_styles_imageset_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_styles_imageset_id ON public.phpbb_styles USING btree (imageset_id);
+
+
+--
+-- Name: phpbb_styles_imageset_imgset_nm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_styles_imageset_imgset_nm ON public.phpbb_styles_imageset USING btree (imageset_name);
+
+
+--
+-- Name: phpbb_styles_style_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_styles_style_name ON public.phpbb_styles USING btree (style_name);
+
+
+--
+-- Name: phpbb_styles_template_data_tfn; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_styles_template_data_tfn ON public.phpbb_styles_template_data USING btree (template_filename);
+
+
+--
+-- Name: phpbb_styles_template_data_tid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_styles_template_data_tid ON public.phpbb_styles_template_data USING btree (template_id);
+
+
+--
+-- Name: phpbb_styles_template_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_styles_template_id ON public.phpbb_styles USING btree (template_id);
+
+
+--
+-- Name: phpbb_styles_template_tmplte_nm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_styles_template_tmplte_nm ON public.phpbb_styles_template USING btree (template_name);
+
+
+--
+-- Name: phpbb_styles_theme_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_styles_theme_id ON public.phpbb_styles USING btree (theme_id);
+
+
+--
+-- Name: phpbb_styles_theme_theme_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_styles_theme_theme_name ON public.phpbb_styles_theme USING btree (theme_name);
+
+
+--
+-- Name: phpbb_topics_fid_time_moved; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_fid_time_moved ON public.phpbb_topics USING btree (forum_id, topic_last_post_time, topic_moved_id);
+
+
+--
+-- Name: phpbb_topics_forum_appr_last; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_appr_last ON public.phpbb_topics USING btree (forum_id, topic_approved, topic_last_post_id);
+
+
+--
+-- Name: phpbb_topics_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_id ON public.phpbb_topics USING btree (forum_id);
+
+
+--
+-- Name: phpbb_topics_forum_id_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_id_type ON public.phpbb_topics USING btree (forum_id, topic_type);
+
+
+--
+-- Name: phpbb_topics_last_post_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_last_post_time ON public.phpbb_topics USING btree (topic_last_post_time);
+
+
+--
+-- Name: phpbb_topics_topic_approved; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_topic_approved ON public.phpbb_topics USING btree (topic_approved);
+
+
+--
+-- Name: phpbb_topics_track_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_track_forum_id ON public.phpbb_topics_track USING btree (forum_id);
+
+
+--
+-- Name: phpbb_topics_track_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_track_topic_id ON public.phpbb_topics_track USING btree (topic_id);
+
+
+--
+-- Name: phpbb_topics_watch_notify_stat; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_notify_stat ON public.phpbb_topics_watch USING btree (notify_status);
+
+
+--
+-- Name: phpbb_topics_watch_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_topic_id ON public.phpbb_topics_watch USING btree (topic_id);
+
+
+--
+-- Name: phpbb_topics_watch_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_user_id ON public.phpbb_topics_watch USING btree (user_id);
+
+
+--
+-- Name: phpbb_user_group_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_group_id ON public.phpbb_user_group USING btree (group_id);
+
+
+--
+-- Name: phpbb_user_group_group_leader; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_group_leader ON public.phpbb_user_group USING btree (group_leader);
+
+
+--
+-- Name: phpbb_user_group_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_user_id ON public.phpbb_user_group USING btree (user_id);
+
+
+--
+-- Name: phpbb_users_user_birthday; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_birthday ON public.phpbb_users USING btree (user_birthday);
+
+
+--
+-- Name: phpbb_users_user_email_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_email_hash ON public.phpbb_users USING btree (user_email_hash);
+
+
+--
+-- Name: phpbb_users_user_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_type ON public.phpbb_users USING btree (user_type);
+
+
+--
+-- Name: phpbb_users_username_clean; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_users_username_clean ON public.phpbb_users USING btree (username_clean);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict rpMjxEK4taQXqqlA5qoz75dgnjI6qbpNRFTqUwPb5fmmqmZRGD4NcAx8r6swPEq
+

--- a/migrations/converters/spec/fixtures/phpbb/schemas/3.1/mysql.sql
+++ b/migrations/converters/spec/fixtures/phpbb/schemas/3.1/mysql.sql
@@ -1,0 +1,1089 @@
+/*M!999999\- enable the sandbox mode */ 
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  KEY `group_id` (`group_id`),
+  KEY `auth_opt_id` (`auth_option_id`),
+  KEY `auth_role_id` (`auth_role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_options` (
+  `auth_option_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `auth_option` varchar(50) NOT NULL DEFAULT '',
+  `is_global` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `is_local` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `founder_only` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`auth_option_id`),
+  UNIQUE KEY `auth_option` (`auth_option`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_roles` (
+  `role_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `role_name` varchar(255) NOT NULL DEFAULT '',
+  `role_description` text NOT NULL,
+  `role_type` varchar(10) NOT NULL DEFAULT '',
+  `role_order` smallint(4) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`role_id`),
+  KEY `role_type` (`role_type`),
+  KEY `role_order` (`role_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_roles_data` (
+  `role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`role_id`,`auth_option_id`),
+  KEY `ath_op_id` (`auth_option_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_users` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  KEY `user_id` (`user_id`),
+  KEY `auth_option_id` (`auth_option_id`),
+  KEY `auth_role_id` (`auth_role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_attachments` (
+  `attach_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `post_msg_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `in_message` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `poster_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `is_orphan` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `physical_filename` varchar(255) NOT NULL DEFAULT '',
+  `real_filename` varchar(255) NOT NULL DEFAULT '',
+  `download_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `attach_comment` text NOT NULL,
+  `extension` varchar(100) NOT NULL DEFAULT '',
+  `mimetype` varchar(100) NOT NULL DEFAULT '',
+  `filesize` int(20) unsigned NOT NULL DEFAULT 0,
+  `filetime` int(11) unsigned NOT NULL DEFAULT 0,
+  `thumbnail` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`attach_id`),
+  KEY `filetime` (`filetime`),
+  KEY `post_msg_id` (`post_msg_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `poster_id` (`poster_id`),
+  KEY `is_orphan` (`is_orphan`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_banlist` (
+  `ban_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `ban_userid` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `ban_ip` varchar(40) NOT NULL DEFAULT '',
+  `ban_email` varchar(100) NOT NULL DEFAULT '',
+  `ban_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `ban_end` int(11) unsigned NOT NULL DEFAULT 0,
+  `ban_exclude` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `ban_reason` varchar(255) NOT NULL DEFAULT '',
+  `ban_give_reason` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`ban_id`),
+  KEY `ban_end` (`ban_end`),
+  KEY `ban_user` (`ban_userid`,`ban_exclude`),
+  KEY `ban_email` (`ban_email`,`ban_exclude`),
+  KEY `ban_ip` (`ban_ip`,`ban_exclude`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bbcodes` (
+  `bbcode_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `bbcode_tag` varchar(16) NOT NULL DEFAULT '',
+  `bbcode_helpline` varchar(255) NOT NULL DEFAULT '',
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_match` text NOT NULL,
+  `bbcode_tpl` mediumtext NOT NULL,
+  `first_pass_match` mediumtext NOT NULL,
+  `first_pass_replace` mediumtext NOT NULL,
+  `second_pass_match` mediumtext NOT NULL,
+  `second_pass_replace` mediumtext NOT NULL,
+  PRIMARY KEY (`bbcode_id`),
+  KEY `display_on_post` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bookmarks` (
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`topic_id`,`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bots` (
+  `bot_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `bot_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `bot_name` varchar(255) NOT NULL DEFAULT '',
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `bot_agent` varchar(255) NOT NULL DEFAULT '',
+  `bot_ip` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`bot_id`),
+  KEY `bot_active` (`bot_active`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_config` (
+  `config_name` varchar(255) NOT NULL DEFAULT '',
+  `config_value` varchar(255) NOT NULL DEFAULT '',
+  `is_dynamic` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`config_name`),
+  KEY `is_dynamic` (`is_dynamic`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_config_text` (
+  `config_name` varchar(255) NOT NULL DEFAULT '',
+  `config_value` mediumtext NOT NULL,
+  PRIMARY KEY (`config_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_confirm` (
+  `confirm_id` char(32) NOT NULL DEFAULT '',
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `confirm_type` tinyint(3) NOT NULL DEFAULT 0,
+  `code` varchar(8) NOT NULL DEFAULT '',
+  `seed` int(10) unsigned NOT NULL DEFAULT 0,
+  `attempts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`session_id`,`confirm_id`),
+  KEY `confirm_type` (`confirm_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_disallow` (
+  `disallow_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `disallow_username` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`disallow_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_drafts` (
+  `draft_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `save_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `draft_subject` varchar(255) NOT NULL DEFAULT '',
+  `draft_message` mediumtext NOT NULL,
+  PRIMARY KEY (`draft_id`),
+  KEY `save_time` (`save_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_ext` (
+  `ext_name` varchar(255) NOT NULL DEFAULT '',
+  `ext_active` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `ext_state` text NOT NULL,
+  UNIQUE KEY `ext_name` (`ext_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_extension_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `cat_id` tinyint(2) NOT NULL DEFAULT 0,
+  `allow_group` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `download_mode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `upload_icon` varchar(255) NOT NULL DEFAULT '',
+  `max_filesize` int(20) unsigned NOT NULL DEFAULT 0,
+  `allowed_forums` text NOT NULL,
+  `allow_in_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_extensions` (
+  `extension_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `extension` varchar(100) NOT NULL DEFAULT '',
+  PRIMARY KEY (`extension_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums` (
+  `forum_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `left_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `right_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_parents` mediumtext NOT NULL,
+  `forum_name` varchar(255) NOT NULL DEFAULT '',
+  `forum_desc` text NOT NULL,
+  `forum_desc_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `forum_desc_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `forum_desc_uid` varchar(8) NOT NULL DEFAULT '',
+  `forum_link` varchar(255) NOT NULL DEFAULT '',
+  `forum_password` varchar(255) NOT NULL DEFAULT '',
+  `forum_style` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_image` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules` text NOT NULL,
+  `forum_rules_link` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `forum_rules_uid` varchar(8) NOT NULL DEFAULT '',
+  `forum_topics_per_page` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_type` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_status` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_last_post_subject` varchar(255) NOT NULL DEFAULT '',
+  `forum_last_post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `forum_last_poster_name` varchar(255) NOT NULL DEFAULT '',
+  `forum_last_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `forum_flags` tinyint(4) NOT NULL DEFAULT 32,
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_indexing` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_icons` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_prune` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `prune_next` int(11) unsigned NOT NULL DEFAULT 0,
+  `prune_days` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `prune_viewed` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `prune_freq` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_subforum_list` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `forum_options` int(20) unsigned NOT NULL DEFAULT 0,
+  `enable_shadow_prune` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `prune_shadow_days` mediumint(8) unsigned NOT NULL DEFAULT 7,
+  `prune_shadow_freq` mediumint(8) unsigned NOT NULL DEFAULT 1,
+  `prune_shadow_next` int(11) NOT NULL DEFAULT 0,
+  `forum_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_approved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_unapproved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`forum_id`),
+  KEY `left_right_id` (`left_id`,`right_id`),
+  KEY `forum_lastpost_id` (`forum_last_post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_access` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `session_id` char(32) NOT NULL DEFAULT '',
+  PRIMARY KEY (`forum_id`,`user_id`,`session_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_track` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `mark_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_watch` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `notify_status` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  KEY `forum_id` (`forum_id`),
+  KEY `user_id` (`user_id`),
+  KEY `notify_stat` (`notify_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_type` tinyint(4) NOT NULL DEFAULT 1,
+  `group_founder_manage` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_skip_auth` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `group_desc` text NOT NULL,
+  `group_desc_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `group_desc_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `group_desc_uid` varchar(8) NOT NULL DEFAULT '',
+  `group_display` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_avatar` varchar(255) NOT NULL DEFAULT '',
+  `group_avatar_type` varchar(255) NOT NULL DEFAULT '',
+  `group_avatar_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `group_avatar_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `group_rank` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_colour` varchar(6) NOT NULL DEFAULT '',
+  `group_sig_chars` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_receive_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_message_limit` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_legend` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_max_recipients` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`group_id`),
+  KEY `group_legend_name` (`group_legend`,`group_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_icons` (
+  `icons_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `icons_url` varchar(255) NOT NULL DEFAULT '',
+  `icons_width` tinyint(4) NOT NULL DEFAULT 0,
+  `icons_height` tinyint(4) NOT NULL DEFAULT 0,
+  `icons_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`icons_id`),
+  KEY `display_on_posting` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_lang` (
+  `lang_id` tinyint(4) NOT NULL AUTO_INCREMENT,
+  `lang_iso` varchar(30) NOT NULL DEFAULT '',
+  `lang_dir` varchar(30) NOT NULL DEFAULT '',
+  `lang_english_name` varchar(100) NOT NULL DEFAULT '',
+  `lang_local_name` varchar(255) NOT NULL DEFAULT '',
+  `lang_author` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`lang_id`),
+  KEY `lang_iso` (`lang_iso`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_log` (
+  `log_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `log_type` tinyint(4) NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `reportee_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `log_ip` varchar(40) NOT NULL DEFAULT '',
+  `log_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `log_operation` text NOT NULL,
+  `log_data` mediumtext NOT NULL,
+  PRIMARY KEY (`log_id`),
+  KEY `log_type` (`log_type`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `reportee_id` (`reportee_id`),
+  KEY `user_id` (`user_id`),
+  KEY `log_time` (`log_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_login_attempts` (
+  `attempt_ip` varchar(40) NOT NULL DEFAULT '',
+  `attempt_browser` varchar(150) NOT NULL DEFAULT '',
+  `attempt_forwarded_for` varchar(255) NOT NULL DEFAULT '',
+  `attempt_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '0',
+  `username_clean` varchar(255) NOT NULL DEFAULT '0',
+  KEY `att_ip` (`attempt_ip`,`attempt_time`),
+  KEY `att_for` (`attempt_forwarded_for`,`attempt_time`),
+  KEY `att_time` (`attempt_time`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_migrations` (
+  `migration_name` varchar(255) NOT NULL DEFAULT '',
+  `migration_depends_on` text NOT NULL,
+  `migration_schema_done` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `migration_data_done` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `migration_data_state` text NOT NULL,
+  `migration_start_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `migration_end_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`migration_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_moderator_cache` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '',
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  KEY `disp_idx` (`display_on_index`),
+  KEY `forum_id` (`forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_modules` (
+  `module_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `module_enabled` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `module_display` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `module_basename` varchar(255) NOT NULL DEFAULT '',
+  `module_class` varchar(10) NOT NULL DEFAULT '',
+  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `left_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `right_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `module_langname` varchar(255) NOT NULL DEFAULT '',
+  `module_mode` varchar(255) NOT NULL DEFAULT '',
+  `module_auth` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`module_id`),
+  KEY `left_right_id` (`left_id`,`right_id`),
+  KEY `module_enabled` (`module_enabled`),
+  KEY `class_left_id` (`module_class`,`left_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_notification_types` (
+  `notification_type_id` smallint(4) unsigned NOT NULL AUTO_INCREMENT,
+  `notification_type_name` varchar(255) NOT NULL DEFAULT '',
+  `notification_type_enabled` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`notification_type_id`),
+  UNIQUE KEY `type` (`notification_type_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_notifications` (
+  `notification_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `notification_type_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `item_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `item_parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `notification_read` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `notification_time` int(11) unsigned NOT NULL DEFAULT 1,
+  `notification_data` text NOT NULL,
+  PRIMARY KEY (`notification_id`),
+  KEY `item_ident` (`notification_type_id`,`item_id`),
+  KEY `user` (`user_id`,`notification_read`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_oauth_accounts` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `provider` varchar(255) NOT NULL DEFAULT '',
+  `oauth_provider_id` text NOT NULL,
+  PRIMARY KEY (`user_id`,`provider`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_oauth_tokens` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `provider` varchar(255) NOT NULL DEFAULT '',
+  `oauth_token` mediumtext NOT NULL,
+  KEY `user_id` (`user_id`),
+  KEY `provider` (`provider`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_poll_options` (
+  `poll_option_id` tinyint(4) NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poll_option_text` text NOT NULL,
+  `poll_option_total` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  KEY `poll_opt_id` (`poll_option_id`),
+  KEY `topic_id` (`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_poll_votes` (
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poll_option_id` tinyint(4) NOT NULL DEFAULT 0,
+  `vote_user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `vote_user_ip` varchar(40) NOT NULL DEFAULT '',
+  KEY `topic_id` (`topic_id`),
+  KEY `vote_user_id` (`vote_user_id`),
+  KEY `vote_user_ip` (`vote_user_ip`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_posts` (
+  `post_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poster_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poster_ip` varchar(40) NOT NULL DEFAULT '',
+  `post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `post_username` varchar(255) NOT NULL DEFAULT '',
+  `post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `post_text` mediumtext NOT NULL,
+  `post_checksum` varchar(32) NOT NULL DEFAULT '',
+  `post_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `post_postcount` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `post_edit_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_edit_reason` varchar(255) NOT NULL DEFAULT '',
+  `post_edit_user` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `post_edit_count` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `post_edit_locked` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `post_visibility` tinyint(3) NOT NULL DEFAULT 0,
+  `post_delete_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_delete_reason` varchar(255) NOT NULL DEFAULT '',
+  `post_delete_user` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`post_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `poster_ip` (`poster_ip`),
+  KEY `poster_id` (`poster_id`),
+  KEY `tid_post_time` (`topic_id`,`post_time`),
+  KEY `post_username` (`post_username`),
+  KEY `post_visibility` (`post_visibility`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs` (
+  `msg_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `root_level` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_ip` varchar(40) NOT NULL DEFAULT '',
+  `message_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `message_subject` varchar(255) NOT NULL DEFAULT '',
+  `message_text` mediumtext NOT NULL,
+  `message_edit_reason` varchar(255) NOT NULL DEFAULT '',
+  `message_edit_user` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `message_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `message_edit_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `message_edit_count` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `to_address` text NOT NULL,
+  `bcc_address` text NOT NULL,
+  `message_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`msg_id`),
+  KEY `author_ip` (`author_ip`),
+  KEY `message_time` (`message_time`),
+  KEY `author_id` (`author_id`),
+  KEY `root_level` (`root_level`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_folder` (
+  `folder_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `folder_name` varchar(255) NOT NULL DEFAULT '',
+  `pm_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`folder_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_rules` (
+  `rule_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_check` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_connection` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_string` varchar(255) NOT NULL DEFAULT '',
+  `rule_user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_action` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_folder_id` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`rule_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_to` (
+  `msg_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `pm_deleted` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_new` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `pm_unread` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `pm_replied` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_marked` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_forwarded` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `folder_id` int(11) NOT NULL DEFAULT 0,
+  KEY `msg_id` (`msg_id`),
+  KEY `author_id` (`author_id`),
+  KEY `usr_flder_id` (`user_id`,`folder_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields` (
+  `field_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `field_name` varchar(255) NOT NULL DEFAULT '',
+  `field_type` varchar(100) NOT NULL DEFAULT '',
+  `field_ident` varchar(20) NOT NULL DEFAULT '',
+  `field_length` varchar(20) NOT NULL DEFAULT '',
+  `field_minlen` varchar(255) NOT NULL DEFAULT '',
+  `field_maxlen` varchar(255) NOT NULL DEFAULT '',
+  `field_novalue` varchar(255) NOT NULL DEFAULT '',
+  `field_default_value` varchar(255) NOT NULL DEFAULT '',
+  `field_validation` varchar(64) NOT NULL DEFAULT '',
+  `field_required` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_reg` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_hide` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_no_view` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_active` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `field_show_profile` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_vt` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_novalue` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_ml` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_is_contact` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_contact_desc` varchar(255) NOT NULL DEFAULT '',
+  `field_contact_url` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`),
+  KEY `fld_type` (`field_type`),
+  KEY `fld_ordr` (`field_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields_data` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `pf_phpbb_interests` mediumtext NOT NULL,
+  `pf_phpbb_occupation` mediumtext NOT NULL,
+  `pf_phpbb_facebook` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_googleplus` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_icq` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_location` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_skype` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_twitter` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_website` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_wlm` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_yahoo` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_youtube` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_aol` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields_lang` (
+  `field_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `field_type` varchar(100) NOT NULL DEFAULT '',
+  `lang_value` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`,`lang_id`,`option_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_lang` (
+  `field_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_name` varchar(255) NOT NULL DEFAULT '',
+  `lang_explain` text NOT NULL,
+  `lang_default_value` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`,`lang_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_ranks` (
+  `rank_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `rank_title` varchar(255) NOT NULL DEFAULT '',
+  `rank_min` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rank_special` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `rank_image` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`rank_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_reports` (
+  `report_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `reason_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `report_closed` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `report_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `report_text` mediumtext NOT NULL,
+  `pm_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `reported_post_enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `reported_post_enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `reported_post_enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `reported_post_text` mediumtext NOT NULL,
+  `reported_post_uid` varchar(8) NOT NULL DEFAULT '',
+  `reported_post_bitfield` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`report_id`),
+  KEY `post_id` (`post_id`),
+  KEY `pm_id` (`pm_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_reports_reasons` (
+  `reason_id` smallint(4) unsigned NOT NULL AUTO_INCREMENT,
+  `reason_title` varchar(255) NOT NULL DEFAULT '',
+  `reason_description` mediumtext NOT NULL,
+  `reason_order` smallint(4) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`reason_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_results` (
+  `search_key` varchar(32) NOT NULL DEFAULT '',
+  `search_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `search_keywords` mediumtext NOT NULL,
+  `search_authors` mediumtext NOT NULL,
+  PRIMARY KEY (`search_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_wordlist` (
+  `word_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `word_text` varchar(255) NOT NULL DEFAULT '',
+  `word_common` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `word_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`word_id`),
+  UNIQUE KEY `wrd_txt` (`word_text`),
+  KEY `wrd_cnt` (`word_count`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_wordmatch` (
+  `post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `word_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `title_match` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  UNIQUE KEY `un_mtch` (`word_id`,`post_id`,`title_match`),
+  KEY `word_id` (`word_id`),
+  KEY `post_id` (`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sessions` (
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `session_user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `session_last_visit` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_ip` varchar(40) NOT NULL DEFAULT '',
+  `session_browser` varchar(150) NOT NULL DEFAULT '',
+  `session_forwarded_for` varchar(255) NOT NULL DEFAULT '',
+  `session_page` varchar(255) NOT NULL DEFAULT '',
+  `session_viewonline` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `session_autologin` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `session_admin` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `session_forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`session_id`),
+  KEY `session_time` (`session_time`),
+  KEY `session_user_id` (`session_user_id`),
+  KEY `session_fid` (`session_forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sessions_keys` (
+  `key_id` char(32) NOT NULL DEFAULT '',
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `last_ip` varchar(40) NOT NULL DEFAULT '',
+  `last_login` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`key_id`,`user_id`),
+  KEY `last_login` (`last_login`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sitelist` (
+  `site_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `site_ip` varchar(40) NOT NULL DEFAULT '',
+  `site_hostname` varchar(255) NOT NULL DEFAULT '',
+  `ip_exclude` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`site_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_smilies` (
+  `smiley_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(50) NOT NULL DEFAULT '',
+  `emotion` varchar(255) NOT NULL DEFAULT '',
+  `smiley_url` varchar(50) NOT NULL DEFAULT '',
+  `smiley_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `smiley_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `smiley_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`smiley_id`),
+  KEY `display_on_post` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_styles` (
+  `style_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `style_name` varchar(255) NOT NULL DEFAULT '',
+  `style_copyright` varchar(255) NOT NULL DEFAULT '',
+  `style_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `style_path` varchar(100) NOT NULL DEFAULT '',
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT 'kNg=',
+  `style_parent_id` int(4) unsigned NOT NULL DEFAULT 0,
+  `style_parent_tree` text NOT NULL,
+  PRIMARY KEY (`style_id`),
+  UNIQUE KEY `style_name` (`style_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_teampage` (
+  `teampage_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `teampage_name` varchar(255) NOT NULL DEFAULT '',
+  `teampage_position` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `teampage_parent` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`teampage_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics` (
+  `topic_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_title` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `topic_poster` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_time_limit` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_views` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_status` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_type` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_first_post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_first_poster_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `topic_first_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `topic_last_post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_last_poster_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_last_poster_name` varchar(255) NOT NULL DEFAULT '',
+  `topic_last_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `topic_last_post_subject` varchar(255) NOT NULL DEFAULT '',
+  `topic_last_post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_last_view_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_moved_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_bumped` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_bumper` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poll_title` varchar(255) NOT NULL DEFAULT '',
+  `poll_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_length` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_max_options` tinyint(4) NOT NULL DEFAULT 1,
+  `poll_last_vote` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_vote_change` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_visibility` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_delete_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_delete_reason` varchar(255) NOT NULL DEFAULT '',
+  `topic_delete_user` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`topic_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `forum_id_type` (`forum_id`,`topic_type`),
+  KEY `last_post_time` (`topic_last_post_time`),
+  KEY `fid_time_moved` (`forum_id`,`topic_last_post_time`,`topic_moved_id`),
+  KEY `topic_visibility` (`topic_visibility`),
+  KEY `forum_vis_last` (`forum_id`,`topic_visibility`,`topic_last_post_id`),
+  KEY `latest_topics` (`forum_id`,`topic_last_post_time`,`topic_last_post_id`,`topic_moved_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_posted` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_posted` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_track` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `mark_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`topic_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_watch` (
+  `topic_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `notify_status` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  KEY `topic_id` (`topic_id`),
+  KEY `user_id` (`user_id`),
+  KEY `notify_stat` (`notify_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_user_group` (
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_leader` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_pending` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  KEY `group_id` (`group_id`),
+  KEY `user_id` (`user_id`),
+  KEY `group_leader` (`group_leader`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_user_notifications` (
+  `item_type` varchar(255) NOT NULL DEFAULT '',
+  `item_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `method` varchar(255) NOT NULL DEFAULT '',
+  `notify` tinyint(1) unsigned NOT NULL DEFAULT 1
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_users` (
+  `user_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_type` tinyint(2) NOT NULL DEFAULT 0,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 3,
+  `user_permissions` mediumtext NOT NULL,
+  `user_perm_from` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_ip` varchar(40) NOT NULL DEFAULT '',
+  `user_regdate` int(11) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '',
+  `username_clean` varchar(255) NOT NULL DEFAULT '',
+  `user_password` varchar(255) NOT NULL DEFAULT '',
+  `user_passchg` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_email` varchar(100) NOT NULL DEFAULT '',
+  `user_email_hash` bigint(20) NOT NULL DEFAULT 0,
+  `user_birthday` varchar(10) NOT NULL DEFAULT '',
+  `user_lastvisit` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastmark` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastpost_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastpage` varchar(200) NOT NULL DEFAULT '',
+  `user_last_confirm_key` varchar(10) NOT NULL DEFAULT '',
+  `user_last_search` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_warnings` tinyint(4) NOT NULL DEFAULT 0,
+  `user_last_warning` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_login_attempts` tinyint(4) NOT NULL DEFAULT 0,
+  `user_inactive_reason` tinyint(2) NOT NULL DEFAULT 0,
+  `user_inactive_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_posts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_lang` varchar(30) NOT NULL DEFAULT '',
+  `user_timezone` varchar(100) NOT NULL DEFAULT '',
+  `user_dateformat` varchar(64) NOT NULL DEFAULT 'd M Y H:i',
+  `user_style` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_rank` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_colour` varchar(6) NOT NULL DEFAULT '',
+  `user_new_privmsg` int(4) NOT NULL DEFAULT 0,
+  `user_unread_privmsg` int(4) NOT NULL DEFAULT 0,
+  `user_last_privmsg` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_message_rules` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_full_folder` int(11) NOT NULL DEFAULT -3,
+  `user_emailtime` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_topic_show_days` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_topic_sortby_type` varchar(1) NOT NULL DEFAULT 't',
+  `user_topic_sortby_dir` varchar(1) NOT NULL DEFAULT 'd',
+  `user_post_show_days` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_post_sortby_type` varchar(1) NOT NULL DEFAULT 't',
+  `user_post_sortby_dir` varchar(1) NOT NULL DEFAULT 'a',
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_notify_pm` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_notify_type` tinyint(4) NOT NULL DEFAULT 0,
+  `user_allow_pm` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_viewonline` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_viewemail` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_massemail` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_options` int(11) unsigned NOT NULL DEFAULT 230271,
+  `user_avatar` varchar(255) NOT NULL DEFAULT '',
+  `user_avatar_type` varchar(255) NOT NULL DEFAULT '',
+  `user_avatar_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_avatar_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_sig` mediumtext NOT NULL,
+  `user_sig_bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `user_sig_bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `user_jabber` varchar(255) NOT NULL DEFAULT '',
+  `user_actkey` varchar(32) NOT NULL DEFAULT '',
+  `user_newpasswd` varchar(255) NOT NULL DEFAULT '',
+  `user_form_salt` varchar(32) NOT NULL DEFAULT '',
+  `user_new` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_reminded` tinyint(4) NOT NULL DEFAULT 0,
+  `user_reminded_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`),
+  UNIQUE KEY `username_clean` (`username_clean`),
+  KEY `user_birthday` (`user_birthday`),
+  KEY `user_email_hash` (`user_email_hash`),
+  KEY `user_type` (`user_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_warnings` (
+  `warning_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `post_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `log_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `warning_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`warning_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_words` (
+  `word_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `word` varchar(255) NOT NULL DEFAULT '',
+  `replacement` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`word_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_zebra` (
+  `user_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `zebra_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `friend` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `foe` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`zebra_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;

--- a/migrations/converters/spec/fixtures/phpbb/schemas/3.1/postgres.sql
+++ b/migrations/converters/spec/fixtures/phpbb/schemas/3.1/postgres.sql
@@ -1,0 +1,3245 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict GTMkagd19OiQgHar1zVSRTpFkcQivVqRjGIdyGD3gn3JkvPhNezeNTC4M5koogW
+
+-- Dumped from database version 16.14 (Debian 16.14-1.pgdg13+1)
+-- Dumped by pg_dump version 16.14 (Debian 16.14-1.pgdg13+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: varchar_ci; Type: DOMAIN; Schema: public; Owner: -
+--
+
+CREATE DOMAIN public.varchar_ci AS character varying(255) NOT NULL DEFAULT ''::character varying;
+
+
+--
+-- Name: _varchar_ci_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) = LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_greater_equals(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_greater_equals(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) >= LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_greater_than(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_greater_than(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) > LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_less_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_less_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) <= LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_less_than(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_less_than(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) < LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_not_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_not_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) != LOWER($2)$_$;
+
+
+--
+-- Name: <; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.< (
+    FUNCTION = public._varchar_ci_less_than,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.>),
+    NEGATOR = OPERATOR(public.>=),
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+--
+-- Name: <=; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.<= (
+    FUNCTION = public._varchar_ci_less_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.>=),
+    NEGATOR = OPERATOR(public.>),
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+--
+-- Name: <>; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.<> (
+    FUNCTION = public._varchar_ci_not_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<>),
+    NEGATOR = OPERATOR(public.=),
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+
+
+--
+-- Name: =; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.= (
+    FUNCTION = public._varchar_ci_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.=),
+    NEGATOR = OPERATOR(public.<>),
+    MERGES,
+    HASHES,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel
+);
+
+
+--
+-- Name: >; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.> (
+    FUNCTION = public._varchar_ci_greater_than,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<),
+    NEGATOR = OPERATOR(public.<=),
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+--
+-- Name: >=; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.>= (
+    FUNCTION = public._varchar_ci_greater_equals,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<=),
+    NEGATOR = OPERATOR(public.<),
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: phpbb_acl_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_groups (
+    group_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_role_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_groups_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_auth_role_id_check CHECK ((auth_role_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_group_id_check CHECK ((group_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_options_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_acl_options_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_acl_options; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_options (
+    auth_option_id integer DEFAULT nextval('public.phpbb_acl_options_seq'::regclass) NOT NULL,
+    auth_option character varying(50) DEFAULT ''::character varying NOT NULL,
+    is_global smallint DEFAULT '0'::smallint NOT NULL,
+    is_local smallint DEFAULT '0'::smallint NOT NULL,
+    founder_only smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_options_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_options_founder_only_check CHECK ((founder_only >= 0)),
+    CONSTRAINT phpbb_acl_options_is_global_check CHECK ((is_global >= 0)),
+    CONSTRAINT phpbb_acl_options_is_local_check CHECK ((is_local >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_roles_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_acl_roles_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_acl_roles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_roles (
+    role_id integer DEFAULT nextval('public.phpbb_acl_roles_seq'::regclass) NOT NULL,
+    role_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    role_description character varying(4000) DEFAULT ''::character varying NOT NULL,
+    role_type character varying(10) DEFAULT ''::character varying NOT NULL,
+    role_order smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_roles_role_id_check CHECK ((role_id >= 0)),
+    CONSTRAINT phpbb_acl_roles_role_order_check CHECK ((role_order >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_roles_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_roles_data (
+    role_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_roles_data_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_roles_data_role_id_check CHECK ((role_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_users (
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_role_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_users_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_users_auth_role_id_check CHECK ((auth_role_id >= 0)),
+    CONSTRAINT phpbb_acl_users_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_acl_users_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_attachments_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_attachments_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_attachments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_attachments (
+    attach_id integer DEFAULT nextval('public.phpbb_attachments_seq'::regclass) NOT NULL,
+    post_msg_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    in_message smallint DEFAULT '0'::smallint NOT NULL,
+    poster_id integer DEFAULT 0 NOT NULL,
+    is_orphan smallint DEFAULT '1'::smallint NOT NULL,
+    physical_filename character varying(255) DEFAULT ''::character varying NOT NULL,
+    real_filename character varying(255) DEFAULT ''::character varying NOT NULL,
+    download_count integer DEFAULT 0 NOT NULL,
+    attach_comment character varying(4000) DEFAULT ''::character varying NOT NULL,
+    extension character varying(100) DEFAULT ''::character varying NOT NULL,
+    mimetype character varying(100) DEFAULT ''::character varying NOT NULL,
+    filesize integer DEFAULT 0 NOT NULL,
+    filetime integer DEFAULT 0 NOT NULL,
+    thumbnail smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_attachments_attach_id_check CHECK ((attach_id >= 0)),
+    CONSTRAINT phpbb_attachments_download_count_check CHECK ((download_count >= 0)),
+    CONSTRAINT phpbb_attachments_filesize_check CHECK ((filesize >= 0)),
+    CONSTRAINT phpbb_attachments_filetime_check CHECK ((filetime >= 0)),
+    CONSTRAINT phpbb_attachments_in_message_check CHECK ((in_message >= 0)),
+    CONSTRAINT phpbb_attachments_is_orphan_check CHECK ((is_orphan >= 0)),
+    CONSTRAINT phpbb_attachments_post_msg_id_check CHECK ((post_msg_id >= 0)),
+    CONSTRAINT phpbb_attachments_poster_id_check CHECK ((poster_id >= 0)),
+    CONSTRAINT phpbb_attachments_thumbnail_check CHECK ((thumbnail >= 0)),
+    CONSTRAINT phpbb_attachments_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_banlist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_banlist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_banlist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_banlist (
+    ban_id integer DEFAULT nextval('public.phpbb_banlist_seq'::regclass) NOT NULL,
+    ban_userid integer DEFAULT 0 NOT NULL,
+    ban_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    ban_email character varying(100) DEFAULT ''::character varying NOT NULL,
+    ban_start integer DEFAULT 0 NOT NULL,
+    ban_end integer DEFAULT 0 NOT NULL,
+    ban_exclude smallint DEFAULT '0'::smallint NOT NULL,
+    ban_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    ban_give_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_banlist_ban_end_check CHECK ((ban_end >= 0)),
+    CONSTRAINT phpbb_banlist_ban_exclude_check CHECK ((ban_exclude >= 0)),
+    CONSTRAINT phpbb_banlist_ban_id_check CHECK ((ban_id >= 0)),
+    CONSTRAINT phpbb_banlist_ban_start_check CHECK ((ban_start >= 0)),
+    CONSTRAINT phpbb_banlist_ban_userid_check CHECK ((ban_userid >= 0))
+);
+
+
+--
+-- Name: phpbb_bbcodes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bbcodes (
+    bbcode_id smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_tag character varying(16) DEFAULT ''::character varying NOT NULL,
+    bbcode_helpline character varying(255) DEFAULT ''::character varying NOT NULL,
+    display_on_posting smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_match character varying(4000) DEFAULT ''::character varying NOT NULL,
+    bbcode_tpl text DEFAULT ''::text NOT NULL,
+    first_pass_match text DEFAULT ''::text NOT NULL,
+    first_pass_replace text DEFAULT ''::text NOT NULL,
+    second_pass_match text DEFAULT ''::text NOT NULL,
+    second_pass_replace text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_bbcodes_bbcode_id_check CHECK ((bbcode_id >= 0)),
+    CONSTRAINT phpbb_bbcodes_display_on_posting_check CHECK ((display_on_posting >= 0))
+);
+
+
+--
+-- Name: phpbb_bookmarks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bookmarks (
+    topic_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_bookmarks_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_bookmarks_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_bots_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_bots_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_bots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bots (
+    bot_id integer DEFAULT nextval('public.phpbb_bots_seq'::regclass) NOT NULL,
+    bot_active smallint DEFAULT '1'::smallint NOT NULL,
+    bot_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    bot_agent character varying(255) DEFAULT ''::character varying NOT NULL,
+    bot_ip character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_bots_bot_active_check CHECK ((bot_active >= 0)),
+    CONSTRAINT phpbb_bots_bot_id_check CHECK ((bot_id >= 0)),
+    CONSTRAINT phpbb_bots_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_config; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_config (
+    config_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    config_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    is_dynamic smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_config_is_dynamic_check CHECK ((is_dynamic >= 0))
+);
+
+
+--
+-- Name: phpbb_config_text; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_config_text (
+    config_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    config_value text DEFAULT ''::text NOT NULL
+);
+
+
+--
+-- Name: phpbb_confirm; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_confirm (
+    confirm_id character(32) DEFAULT ''::bpchar NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    confirm_type smallint DEFAULT '0'::smallint NOT NULL,
+    code character varying(8) DEFAULT ''::character varying NOT NULL,
+    seed integer DEFAULT 0 NOT NULL,
+    attempts integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_confirm_attempts_check CHECK ((attempts >= 0)),
+    CONSTRAINT phpbb_confirm_seed_check CHECK ((seed >= 0))
+);
+
+
+--
+-- Name: phpbb_disallow_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_disallow_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_disallow; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_disallow (
+    disallow_id integer DEFAULT nextval('public.phpbb_disallow_seq'::regclass) NOT NULL,
+    disallow_username character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_disallow_disallow_id_check CHECK ((disallow_id >= 0))
+);
+
+
+--
+-- Name: phpbb_drafts_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_drafts_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_drafts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_drafts (
+    draft_id integer DEFAULT nextval('public.phpbb_drafts_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    save_time integer DEFAULT 0 NOT NULL,
+    draft_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    draft_message text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_drafts_draft_id_check CHECK ((draft_id >= 0)),
+    CONSTRAINT phpbb_drafts_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_drafts_save_time_check CHECK ((save_time >= 0)),
+    CONSTRAINT phpbb_drafts_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_drafts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_ext; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_ext (
+    ext_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    ext_active smallint DEFAULT '0'::smallint NOT NULL,
+    ext_state character varying(8000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_ext_ext_active_check CHECK ((ext_active >= 0))
+);
+
+
+--
+-- Name: phpbb_extension_groups_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_extension_groups_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_extension_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_extension_groups (
+    group_id integer DEFAULT nextval('public.phpbb_extension_groups_seq'::regclass) NOT NULL,
+    group_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    cat_id smallint DEFAULT '0'::smallint NOT NULL,
+    allow_group smallint DEFAULT '0'::smallint NOT NULL,
+    download_mode smallint DEFAULT '1'::smallint NOT NULL,
+    upload_icon character varying(255) DEFAULT ''::character varying NOT NULL,
+    max_filesize integer DEFAULT 0 NOT NULL,
+    allowed_forums character varying(8000) DEFAULT ''::character varying NOT NULL,
+    allow_in_pm smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_extension_groups_allow_group_check CHECK ((allow_group >= 0)),
+    CONSTRAINT phpbb_extension_groups_allow_in_pm_check CHECK ((allow_in_pm >= 0)),
+    CONSTRAINT phpbb_extension_groups_download_mode_check CHECK ((download_mode >= 0)),
+    CONSTRAINT phpbb_extension_groups_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_extension_groups_max_filesize_check CHECK ((max_filesize >= 0))
+);
+
+
+--
+-- Name: phpbb_extensions_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_extensions_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_extensions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_extensions (
+    extension_id integer DEFAULT nextval('public.phpbb_extensions_seq'::regclass) NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    extension character varying(100) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_extensions_extension_id_check CHECK ((extension_id >= 0)),
+    CONSTRAINT phpbb_extensions_group_id_check CHECK ((group_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_forums_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_forums; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums (
+    forum_id integer DEFAULT nextval('public.phpbb_forums_seq'::regclass) NOT NULL,
+    parent_id integer DEFAULT 0 NOT NULL,
+    left_id integer DEFAULT 0 NOT NULL,
+    right_id integer DEFAULT 0 NOT NULL,
+    forum_parents text DEFAULT ''::text NOT NULL,
+    forum_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_desc character varying(4000) DEFAULT ''::character varying NOT NULL,
+    forum_desc_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_desc_options integer DEFAULT 7 NOT NULL,
+    forum_desc_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    forum_link character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_password character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_style integer DEFAULT 0 NOT NULL,
+    forum_image character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules character varying(4000) DEFAULT ''::character varying NOT NULL,
+    forum_rules_link character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules_options integer DEFAULT 7 NOT NULL,
+    forum_rules_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    forum_topics_per_page smallint DEFAULT '0'::smallint NOT NULL,
+    forum_type smallint DEFAULT '0'::smallint NOT NULL,
+    forum_status smallint DEFAULT '0'::smallint NOT NULL,
+    forum_last_post_id integer DEFAULT 0 NOT NULL,
+    forum_last_poster_id integer DEFAULT 0 NOT NULL,
+    forum_last_post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_last_post_time integer DEFAULT 0 NOT NULL,
+    forum_last_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_last_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    forum_flags smallint DEFAULT '32'::smallint NOT NULL,
+    display_on_index smallint DEFAULT '1'::smallint NOT NULL,
+    enable_indexing smallint DEFAULT '1'::smallint NOT NULL,
+    enable_icons smallint DEFAULT '1'::smallint NOT NULL,
+    enable_prune smallint DEFAULT '0'::smallint NOT NULL,
+    prune_next integer DEFAULT 0 NOT NULL,
+    prune_days integer DEFAULT 0 NOT NULL,
+    prune_viewed integer DEFAULT 0 NOT NULL,
+    prune_freq integer DEFAULT 0 NOT NULL,
+    display_subforum_list smallint DEFAULT '1'::smallint NOT NULL,
+    forum_options integer DEFAULT 0 NOT NULL,
+    enable_shadow_prune smallint DEFAULT '0'::smallint NOT NULL,
+    prune_shadow_days integer DEFAULT 7 NOT NULL,
+    prune_shadow_freq integer DEFAULT 1 NOT NULL,
+    prune_shadow_next integer DEFAULT 0 NOT NULL,
+    forum_posts_approved integer DEFAULT 0 NOT NULL,
+    forum_posts_unapproved integer DEFAULT 0 NOT NULL,
+    forum_posts_softdeleted integer DEFAULT 0 NOT NULL,
+    forum_topics_approved integer DEFAULT 0 NOT NULL,
+    forum_topics_unapproved integer DEFAULT 0 NOT NULL,
+    forum_topics_softdeleted integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_forums_display_on_index_check CHECK ((display_on_index >= 0)),
+    CONSTRAINT phpbb_forums_display_subforum_list_check CHECK ((display_subforum_list >= 0)),
+    CONSTRAINT phpbb_forums_enable_icons_check CHECK ((enable_icons >= 0)),
+    CONSTRAINT phpbb_forums_enable_indexing_check CHECK ((enable_indexing >= 0)),
+    CONSTRAINT phpbb_forums_enable_prune_check CHECK ((enable_prune >= 0)),
+    CONSTRAINT phpbb_forums_enable_shadow_prune_check CHECK ((enable_shadow_prune >= 0)),
+    CONSTRAINT phpbb_forums_forum_desc_options_check CHECK ((forum_desc_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_post_id_check CHECK ((forum_last_post_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_post_time_check CHECK ((forum_last_post_time >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_poster_id_check CHECK ((forum_last_poster_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_options_check CHECK ((forum_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_approved_check CHECK ((forum_posts_approved >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_softdeleted_check CHECK ((forum_posts_softdeleted >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_unapproved_check CHECK ((forum_posts_unapproved >= 0)),
+    CONSTRAINT phpbb_forums_forum_rules_options_check CHECK ((forum_rules_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_style_check CHECK ((forum_style >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_approved_check CHECK ((forum_topics_approved >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_softdeleted_check CHECK ((forum_topics_softdeleted >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_unapproved_check CHECK ((forum_topics_unapproved >= 0)),
+    CONSTRAINT phpbb_forums_left_id_check CHECK ((left_id >= 0)),
+    CONSTRAINT phpbb_forums_parent_id_check CHECK ((parent_id >= 0)),
+    CONSTRAINT phpbb_forums_prune_days_check CHECK ((prune_days >= 0)),
+    CONSTRAINT phpbb_forums_prune_freq_check CHECK ((prune_freq >= 0)),
+    CONSTRAINT phpbb_forums_prune_next_check CHECK ((prune_next >= 0)),
+    CONSTRAINT phpbb_forums_prune_shadow_days_check CHECK ((prune_shadow_days >= 0)),
+    CONSTRAINT phpbb_forums_prune_shadow_freq_check CHECK ((prune_shadow_freq >= 0)),
+    CONSTRAINT phpbb_forums_prune_viewed_check CHECK ((prune_viewed >= 0)),
+    CONSTRAINT phpbb_forums_right_id_check CHECK ((right_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_access; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_access (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    CONSTRAINT phpbb_forums_access_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_access_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_track; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_track (
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    mark_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_forums_track_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_track_mark_time_check CHECK ((mark_time >= 0)),
+    CONSTRAINT phpbb_forums_track_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_watch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_watch (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notify_status smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_forums_watch_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_watch_notify_status_check CHECK ((notify_status >= 0)),
+    CONSTRAINT phpbb_forums_watch_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_groups_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_groups_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_groups (
+    group_id integer DEFAULT nextval('public.phpbb_groups_seq'::regclass) NOT NULL,
+    group_type smallint DEFAULT '1'::smallint NOT NULL,
+    group_founder_manage smallint DEFAULT '0'::smallint NOT NULL,
+    group_skip_auth smallint DEFAULT '0'::smallint NOT NULL,
+    group_name public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    group_desc character varying(4000) DEFAULT ''::character varying NOT NULL,
+    group_desc_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_desc_options integer DEFAULT 7 NOT NULL,
+    group_desc_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    group_display smallint DEFAULT '0'::smallint NOT NULL,
+    group_avatar character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_avatar_type character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_avatar_width smallint DEFAULT '0'::smallint NOT NULL,
+    group_avatar_height smallint DEFAULT '0'::smallint NOT NULL,
+    group_rank integer DEFAULT 0 NOT NULL,
+    group_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    group_sig_chars integer DEFAULT 0 NOT NULL,
+    group_receive_pm smallint DEFAULT '0'::smallint NOT NULL,
+    group_message_limit integer DEFAULT 0 NOT NULL,
+    group_legend integer DEFAULT 0 NOT NULL,
+    group_max_recipients integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_groups_group_avatar_height_check CHECK ((group_avatar_height >= 0)),
+    CONSTRAINT phpbb_groups_group_avatar_width_check CHECK ((group_avatar_width >= 0)),
+    CONSTRAINT phpbb_groups_group_desc_options_check CHECK ((group_desc_options >= 0)),
+    CONSTRAINT phpbb_groups_group_display_check CHECK ((group_display >= 0)),
+    CONSTRAINT phpbb_groups_group_founder_manage_check CHECK ((group_founder_manage >= 0)),
+    CONSTRAINT phpbb_groups_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_groups_group_legend_check CHECK ((group_legend >= 0)),
+    CONSTRAINT phpbb_groups_group_max_recipients_check CHECK ((group_max_recipients >= 0)),
+    CONSTRAINT phpbb_groups_group_message_limit_check CHECK ((group_message_limit >= 0)),
+    CONSTRAINT phpbb_groups_group_rank_check CHECK ((group_rank >= 0)),
+    CONSTRAINT phpbb_groups_group_receive_pm_check CHECK ((group_receive_pm >= 0)),
+    CONSTRAINT phpbb_groups_group_sig_chars_check CHECK ((group_sig_chars >= 0)),
+    CONSTRAINT phpbb_groups_group_skip_auth_check CHECK ((group_skip_auth >= 0))
+);
+
+
+--
+-- Name: phpbb_icons_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_icons_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_icons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_icons (
+    icons_id integer DEFAULT nextval('public.phpbb_icons_seq'::regclass) NOT NULL,
+    icons_url character varying(255) DEFAULT ''::character varying NOT NULL,
+    icons_width smallint DEFAULT '0'::smallint NOT NULL,
+    icons_height smallint DEFAULT '0'::smallint NOT NULL,
+    icons_order integer DEFAULT 0 NOT NULL,
+    display_on_posting smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_icons_display_on_posting_check CHECK ((display_on_posting >= 0)),
+    CONSTRAINT phpbb_icons_icons_id_check CHECK ((icons_id >= 0)),
+    CONSTRAINT phpbb_icons_icons_order_check CHECK ((icons_order >= 0))
+);
+
+
+--
+-- Name: phpbb_lang_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_lang_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_lang (
+    lang_id smallint DEFAULT nextval('public.phpbb_lang_seq'::regclass) NOT NULL,
+    lang_iso character varying(30) DEFAULT ''::character varying NOT NULL,
+    lang_dir character varying(30) DEFAULT ''::character varying NOT NULL,
+    lang_english_name character varying(100) DEFAULT ''::character varying NOT NULL,
+    lang_local_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    lang_author character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+--
+-- Name: phpbb_log_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_log_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_log (
+    log_id integer DEFAULT nextval('public.phpbb_log_seq'::regclass) NOT NULL,
+    log_type smallint DEFAULT '0'::smallint NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    reportee_id integer DEFAULT 0 NOT NULL,
+    log_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    log_time integer DEFAULT 0 NOT NULL,
+    log_operation character varying(4000) DEFAULT ''::character varying NOT NULL,
+    log_data text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_log_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_log_log_id_check CHECK ((log_id >= 0)),
+    CONSTRAINT phpbb_log_log_time_check CHECK ((log_time >= 0)),
+    CONSTRAINT phpbb_log_reportee_id_check CHECK ((reportee_id >= 0)),
+    CONSTRAINT phpbb_log_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_log_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_login_attempts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_login_attempts (
+    attempt_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    attempt_browser character varying(150) DEFAULT ''::character varying NOT NULL,
+    attempt_forwarded_for character varying(255) DEFAULT ''::character varying NOT NULL,
+    attempt_time integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    username character varying(255) DEFAULT '0'::character varying NOT NULL,
+    username_clean public.varchar_ci DEFAULT '0'::character varying NOT NULL,
+    CONSTRAINT phpbb_login_attempts_attempt_time_check CHECK ((attempt_time >= 0)),
+    CONSTRAINT phpbb_login_attempts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_migrations (
+    migration_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    migration_depends_on character varying(8000) DEFAULT ''::character varying NOT NULL,
+    migration_schema_done smallint DEFAULT '0'::smallint NOT NULL,
+    migration_data_done smallint DEFAULT '0'::smallint NOT NULL,
+    migration_data_state character varying(8000) DEFAULT ''::character varying NOT NULL,
+    migration_start_time integer DEFAULT 0 NOT NULL,
+    migration_end_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_migrations_migration_data_done_check CHECK ((migration_data_done >= 0)),
+    CONSTRAINT phpbb_migrations_migration_end_time_check CHECK ((migration_end_time >= 0)),
+    CONSTRAINT phpbb_migrations_migration_schema_done_check CHECK ((migration_schema_done >= 0)),
+    CONSTRAINT phpbb_migrations_migration_start_time_check CHECK ((migration_start_time >= 0))
+);
+
+
+--
+-- Name: phpbb_moderator_cache; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_moderator_cache (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    username character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    group_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    display_on_index smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_moderator_cache_display_on_index_check CHECK ((display_on_index >= 0)),
+    CONSTRAINT phpbb_moderator_cache_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_moderator_cache_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_moderator_cache_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_modules_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_modules_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_modules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_modules (
+    module_id integer DEFAULT nextval('public.phpbb_modules_seq'::regclass) NOT NULL,
+    module_enabled smallint DEFAULT '1'::smallint NOT NULL,
+    module_display smallint DEFAULT '1'::smallint NOT NULL,
+    module_basename character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_class character varying(10) DEFAULT ''::character varying NOT NULL,
+    parent_id integer DEFAULT 0 NOT NULL,
+    left_id integer DEFAULT 0 NOT NULL,
+    right_id integer DEFAULT 0 NOT NULL,
+    module_langname character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_mode character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_auth character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_modules_left_id_check CHECK ((left_id >= 0)),
+    CONSTRAINT phpbb_modules_module_display_check CHECK ((module_display >= 0)),
+    CONSTRAINT phpbb_modules_module_enabled_check CHECK ((module_enabled >= 0)),
+    CONSTRAINT phpbb_modules_module_id_check CHECK ((module_id >= 0)),
+    CONSTRAINT phpbb_modules_parent_id_check CHECK ((parent_id >= 0)),
+    CONSTRAINT phpbb_modules_right_id_check CHECK ((right_id >= 0))
+);
+
+
+--
+-- Name: phpbb_notification_types_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_notification_types_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_notification_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_notification_types (
+    notification_type_id smallint DEFAULT nextval('public.phpbb_notification_types_seq'::regclass) NOT NULL,
+    notification_type_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    notification_type_enabled smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_notification_types_notification_type_enabled_check CHECK ((notification_type_enabled >= 0)),
+    CONSTRAINT phpbb_notification_types_notification_type_id_check CHECK ((notification_type_id >= 0))
+);
+
+
+--
+-- Name: phpbb_notifications_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_notifications_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_notifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_notifications (
+    notification_id integer DEFAULT nextval('public.phpbb_notifications_seq'::regclass) NOT NULL,
+    notification_type_id smallint DEFAULT '0'::smallint NOT NULL,
+    item_id integer DEFAULT 0 NOT NULL,
+    item_parent_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notification_read smallint DEFAULT '0'::smallint NOT NULL,
+    notification_time integer DEFAULT 1 NOT NULL,
+    notification_data character varying(4000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_notifications_item_id_check CHECK ((item_id >= 0)),
+    CONSTRAINT phpbb_notifications_item_parent_id_check CHECK ((item_parent_id >= 0)),
+    CONSTRAINT phpbb_notifications_notification_id_check CHECK ((notification_id >= 0)),
+    CONSTRAINT phpbb_notifications_notification_read_check CHECK ((notification_read >= 0)),
+    CONSTRAINT phpbb_notifications_notification_time_check CHECK ((notification_time >= 0)),
+    CONSTRAINT phpbb_notifications_notification_type_id_check CHECK ((notification_type_id >= 0)),
+    CONSTRAINT phpbb_notifications_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_oauth_accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_oauth_accounts (
+    user_id integer DEFAULT 0 NOT NULL,
+    provider character varying(255) DEFAULT ''::character varying NOT NULL,
+    oauth_provider_id character varying(4000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_oauth_accounts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_oauth_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_oauth_tokens (
+    user_id integer DEFAULT 0 NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    provider character varying(255) DEFAULT ''::character varying NOT NULL,
+    oauth_token text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_oauth_tokens_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_poll_options; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_poll_options (
+    poll_option_id smallint DEFAULT '0'::smallint NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    poll_option_text character varying(4000) DEFAULT ''::character varying NOT NULL,
+    poll_option_total integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_poll_options_poll_option_total_check CHECK ((poll_option_total >= 0)),
+    CONSTRAINT phpbb_poll_options_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_poll_votes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_poll_votes (
+    topic_id integer DEFAULT 0 NOT NULL,
+    poll_option_id smallint DEFAULT '0'::smallint NOT NULL,
+    vote_user_id integer DEFAULT 0 NOT NULL,
+    vote_user_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_poll_votes_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_poll_votes_vote_user_id_check CHECK ((vote_user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_posts_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_posts_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_posts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_posts (
+    post_id integer DEFAULT nextval('public.phpbb_posts_seq'::regclass) NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    poster_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    poster_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    post_time integer DEFAULT 0 NOT NULL,
+    post_reported smallint DEFAULT '0'::smallint NOT NULL,
+    enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    enable_sig smallint DEFAULT '1'::smallint NOT NULL,
+    post_username character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_text text DEFAULT ''::text NOT NULL,
+    post_checksum character varying(32) DEFAULT ''::character varying NOT NULL,
+    post_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    post_postcount smallint DEFAULT '1'::smallint NOT NULL,
+    post_edit_time integer DEFAULT 0 NOT NULL,
+    post_edit_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_edit_user integer DEFAULT 0 NOT NULL,
+    post_edit_count smallint DEFAULT '0'::smallint NOT NULL,
+    post_edit_locked smallint DEFAULT '0'::smallint NOT NULL,
+    post_visibility smallint DEFAULT '0'::smallint NOT NULL,
+    post_delete_time integer DEFAULT 0 NOT NULL,
+    post_delete_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_delete_user integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_posts_enable_bbcode_check CHECK ((enable_bbcode >= 0)),
+    CONSTRAINT phpbb_posts_enable_magic_url_check CHECK ((enable_magic_url >= 0)),
+    CONSTRAINT phpbb_posts_enable_sig_check CHECK ((enable_sig >= 0)),
+    CONSTRAINT phpbb_posts_enable_smilies_check CHECK ((enable_smilies >= 0)),
+    CONSTRAINT phpbb_posts_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_posts_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_posts_post_attachment_check CHECK ((post_attachment >= 0)),
+    CONSTRAINT phpbb_posts_post_delete_time_check CHECK ((post_delete_time >= 0)),
+    CONSTRAINT phpbb_posts_post_delete_user_check CHECK ((post_delete_user >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_count_check CHECK ((post_edit_count >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_locked_check CHECK ((post_edit_locked >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_time_check CHECK ((post_edit_time >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_user_check CHECK ((post_edit_user >= 0)),
+    CONSTRAINT phpbb_posts_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_posts_post_postcount_check CHECK ((post_postcount >= 0)),
+    CONSTRAINT phpbb_posts_post_reported_check CHECK ((post_reported >= 0)),
+    CONSTRAINT phpbb_posts_post_time_check CHECK ((post_time >= 0)),
+    CONSTRAINT phpbb_posts_poster_id_check CHECK ((poster_id >= 0)),
+    CONSTRAINT phpbb_posts_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs (
+    msg_id integer DEFAULT nextval('public.phpbb_privmsgs_seq'::regclass) NOT NULL,
+    root_level integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    author_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    message_time integer DEFAULT 0 NOT NULL,
+    enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    enable_sig smallint DEFAULT '1'::smallint NOT NULL,
+    message_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    message_text text DEFAULT ''::text NOT NULL,
+    message_edit_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    message_edit_user integer DEFAULT 0 NOT NULL,
+    message_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    message_edit_time integer DEFAULT 0 NOT NULL,
+    message_edit_count smallint DEFAULT '0'::smallint NOT NULL,
+    to_address character varying(4000) DEFAULT ''::character varying NOT NULL,
+    bcc_address character varying(4000) DEFAULT ''::character varying NOT NULL,
+    message_reported smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_privmsgs_author_id_check CHECK ((author_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_bbcode_check CHECK ((enable_bbcode >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_magic_url_check CHECK ((enable_magic_url >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_sig_check CHECK ((enable_sig >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_smilies_check CHECK ((enable_smilies >= 0)),
+    CONSTRAINT phpbb_privmsgs_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_attachment_check CHECK ((message_attachment >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_count_check CHECK ((message_edit_count >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_time_check CHECK ((message_edit_time >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_user_check CHECK ((message_edit_user >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_reported_check CHECK ((message_reported >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_time_check CHECK ((message_time >= 0)),
+    CONSTRAINT phpbb_privmsgs_msg_id_check CHECK ((msg_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_root_level_check CHECK ((root_level >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_folder_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_folder_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs_folder; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_folder (
+    folder_id integer DEFAULT nextval('public.phpbb_privmsgs_folder_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    folder_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    pm_count integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_folder_folder_id_check CHECK ((folder_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_folder_pm_count_check CHECK ((pm_count >= 0)),
+    CONSTRAINT phpbb_privmsgs_folder_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_rules_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_rules_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs_rules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_rules (
+    rule_id integer DEFAULT nextval('public.phpbb_privmsgs_rules_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    rule_check integer DEFAULT 0 NOT NULL,
+    rule_connection integer DEFAULT 0 NOT NULL,
+    rule_string character varying(255) DEFAULT ''::character varying NOT NULL,
+    rule_user_id integer DEFAULT 0 NOT NULL,
+    rule_group_id integer DEFAULT 0 NOT NULL,
+    rule_action integer DEFAULT 0 NOT NULL,
+    rule_folder_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_rules_rule_action_check CHECK ((rule_action >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_check_check CHECK ((rule_check >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_connection_check CHECK ((rule_connection >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_group_id_check CHECK ((rule_group_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_id_check CHECK ((rule_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_user_id_check CHECK ((rule_user_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_to; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_to (
+    msg_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    pm_deleted smallint DEFAULT '0'::smallint NOT NULL,
+    pm_new smallint DEFAULT '1'::smallint NOT NULL,
+    pm_unread smallint DEFAULT '1'::smallint NOT NULL,
+    pm_replied smallint DEFAULT '0'::smallint NOT NULL,
+    pm_marked smallint DEFAULT '0'::smallint NOT NULL,
+    pm_forwarded smallint DEFAULT '0'::smallint NOT NULL,
+    folder_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_to_author_id_check CHECK ((author_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_msg_id_check CHECK ((msg_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_deleted_check CHECK ((pm_deleted >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_forwarded_check CHECK ((pm_forwarded >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_marked_check CHECK ((pm_marked >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_new_check CHECK ((pm_new >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_replied_check CHECK ((pm_replied >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_unread_check CHECK ((pm_unread >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_profile_fields_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_profile_fields; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields (
+    field_id integer DEFAULT nextval('public.phpbb_profile_fields_seq'::regclass) NOT NULL,
+    field_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_type character varying(100) DEFAULT ''::character varying NOT NULL,
+    field_ident character varying(20) DEFAULT ''::character varying NOT NULL,
+    field_length character varying(20) DEFAULT ''::character varying NOT NULL,
+    field_minlen character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_maxlen character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_novalue character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_default_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_validation character varying(64) DEFAULT ''::character varying NOT NULL,
+    field_required smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_reg smallint DEFAULT '0'::smallint NOT NULL,
+    field_hide smallint DEFAULT '0'::smallint NOT NULL,
+    field_no_view smallint DEFAULT '0'::smallint NOT NULL,
+    field_active smallint DEFAULT '0'::smallint NOT NULL,
+    field_order integer DEFAULT 0 NOT NULL,
+    field_show_profile smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_vt smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_novalue smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_pm smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_ml smallint DEFAULT '0'::smallint NOT NULL,
+    field_is_contact smallint DEFAULT '0'::smallint NOT NULL,
+    field_contact_desc character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_contact_url character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_field_active_check CHECK ((field_active >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_hide_check CHECK ((field_hide >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_is_contact_check CHECK ((field_is_contact >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_no_view_check CHECK ((field_no_view >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_order_check CHECK ((field_order >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_required_check CHECK ((field_required >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_novalue_check CHECK ((field_show_novalue >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_ml_check CHECK ((field_show_on_ml >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_pm_check CHECK ((field_show_on_pm >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_reg_check CHECK ((field_show_on_reg >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_vt_check CHECK ((field_show_on_vt >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_profile_check CHECK ((field_show_profile >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields_data (
+    user_id integer DEFAULT 0 NOT NULL,
+    pf_phpbb_interests text DEFAULT ''::text NOT NULL,
+    pf_phpbb_occupation text DEFAULT ''::text NOT NULL,
+    pf_phpbb_facebook character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_googleplus character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_icq character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_location character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_skype character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_twitter character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_website character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_wlm character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_yahoo character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_youtube character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_aol character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_data_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields_lang (
+    field_id integer DEFAULT 0 NOT NULL,
+    lang_id integer DEFAULT 0 NOT NULL,
+    option_id integer DEFAULT 0 NOT NULL,
+    field_type character varying(100) DEFAULT ''::character varying NOT NULL,
+    lang_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_lang_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_lang_lang_id_check CHECK ((lang_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_lang_option_id_check CHECK ((option_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_lang (
+    field_id integer DEFAULT 0 NOT NULL,
+    lang_id integer DEFAULT 0 NOT NULL,
+    lang_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    lang_explain character varying(4000) DEFAULT ''::character varying NOT NULL,
+    lang_default_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_lang_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_lang_lang_id_check CHECK ((lang_id >= 0))
+);
+
+
+--
+-- Name: phpbb_ranks_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_ranks_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_ranks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_ranks (
+    rank_id integer DEFAULT nextval('public.phpbb_ranks_seq'::regclass) NOT NULL,
+    rank_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    rank_min integer DEFAULT 0 NOT NULL,
+    rank_special smallint DEFAULT '0'::smallint NOT NULL,
+    rank_image character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_ranks_rank_id_check CHECK ((rank_id >= 0)),
+    CONSTRAINT phpbb_ranks_rank_min_check CHECK ((rank_min >= 0)),
+    CONSTRAINT phpbb_ranks_rank_special_check CHECK ((rank_special >= 0))
+);
+
+
+--
+-- Name: phpbb_reports_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_reports_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_reports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_reports (
+    report_id integer DEFAULT nextval('public.phpbb_reports_seq'::regclass) NOT NULL,
+    reason_id smallint DEFAULT '0'::smallint NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    user_notify smallint DEFAULT '0'::smallint NOT NULL,
+    report_closed smallint DEFAULT '0'::smallint NOT NULL,
+    report_time integer DEFAULT 0 NOT NULL,
+    report_text text DEFAULT ''::text NOT NULL,
+    pm_id integer DEFAULT 0 NOT NULL,
+    reported_post_enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    reported_post_enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    reported_post_enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    reported_post_text text DEFAULT ''::text NOT NULL,
+    reported_post_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    reported_post_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_reports_pm_id_check CHECK ((pm_id >= 0)),
+    CONSTRAINT phpbb_reports_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_reports_reason_id_check CHECK ((reason_id >= 0)),
+    CONSTRAINT phpbb_reports_report_closed_check CHECK ((report_closed >= 0)),
+    CONSTRAINT phpbb_reports_report_id_check CHECK ((report_id >= 0)),
+    CONSTRAINT phpbb_reports_report_time_check CHECK ((report_time >= 0)),
+    CONSTRAINT phpbb_reports_reported_post_enable_bbcode_check CHECK ((reported_post_enable_bbcode >= 0)),
+    CONSTRAINT phpbb_reports_reported_post_enable_magic_url_check CHECK ((reported_post_enable_magic_url >= 0)),
+    CONSTRAINT phpbb_reports_reported_post_enable_smilies_check CHECK ((reported_post_enable_smilies >= 0)),
+    CONSTRAINT phpbb_reports_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_reports_user_notify_check CHECK ((user_notify >= 0))
+);
+
+
+--
+-- Name: phpbb_reports_reasons_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_reports_reasons_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_reports_reasons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_reports_reasons (
+    reason_id smallint DEFAULT nextval('public.phpbb_reports_reasons_seq'::regclass) NOT NULL,
+    reason_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    reason_description text DEFAULT ''::text NOT NULL,
+    reason_order smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_reports_reasons_reason_id_check CHECK ((reason_id >= 0)),
+    CONSTRAINT phpbb_reports_reasons_reason_order_check CHECK ((reason_order >= 0))
+);
+
+
+--
+-- Name: phpbb_search_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_results (
+    search_key character varying(32) DEFAULT ''::character varying NOT NULL,
+    search_time integer DEFAULT 0 NOT NULL,
+    search_keywords text DEFAULT ''::text NOT NULL,
+    search_authors text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_search_results_search_time_check CHECK ((search_time >= 0))
+);
+
+
+--
+-- Name: phpbb_search_wordlist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_search_wordlist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_search_wordlist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_wordlist (
+    word_id integer DEFAULT nextval('public.phpbb_search_wordlist_seq'::regclass) NOT NULL,
+    word_text character varying(255) DEFAULT ''::character varying NOT NULL,
+    word_common smallint DEFAULT '0'::smallint NOT NULL,
+    word_count integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_search_wordlist_word_common_check CHECK ((word_common >= 0)),
+    CONSTRAINT phpbb_search_wordlist_word_count_check CHECK ((word_count >= 0)),
+    CONSTRAINT phpbb_search_wordlist_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_search_wordmatch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_wordmatch (
+    post_id integer DEFAULT 0 NOT NULL,
+    word_id integer DEFAULT 0 NOT NULL,
+    title_match smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_search_wordmatch_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_search_wordmatch_title_match_check CHECK ((title_match >= 0)),
+    CONSTRAINT phpbb_search_wordmatch_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sessions (
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    session_user_id integer DEFAULT 0 NOT NULL,
+    session_last_visit integer DEFAULT 0 NOT NULL,
+    session_start integer DEFAULT 0 NOT NULL,
+    session_time integer DEFAULT 0 NOT NULL,
+    session_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    session_browser character varying(150) DEFAULT ''::character varying NOT NULL,
+    session_forwarded_for character varying(255) DEFAULT ''::character varying NOT NULL,
+    session_page character varying(255) DEFAULT ''::character varying NOT NULL,
+    session_viewonline smallint DEFAULT '1'::smallint NOT NULL,
+    session_autologin smallint DEFAULT '0'::smallint NOT NULL,
+    session_admin smallint DEFAULT '0'::smallint NOT NULL,
+    session_forum_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_sessions_session_admin_check CHECK ((session_admin >= 0)),
+    CONSTRAINT phpbb_sessions_session_autologin_check CHECK ((session_autologin >= 0)),
+    CONSTRAINT phpbb_sessions_session_forum_id_check CHECK ((session_forum_id >= 0)),
+    CONSTRAINT phpbb_sessions_session_last_visit_check CHECK ((session_last_visit >= 0)),
+    CONSTRAINT phpbb_sessions_session_start_check CHECK ((session_start >= 0)),
+    CONSTRAINT phpbb_sessions_session_time_check CHECK ((session_time >= 0)),
+    CONSTRAINT phpbb_sessions_session_user_id_check CHECK ((session_user_id >= 0)),
+    CONSTRAINT phpbb_sessions_session_viewonline_check CHECK ((session_viewonline >= 0))
+);
+
+
+--
+-- Name: phpbb_sessions_keys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sessions_keys (
+    key_id character(32) DEFAULT ''::bpchar NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    last_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    last_login integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_sessions_keys_last_login_check CHECK ((last_login >= 0)),
+    CONSTRAINT phpbb_sessions_keys_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_sitelist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_sitelist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_sitelist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sitelist (
+    site_id integer DEFAULT nextval('public.phpbb_sitelist_seq'::regclass) NOT NULL,
+    site_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    site_hostname character varying(255) DEFAULT ''::character varying NOT NULL,
+    ip_exclude smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_sitelist_ip_exclude_check CHECK ((ip_exclude >= 0)),
+    CONSTRAINT phpbb_sitelist_site_id_check CHECK ((site_id >= 0))
+);
+
+
+--
+-- Name: phpbb_smilies_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_smilies_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_smilies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_smilies (
+    smiley_id integer DEFAULT nextval('public.phpbb_smilies_seq'::regclass) NOT NULL,
+    code character varying(50) DEFAULT ''::character varying NOT NULL,
+    emotion character varying(255) DEFAULT ''::character varying NOT NULL,
+    smiley_url character varying(50) DEFAULT ''::character varying NOT NULL,
+    smiley_width smallint DEFAULT '0'::smallint NOT NULL,
+    smiley_height smallint DEFAULT '0'::smallint NOT NULL,
+    smiley_order integer DEFAULT 0 NOT NULL,
+    display_on_posting smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_smilies_display_on_posting_check CHECK ((display_on_posting >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_height_check CHECK ((smiley_height >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_id_check CHECK ((smiley_id >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_order_check CHECK ((smiley_order >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_width_check CHECK ((smiley_width >= 0))
+);
+
+
+--
+-- Name: phpbb_styles_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_styles_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_styles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_styles (
+    style_id integer DEFAULT nextval('public.phpbb_styles_seq'::regclass) NOT NULL,
+    style_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    style_copyright character varying(255) DEFAULT ''::character varying NOT NULL,
+    style_active smallint DEFAULT '1'::smallint NOT NULL,
+    style_path character varying(100) DEFAULT ''::character varying NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT 'kNg='::character varying NOT NULL,
+    style_parent_id integer DEFAULT 0 NOT NULL,
+    style_parent_tree character varying(8000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_styles_style_active_check CHECK ((style_active >= 0)),
+    CONSTRAINT phpbb_styles_style_id_check CHECK ((style_id >= 0)),
+    CONSTRAINT phpbb_styles_style_parent_id_check CHECK ((style_parent_id >= 0))
+);
+
+
+--
+-- Name: phpbb_teampage_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_teampage_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_teampage; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_teampage (
+    teampage_id integer DEFAULT nextval('public.phpbb_teampage_seq'::regclass) NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    teampage_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    teampage_position integer DEFAULT 0 NOT NULL,
+    teampage_parent integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_teampage_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_teampage_teampage_id_check CHECK ((teampage_id >= 0)),
+    CONSTRAINT phpbb_teampage_teampage_parent_check CHECK ((teampage_parent >= 0)),
+    CONSTRAINT phpbb_teampage_teampage_position_check CHECK ((teampage_position >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_topics_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_topics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics (
+    topic_id integer DEFAULT nextval('public.phpbb_topics_seq'::regclass) NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    topic_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    topic_reported smallint DEFAULT '0'::smallint NOT NULL,
+    topic_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_poster integer DEFAULT 0 NOT NULL,
+    topic_time integer DEFAULT 0 NOT NULL,
+    topic_time_limit integer DEFAULT 0 NOT NULL,
+    topic_views integer DEFAULT 0 NOT NULL,
+    topic_status smallint DEFAULT '0'::smallint NOT NULL,
+    topic_type smallint DEFAULT '0'::smallint NOT NULL,
+    topic_first_post_id integer DEFAULT 0 NOT NULL,
+    topic_first_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_first_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_id integer DEFAULT 0 NOT NULL,
+    topic_last_poster_id integer DEFAULT 0 NOT NULL,
+    topic_last_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_last_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_time integer DEFAULT 0 NOT NULL,
+    topic_last_view_time integer DEFAULT 0 NOT NULL,
+    topic_moved_id integer DEFAULT 0 NOT NULL,
+    topic_bumped smallint DEFAULT '0'::smallint NOT NULL,
+    topic_bumper integer DEFAULT 0 NOT NULL,
+    poll_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    poll_start integer DEFAULT 0 NOT NULL,
+    poll_length integer DEFAULT 0 NOT NULL,
+    poll_max_options smallint DEFAULT '1'::smallint NOT NULL,
+    poll_last_vote integer DEFAULT 0 NOT NULL,
+    poll_vote_change smallint DEFAULT '0'::smallint NOT NULL,
+    topic_visibility smallint DEFAULT '0'::smallint NOT NULL,
+    topic_delete_time integer DEFAULT 0 NOT NULL,
+    topic_delete_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_delete_user integer DEFAULT 0 NOT NULL,
+    topic_posts_approved integer DEFAULT 0 NOT NULL,
+    topic_posts_unapproved integer DEFAULT 0 NOT NULL,
+    topic_posts_softdeleted integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_topics_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_topics_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_topics_poll_last_vote_check CHECK ((poll_last_vote >= 0)),
+    CONSTRAINT phpbb_topics_poll_length_check CHECK ((poll_length >= 0)),
+    CONSTRAINT phpbb_topics_poll_start_check CHECK ((poll_start >= 0)),
+    CONSTRAINT phpbb_topics_poll_vote_change_check CHECK ((poll_vote_change >= 0)),
+    CONSTRAINT phpbb_topics_topic_attachment_check CHECK ((topic_attachment >= 0)),
+    CONSTRAINT phpbb_topics_topic_bumped_check CHECK ((topic_bumped >= 0)),
+    CONSTRAINT phpbb_topics_topic_bumper_check CHECK ((topic_bumper >= 0)),
+    CONSTRAINT phpbb_topics_topic_delete_time_check CHECK ((topic_delete_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_delete_user_check CHECK ((topic_delete_user >= 0)),
+    CONSTRAINT phpbb_topics_topic_first_post_id_check CHECK ((topic_first_post_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_post_id_check CHECK ((topic_last_post_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_post_time_check CHECK ((topic_last_post_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_poster_id_check CHECK ((topic_last_poster_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_view_time_check CHECK ((topic_last_view_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_moved_id_check CHECK ((topic_moved_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_poster_check CHECK ((topic_poster >= 0)),
+    CONSTRAINT phpbb_topics_topic_posts_approved_check CHECK ((topic_posts_approved >= 0)),
+    CONSTRAINT phpbb_topics_topic_posts_softdeleted_check CHECK ((topic_posts_softdeleted >= 0)),
+    CONSTRAINT phpbb_topics_topic_posts_unapproved_check CHECK ((topic_posts_unapproved >= 0)),
+    CONSTRAINT phpbb_topics_topic_reported_check CHECK ((topic_reported >= 0)),
+    CONSTRAINT phpbb_topics_topic_time_check CHECK ((topic_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_time_limit_check CHECK ((topic_time_limit >= 0)),
+    CONSTRAINT phpbb_topics_topic_views_check CHECK ((topic_views >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_posted; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_posted (
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    topic_posted smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_topics_posted_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_posted_topic_posted_check CHECK ((topic_posted >= 0)),
+    CONSTRAINT phpbb_topics_posted_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_track; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_track (
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    mark_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_topics_track_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_topics_track_mark_time_check CHECK ((mark_time >= 0)),
+    CONSTRAINT phpbb_topics_track_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_track_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_watch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_watch (
+    topic_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notify_status smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_topics_watch_notify_status_check CHECK ((notify_status >= 0)),
+    CONSTRAINT phpbb_topics_watch_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_watch_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_user_group; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_user_group (
+    group_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    group_leader smallint DEFAULT '0'::smallint NOT NULL,
+    user_pending smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_user_group_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_user_group_group_leader_check CHECK ((group_leader >= 0)),
+    CONSTRAINT phpbb_user_group_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_user_group_user_pending_check CHECK ((user_pending >= 0))
+);
+
+
+--
+-- Name: phpbb_user_notifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_user_notifications (
+    item_type character varying(255) DEFAULT ''::character varying NOT NULL,
+    item_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    method character varying(255) DEFAULT ''::character varying NOT NULL,
+    notify smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_user_notifications_item_id_check CHECK ((item_id >= 0)),
+    CONSTRAINT phpbb_user_notifications_notify_check CHECK ((notify >= 0)),
+    CONSTRAINT phpbb_user_notifications_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_users_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_users_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_users (
+    user_id integer DEFAULT nextval('public.phpbb_users_seq'::regclass) NOT NULL,
+    user_type smallint DEFAULT '0'::smallint NOT NULL,
+    group_id integer DEFAULT 3 NOT NULL,
+    user_permissions text DEFAULT ''::text NOT NULL,
+    user_perm_from integer DEFAULT 0 NOT NULL,
+    user_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    user_regdate integer DEFAULT 0 NOT NULL,
+    username public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    username_clean public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    user_password character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_passchg integer DEFAULT 0 NOT NULL,
+    user_email character varying(100) DEFAULT ''::character varying NOT NULL,
+    user_email_hash bigint DEFAULT '0'::bigint NOT NULL,
+    user_birthday character varying(10) DEFAULT ''::character varying NOT NULL,
+    user_lastvisit integer DEFAULT 0 NOT NULL,
+    user_lastmark integer DEFAULT 0 NOT NULL,
+    user_lastpost_time integer DEFAULT 0 NOT NULL,
+    user_lastpage character varying(200) DEFAULT ''::character varying NOT NULL,
+    user_last_confirm_key character varying(10) DEFAULT ''::character varying NOT NULL,
+    user_last_search integer DEFAULT 0 NOT NULL,
+    user_warnings smallint DEFAULT '0'::smallint NOT NULL,
+    user_last_warning integer DEFAULT 0 NOT NULL,
+    user_login_attempts smallint DEFAULT '0'::smallint NOT NULL,
+    user_inactive_reason smallint DEFAULT '0'::smallint NOT NULL,
+    user_inactive_time integer DEFAULT 0 NOT NULL,
+    user_posts integer DEFAULT 0 NOT NULL,
+    user_lang character varying(30) DEFAULT ''::character varying NOT NULL,
+    user_timezone character varying(100) DEFAULT ''::character varying NOT NULL,
+    user_dateformat character varying(64) DEFAULT 'd M Y H:i'::character varying NOT NULL,
+    user_style integer DEFAULT 0 NOT NULL,
+    user_rank integer DEFAULT 0 NOT NULL,
+    user_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    user_new_privmsg integer DEFAULT 0 NOT NULL,
+    user_unread_privmsg integer DEFAULT 0 NOT NULL,
+    user_last_privmsg integer DEFAULT 0 NOT NULL,
+    user_message_rules smallint DEFAULT '0'::smallint NOT NULL,
+    user_full_folder integer DEFAULT '-3'::integer NOT NULL,
+    user_emailtime integer DEFAULT 0 NOT NULL,
+    user_topic_show_days smallint DEFAULT '0'::smallint NOT NULL,
+    user_topic_sortby_type character varying(1) DEFAULT 't'::character varying NOT NULL,
+    user_topic_sortby_dir character varying(1) DEFAULT 'd'::character varying NOT NULL,
+    user_post_show_days smallint DEFAULT '0'::smallint NOT NULL,
+    user_post_sortby_type character varying(1) DEFAULT 't'::character varying NOT NULL,
+    user_post_sortby_dir character varying(1) DEFAULT 'a'::character varying NOT NULL,
+    user_notify smallint DEFAULT '0'::smallint NOT NULL,
+    user_notify_pm smallint DEFAULT '1'::smallint NOT NULL,
+    user_notify_type smallint DEFAULT '0'::smallint NOT NULL,
+    user_allow_pm smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_viewonline smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_viewemail smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_massemail smallint DEFAULT '1'::smallint NOT NULL,
+    user_options integer DEFAULT 230271 NOT NULL,
+    user_avatar character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_avatar_type character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_avatar_width smallint DEFAULT '0'::smallint NOT NULL,
+    user_avatar_height smallint DEFAULT '0'::smallint NOT NULL,
+    user_sig text DEFAULT ''::text NOT NULL,
+    user_sig_bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    user_sig_bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_jabber character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_actkey character varying(32) DEFAULT ''::character varying NOT NULL,
+    user_newpasswd character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_form_salt character varying(32) DEFAULT ''::character varying NOT NULL,
+    user_new smallint DEFAULT '1'::smallint NOT NULL,
+    user_reminded smallint DEFAULT '0'::smallint NOT NULL,
+    user_reminded_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_users_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_users_user_allow_massemail_check CHECK ((user_allow_massemail >= 0)),
+    CONSTRAINT phpbb_users_user_allow_pm_check CHECK ((user_allow_pm >= 0)),
+    CONSTRAINT phpbb_users_user_allow_viewemail_check CHECK ((user_allow_viewemail >= 0)),
+    CONSTRAINT phpbb_users_user_allow_viewonline_check CHECK ((user_allow_viewonline >= 0)),
+    CONSTRAINT phpbb_users_user_avatar_height_check CHECK ((user_avatar_height >= 0)),
+    CONSTRAINT phpbb_users_user_avatar_width_check CHECK ((user_avatar_width >= 0)),
+    CONSTRAINT phpbb_users_user_emailtime_check CHECK ((user_emailtime >= 0)),
+    CONSTRAINT phpbb_users_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_users_user_inactive_time_check CHECK ((user_inactive_time >= 0)),
+    CONSTRAINT phpbb_users_user_last_privmsg_check CHECK ((user_last_privmsg >= 0)),
+    CONSTRAINT phpbb_users_user_last_search_check CHECK ((user_last_search >= 0)),
+    CONSTRAINT phpbb_users_user_last_warning_check CHECK ((user_last_warning >= 0)),
+    CONSTRAINT phpbb_users_user_lastmark_check CHECK ((user_lastmark >= 0)),
+    CONSTRAINT phpbb_users_user_lastpost_time_check CHECK ((user_lastpost_time >= 0)),
+    CONSTRAINT phpbb_users_user_lastvisit_check CHECK ((user_lastvisit >= 0)),
+    CONSTRAINT phpbb_users_user_message_rules_check CHECK ((user_message_rules >= 0)),
+    CONSTRAINT phpbb_users_user_new_check CHECK ((user_new >= 0)),
+    CONSTRAINT phpbb_users_user_notify_check CHECK ((user_notify >= 0)),
+    CONSTRAINT phpbb_users_user_notify_pm_check CHECK ((user_notify_pm >= 0)),
+    CONSTRAINT phpbb_users_user_options_check CHECK ((user_options >= 0)),
+    CONSTRAINT phpbb_users_user_passchg_check CHECK ((user_passchg >= 0)),
+    CONSTRAINT phpbb_users_user_perm_from_check CHECK ((user_perm_from >= 0)),
+    CONSTRAINT phpbb_users_user_post_show_days_check CHECK ((user_post_show_days >= 0)),
+    CONSTRAINT phpbb_users_user_posts_check CHECK ((user_posts >= 0)),
+    CONSTRAINT phpbb_users_user_rank_check CHECK ((user_rank >= 0)),
+    CONSTRAINT phpbb_users_user_regdate_check CHECK ((user_regdate >= 0)),
+    CONSTRAINT phpbb_users_user_reminded_time_check CHECK ((user_reminded_time >= 0)),
+    CONSTRAINT phpbb_users_user_style_check CHECK ((user_style >= 0)),
+    CONSTRAINT phpbb_users_user_topic_show_days_check CHECK ((user_topic_show_days >= 0))
+);
+
+
+--
+-- Name: phpbb_warnings_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_warnings_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_warnings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_warnings (
+    warning_id integer DEFAULT nextval('public.phpbb_warnings_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    log_id integer DEFAULT 0 NOT NULL,
+    warning_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_warnings_log_id_check CHECK ((log_id >= 0)),
+    CONSTRAINT phpbb_warnings_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_warnings_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_warnings_warning_id_check CHECK ((warning_id >= 0)),
+    CONSTRAINT phpbb_warnings_warning_time_check CHECK ((warning_time >= 0))
+);
+
+
+--
+-- Name: phpbb_words_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_words_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_words; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_words (
+    word_id integer DEFAULT nextval('public.phpbb_words_seq'::regclass) NOT NULL,
+    word character varying(255) DEFAULT ''::character varying NOT NULL,
+    replacement character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_words_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_zebra; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_zebra (
+    user_id integer DEFAULT 0 NOT NULL,
+    zebra_id integer DEFAULT 0 NOT NULL,
+    friend smallint DEFAULT '0'::smallint NOT NULL,
+    foe smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_zebra_foe_check CHECK ((foe >= 0)),
+    CONSTRAINT phpbb_zebra_friend_check CHECK ((friend >= 0)),
+    CONSTRAINT phpbb_zebra_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_zebra_zebra_id_check CHECK ((zebra_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_options phpbb_acl_options_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_options
+    ADD CONSTRAINT phpbb_acl_options_pkey PRIMARY KEY (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles_data phpbb_acl_roles_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_roles_data
+    ADD CONSTRAINT phpbb_acl_roles_data_pkey PRIMARY KEY (role_id, auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles phpbb_acl_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_roles
+    ADD CONSTRAINT phpbb_acl_roles_pkey PRIMARY KEY (role_id);
+
+
+--
+-- Name: phpbb_attachments phpbb_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_attachments
+    ADD CONSTRAINT phpbb_attachments_pkey PRIMARY KEY (attach_id);
+
+
+--
+-- Name: phpbb_banlist phpbb_banlist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_banlist
+    ADD CONSTRAINT phpbb_banlist_pkey PRIMARY KEY (ban_id);
+
+
+--
+-- Name: phpbb_bbcodes phpbb_bbcodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bbcodes
+    ADD CONSTRAINT phpbb_bbcodes_pkey PRIMARY KEY (bbcode_id);
+
+
+--
+-- Name: phpbb_bookmarks phpbb_bookmarks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bookmarks
+    ADD CONSTRAINT phpbb_bookmarks_pkey PRIMARY KEY (topic_id, user_id);
+
+
+--
+-- Name: phpbb_bots phpbb_bots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bots
+    ADD CONSTRAINT phpbb_bots_pkey PRIMARY KEY (bot_id);
+
+
+--
+-- Name: phpbb_config phpbb_config_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_config
+    ADD CONSTRAINT phpbb_config_pkey PRIMARY KEY (config_name);
+
+
+--
+-- Name: phpbb_config_text phpbb_config_text_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_config_text
+    ADD CONSTRAINT phpbb_config_text_pkey PRIMARY KEY (config_name);
+
+
+--
+-- Name: phpbb_confirm phpbb_confirm_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_confirm
+    ADD CONSTRAINT phpbb_confirm_pkey PRIMARY KEY (session_id, confirm_id);
+
+
+--
+-- Name: phpbb_disallow phpbb_disallow_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_disallow
+    ADD CONSTRAINT phpbb_disallow_pkey PRIMARY KEY (disallow_id);
+
+
+--
+-- Name: phpbb_drafts phpbb_drafts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_drafts
+    ADD CONSTRAINT phpbb_drafts_pkey PRIMARY KEY (draft_id);
+
+
+--
+-- Name: phpbb_extension_groups phpbb_extension_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_extension_groups
+    ADD CONSTRAINT phpbb_extension_groups_pkey PRIMARY KEY (group_id);
+
+
+--
+-- Name: phpbb_extensions phpbb_extensions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_extensions
+    ADD CONSTRAINT phpbb_extensions_pkey PRIMARY KEY (extension_id);
+
+
+--
+-- Name: phpbb_forums_access phpbb_forums_access_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums_access
+    ADD CONSTRAINT phpbb_forums_access_pkey PRIMARY KEY (forum_id, user_id, session_id);
+
+
+--
+-- Name: phpbb_forums phpbb_forums_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums
+    ADD CONSTRAINT phpbb_forums_pkey PRIMARY KEY (forum_id);
+
+
+--
+-- Name: phpbb_forums_track phpbb_forums_track_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums_track
+    ADD CONSTRAINT phpbb_forums_track_pkey PRIMARY KEY (user_id, forum_id);
+
+
+--
+-- Name: phpbb_groups phpbb_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_groups
+    ADD CONSTRAINT phpbb_groups_pkey PRIMARY KEY (group_id);
+
+
+--
+-- Name: phpbb_icons phpbb_icons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_icons
+    ADD CONSTRAINT phpbb_icons_pkey PRIMARY KEY (icons_id);
+
+
+--
+-- Name: phpbb_lang phpbb_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_lang
+    ADD CONSTRAINT phpbb_lang_pkey PRIMARY KEY (lang_id);
+
+
+--
+-- Name: phpbb_log phpbb_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_log
+    ADD CONSTRAINT phpbb_log_pkey PRIMARY KEY (log_id);
+
+
+--
+-- Name: phpbb_migrations phpbb_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_migrations
+    ADD CONSTRAINT phpbb_migrations_pkey PRIMARY KEY (migration_name);
+
+
+--
+-- Name: phpbb_modules phpbb_modules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_modules
+    ADD CONSTRAINT phpbb_modules_pkey PRIMARY KEY (module_id);
+
+
+--
+-- Name: phpbb_notification_types phpbb_notification_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_notification_types
+    ADD CONSTRAINT phpbb_notification_types_pkey PRIMARY KEY (notification_type_id);
+
+
+--
+-- Name: phpbb_notifications phpbb_notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_notifications
+    ADD CONSTRAINT phpbb_notifications_pkey PRIMARY KEY (notification_id);
+
+
+--
+-- Name: phpbb_oauth_accounts phpbb_oauth_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_oauth_accounts
+    ADD CONSTRAINT phpbb_oauth_accounts_pkey PRIMARY KEY (user_id, provider);
+
+
+--
+-- Name: phpbb_posts phpbb_posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_posts
+    ADD CONSTRAINT phpbb_posts_pkey PRIMARY KEY (post_id);
+
+
+--
+-- Name: phpbb_privmsgs_folder phpbb_privmsgs_folder_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs_folder
+    ADD CONSTRAINT phpbb_privmsgs_folder_pkey PRIMARY KEY (folder_id);
+
+
+--
+-- Name: phpbb_privmsgs phpbb_privmsgs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs
+    ADD CONSTRAINT phpbb_privmsgs_pkey PRIMARY KEY (msg_id);
+
+
+--
+-- Name: phpbb_privmsgs_rules phpbb_privmsgs_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs_rules
+    ADD CONSTRAINT phpbb_privmsgs_rules_pkey PRIMARY KEY (rule_id);
+
+
+--
+-- Name: phpbb_profile_fields_data phpbb_profile_fields_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields_data
+    ADD CONSTRAINT phpbb_profile_fields_data_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: phpbb_profile_fields_lang phpbb_profile_fields_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields_lang
+    ADD CONSTRAINT phpbb_profile_fields_lang_pkey PRIMARY KEY (field_id, lang_id, option_id);
+
+
+--
+-- Name: phpbb_profile_fields phpbb_profile_fields_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields
+    ADD CONSTRAINT phpbb_profile_fields_pkey PRIMARY KEY (field_id);
+
+
+--
+-- Name: phpbb_profile_lang phpbb_profile_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_lang
+    ADD CONSTRAINT phpbb_profile_lang_pkey PRIMARY KEY (field_id, lang_id);
+
+
+--
+-- Name: phpbb_ranks phpbb_ranks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_ranks
+    ADD CONSTRAINT phpbb_ranks_pkey PRIMARY KEY (rank_id);
+
+
+--
+-- Name: phpbb_reports phpbb_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_reports
+    ADD CONSTRAINT phpbb_reports_pkey PRIMARY KEY (report_id);
+
+
+--
+-- Name: phpbb_reports_reasons phpbb_reports_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_reports_reasons
+    ADD CONSTRAINT phpbb_reports_reasons_pkey PRIMARY KEY (reason_id);
+
+
+--
+-- Name: phpbb_search_results phpbb_search_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_search_results
+    ADD CONSTRAINT phpbb_search_results_pkey PRIMARY KEY (search_key);
+
+
+--
+-- Name: phpbb_search_wordlist phpbb_search_wordlist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_search_wordlist
+    ADD CONSTRAINT phpbb_search_wordlist_pkey PRIMARY KEY (word_id);
+
+
+--
+-- Name: phpbb_sessions_keys phpbb_sessions_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sessions_keys
+    ADD CONSTRAINT phpbb_sessions_keys_pkey PRIMARY KEY (key_id, user_id);
+
+
+--
+-- Name: phpbb_sessions phpbb_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sessions
+    ADD CONSTRAINT phpbb_sessions_pkey PRIMARY KEY (session_id);
+
+
+--
+-- Name: phpbb_sitelist phpbb_sitelist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sitelist
+    ADD CONSTRAINT phpbb_sitelist_pkey PRIMARY KEY (site_id);
+
+
+--
+-- Name: phpbb_smilies phpbb_smilies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_smilies
+    ADD CONSTRAINT phpbb_smilies_pkey PRIMARY KEY (smiley_id);
+
+
+--
+-- Name: phpbb_styles phpbb_styles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_styles
+    ADD CONSTRAINT phpbb_styles_pkey PRIMARY KEY (style_id);
+
+
+--
+-- Name: phpbb_teampage phpbb_teampage_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_teampage
+    ADD CONSTRAINT phpbb_teampage_pkey PRIMARY KEY (teampage_id);
+
+
+--
+-- Name: phpbb_topics phpbb_topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics
+    ADD CONSTRAINT phpbb_topics_pkey PRIMARY KEY (topic_id);
+
+
+--
+-- Name: phpbb_topics_posted phpbb_topics_posted_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics_posted
+    ADD CONSTRAINT phpbb_topics_posted_pkey PRIMARY KEY (user_id, topic_id);
+
+
+--
+-- Name: phpbb_topics_track phpbb_topics_track_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics_track
+    ADD CONSTRAINT phpbb_topics_track_pkey PRIMARY KEY (user_id, topic_id);
+
+
+--
+-- Name: phpbb_users phpbb_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_users
+    ADD CONSTRAINT phpbb_users_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: phpbb_warnings phpbb_warnings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_warnings
+    ADD CONSTRAINT phpbb_warnings_pkey PRIMARY KEY (warning_id);
+
+
+--
+-- Name: phpbb_words phpbb_words_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_words
+    ADD CONSTRAINT phpbb_words_pkey PRIMARY KEY (word_id);
+
+
+--
+-- Name: phpbb_zebra phpbb_zebra_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_zebra
+    ADD CONSTRAINT phpbb_zebra_pkey PRIMARY KEY (user_id, zebra_id);
+
+
+--
+-- Name: phpbb_acl_groups_auth_opt_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_auth_opt_id ON public.phpbb_acl_groups USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_groups_auth_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_auth_role_id ON public.phpbb_acl_groups USING btree (auth_role_id);
+
+
+--
+-- Name: phpbb_acl_groups_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_group_id ON public.phpbb_acl_groups USING btree (group_id);
+
+
+--
+-- Name: phpbb_acl_options_auth_option; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_acl_options_auth_option ON public.phpbb_acl_options USING btree (auth_option);
+
+
+--
+-- Name: phpbb_acl_roles_data_ath_op_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_data_ath_op_id ON public.phpbb_acl_roles_data USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles_role_order; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_role_order ON public.phpbb_acl_roles USING btree (role_order);
+
+
+--
+-- Name: phpbb_acl_roles_role_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_role_type ON public.phpbb_acl_roles USING btree (role_type);
+
+
+--
+-- Name: phpbb_acl_users_auth_option_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_auth_option_id ON public.phpbb_acl_users USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_users_auth_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_auth_role_id ON public.phpbb_acl_users USING btree (auth_role_id);
+
+
+--
+-- Name: phpbb_acl_users_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_user_id ON public.phpbb_acl_users USING btree (user_id);
+
+
+--
+-- Name: phpbb_attachments_filetime; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_filetime ON public.phpbb_attachments USING btree (filetime);
+
+
+--
+-- Name: phpbb_attachments_is_orphan; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_is_orphan ON public.phpbb_attachments USING btree (is_orphan);
+
+
+--
+-- Name: phpbb_attachments_post_msg_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_post_msg_id ON public.phpbb_attachments USING btree (post_msg_id);
+
+
+--
+-- Name: phpbb_attachments_poster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_poster_id ON public.phpbb_attachments USING btree (poster_id);
+
+
+--
+-- Name: phpbb_attachments_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_topic_id ON public.phpbb_attachments USING btree (topic_id);
+
+
+--
+-- Name: phpbb_banlist_ban_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_email ON public.phpbb_banlist USING btree (ban_email, ban_exclude);
+
+
+--
+-- Name: phpbb_banlist_ban_end; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_end ON public.phpbb_banlist USING btree (ban_end);
+
+
+--
+-- Name: phpbb_banlist_ban_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_ip ON public.phpbb_banlist USING btree (ban_ip, ban_exclude);
+
+
+--
+-- Name: phpbb_banlist_ban_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_user ON public.phpbb_banlist USING btree (ban_userid, ban_exclude);
+
+
+--
+-- Name: phpbb_bbcodes_display_on_post; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_bbcodes_display_on_post ON public.phpbb_bbcodes USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_bots_bot_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_bots_bot_active ON public.phpbb_bots USING btree (bot_active);
+
+
+--
+-- Name: phpbb_config_is_dynamic; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_config_is_dynamic ON public.phpbb_config USING btree (is_dynamic);
+
+
+--
+-- Name: phpbb_confirm_confirm_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_confirm_confirm_type ON public.phpbb_confirm USING btree (confirm_type);
+
+
+--
+-- Name: phpbb_drafts_save_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_drafts_save_time ON public.phpbb_drafts USING btree (save_time);
+
+
+--
+-- Name: phpbb_ext_ext_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_ext_ext_name ON public.phpbb_ext USING btree (ext_name);
+
+
+--
+-- Name: phpbb_forums_forum_lastpost_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_forum_lastpost_id ON public.phpbb_forums USING btree (forum_last_post_id);
+
+
+--
+-- Name: phpbb_forums_left_right_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_left_right_id ON public.phpbb_forums USING btree (left_id, right_id);
+
+
+--
+-- Name: phpbb_forums_watch_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_forum_id ON public.phpbb_forums_watch USING btree (forum_id);
+
+
+--
+-- Name: phpbb_forums_watch_notify_stat; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_notify_stat ON public.phpbb_forums_watch USING btree (notify_status);
+
+
+--
+-- Name: phpbb_forums_watch_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_user_id ON public.phpbb_forums_watch USING btree (user_id);
+
+
+--
+-- Name: phpbb_groups_group_legend_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_groups_group_legend_name ON public.phpbb_groups USING btree (group_legend, group_name);
+
+
+--
+-- Name: phpbb_icons_display_on_posting; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_icons_display_on_posting ON public.phpbb_icons USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_lang_lang_iso; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_lang_lang_iso ON public.phpbb_lang USING btree (lang_iso);
+
+
+--
+-- Name: phpbb_log_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_forum_id ON public.phpbb_log USING btree (forum_id);
+
+
+--
+-- Name: phpbb_log_log_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_log_time ON public.phpbb_log USING btree (log_time);
+
+
+--
+-- Name: phpbb_log_log_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_log_type ON public.phpbb_log USING btree (log_type);
+
+
+--
+-- Name: phpbb_log_reportee_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_reportee_id ON public.phpbb_log USING btree (reportee_id);
+
+
+--
+-- Name: phpbb_log_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_topic_id ON public.phpbb_log USING btree (topic_id);
+
+
+--
+-- Name: phpbb_log_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_user_id ON public.phpbb_log USING btree (user_id);
+
+
+--
+-- Name: phpbb_login_attempts_att_for; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_for ON public.phpbb_login_attempts USING btree (attempt_forwarded_for, attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_att_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_ip ON public.phpbb_login_attempts USING btree (attempt_ip, attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_att_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_time ON public.phpbb_login_attempts USING btree (attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_user_id ON public.phpbb_login_attempts USING btree (user_id);
+
+
+--
+-- Name: phpbb_moderator_cache_disp_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_moderator_cache_disp_idx ON public.phpbb_moderator_cache USING btree (display_on_index);
+
+
+--
+-- Name: phpbb_moderator_cache_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_moderator_cache_forum_id ON public.phpbb_moderator_cache USING btree (forum_id);
+
+
+--
+-- Name: phpbb_modules_class_left_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_class_left_id ON public.phpbb_modules USING btree (module_class, left_id);
+
+
+--
+-- Name: phpbb_modules_left_right_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_left_right_id ON public.phpbb_modules USING btree (left_id, right_id);
+
+
+--
+-- Name: phpbb_modules_module_enabled; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_module_enabled ON public.phpbb_modules USING btree (module_enabled);
+
+
+--
+-- Name: phpbb_notification_types_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_notification_types_type ON public.phpbb_notification_types USING btree (notification_type_name);
+
+
+--
+-- Name: phpbb_notifications_item_ident; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_notifications_item_ident ON public.phpbb_notifications USING btree (notification_type_id, item_id);
+
+
+--
+-- Name: phpbb_notifications_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_notifications_user ON public.phpbb_notifications USING btree (user_id, notification_read);
+
+
+--
+-- Name: phpbb_oauth_tokens_provider; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_tokens_provider ON public.phpbb_oauth_tokens USING btree (provider);
+
+
+--
+-- Name: phpbb_oauth_tokens_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_tokens_user_id ON public.phpbb_oauth_tokens USING btree (user_id);
+
+
+--
+-- Name: phpbb_poll_options_poll_opt_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_options_poll_opt_id ON public.phpbb_poll_options USING btree (poll_option_id);
+
+
+--
+-- Name: phpbb_poll_options_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_options_topic_id ON public.phpbb_poll_options USING btree (topic_id);
+
+
+--
+-- Name: phpbb_poll_votes_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_topic_id ON public.phpbb_poll_votes USING btree (topic_id);
+
+
+--
+-- Name: phpbb_poll_votes_vote_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_vote_user_id ON public.phpbb_poll_votes USING btree (vote_user_id);
+
+
+--
+-- Name: phpbb_poll_votes_vote_user_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_vote_user_ip ON public.phpbb_poll_votes USING btree (vote_user_ip);
+
+
+--
+-- Name: phpbb_posts_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_forum_id ON public.phpbb_posts USING btree (forum_id);
+
+
+--
+-- Name: phpbb_posts_post_username; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_post_username ON public.phpbb_posts USING btree (post_username);
+
+
+--
+-- Name: phpbb_posts_post_visibility; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_post_visibility ON public.phpbb_posts USING btree (post_visibility);
+
+
+--
+-- Name: phpbb_posts_poster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_poster_id ON public.phpbb_posts USING btree (poster_id);
+
+
+--
+-- Name: phpbb_posts_poster_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_poster_ip ON public.phpbb_posts USING btree (poster_ip);
+
+
+--
+-- Name: phpbb_posts_tid_post_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_tid_post_time ON public.phpbb_posts USING btree (topic_id, post_time);
+
+
+--
+-- Name: phpbb_posts_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_topic_id ON public.phpbb_posts USING btree (topic_id);
+
+
+--
+-- Name: phpbb_privmsgs_author_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_author_id ON public.phpbb_privmsgs USING btree (author_id);
+
+
+--
+-- Name: phpbb_privmsgs_author_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_author_ip ON public.phpbb_privmsgs USING btree (author_ip);
+
+
+--
+-- Name: phpbb_privmsgs_folder_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_folder_user_id ON public.phpbb_privmsgs_folder USING btree (user_id);
+
+
+--
+-- Name: phpbb_privmsgs_message_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_message_time ON public.phpbb_privmsgs USING btree (message_time);
+
+
+--
+-- Name: phpbb_privmsgs_root_level; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_root_level ON public.phpbb_privmsgs USING btree (root_level);
+
+
+--
+-- Name: phpbb_privmsgs_rules_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_rules_user_id ON public.phpbb_privmsgs_rules USING btree (user_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_author_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_author_id ON public.phpbb_privmsgs_to USING btree (author_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_msg_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_msg_id ON public.phpbb_privmsgs_to USING btree (msg_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_usr_flder_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_usr_flder_id ON public.phpbb_privmsgs_to USING btree (user_id, folder_id);
+
+
+--
+-- Name: phpbb_profile_fields_fld_ordr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_profile_fields_fld_ordr ON public.phpbb_profile_fields USING btree (field_order);
+
+
+--
+-- Name: phpbb_profile_fields_fld_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_profile_fields_fld_type ON public.phpbb_profile_fields USING btree (field_type);
+
+
+--
+-- Name: phpbb_reports_pm_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_reports_pm_id ON public.phpbb_reports USING btree (pm_id);
+
+
+--
+-- Name: phpbb_reports_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_reports_post_id ON public.phpbb_reports USING btree (post_id);
+
+
+--
+-- Name: phpbb_search_wordlist_wrd_cnt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordlist_wrd_cnt ON public.phpbb_search_wordlist USING btree (word_count);
+
+
+--
+-- Name: phpbb_search_wordlist_wrd_txt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_search_wordlist_wrd_txt ON public.phpbb_search_wordlist USING btree (word_text);
+
+
+--
+-- Name: phpbb_search_wordmatch_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordmatch_post_id ON public.phpbb_search_wordmatch USING btree (post_id);
+
+
+--
+-- Name: phpbb_search_wordmatch_un_mtch; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_search_wordmatch_un_mtch ON public.phpbb_search_wordmatch USING btree (word_id, post_id, title_match);
+
+
+--
+-- Name: phpbb_search_wordmatch_word_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordmatch_word_id ON public.phpbb_search_wordmatch USING btree (word_id);
+
+
+--
+-- Name: phpbb_sessions_keys_last_login; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_keys_last_login ON public.phpbb_sessions_keys USING btree (last_login);
+
+
+--
+-- Name: phpbb_sessions_session_fid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_fid ON public.phpbb_sessions USING btree (session_forum_id);
+
+
+--
+-- Name: phpbb_sessions_session_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_time ON public.phpbb_sessions USING btree (session_time);
+
+
+--
+-- Name: phpbb_sessions_session_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_user_id ON public.phpbb_sessions USING btree (session_user_id);
+
+
+--
+-- Name: phpbb_smilies_display_on_post; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_smilies_display_on_post ON public.phpbb_smilies USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_styles_style_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_styles_style_name ON public.phpbb_styles USING btree (style_name);
+
+
+--
+-- Name: phpbb_topics_fid_time_moved; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_fid_time_moved ON public.phpbb_topics USING btree (forum_id, topic_last_post_time, topic_moved_id);
+
+
+--
+-- Name: phpbb_topics_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_id ON public.phpbb_topics USING btree (forum_id);
+
+
+--
+-- Name: phpbb_topics_forum_id_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_id_type ON public.phpbb_topics USING btree (forum_id, topic_type);
+
+
+--
+-- Name: phpbb_topics_forum_vis_last; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_vis_last ON public.phpbb_topics USING btree (forum_id, topic_visibility, topic_last_post_id);
+
+
+--
+-- Name: phpbb_topics_last_post_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_last_post_time ON public.phpbb_topics USING btree (topic_last_post_time);
+
+
+--
+-- Name: phpbb_topics_latest_topics; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_latest_topics ON public.phpbb_topics USING btree (forum_id, topic_last_post_time, topic_last_post_id, topic_moved_id);
+
+
+--
+-- Name: phpbb_topics_topic_visibility; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_topic_visibility ON public.phpbb_topics USING btree (topic_visibility);
+
+
+--
+-- Name: phpbb_topics_track_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_track_forum_id ON public.phpbb_topics_track USING btree (forum_id);
+
+
+--
+-- Name: phpbb_topics_track_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_track_topic_id ON public.phpbb_topics_track USING btree (topic_id);
+
+
+--
+-- Name: phpbb_topics_watch_notify_stat; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_notify_stat ON public.phpbb_topics_watch USING btree (notify_status);
+
+
+--
+-- Name: phpbb_topics_watch_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_topic_id ON public.phpbb_topics_watch USING btree (topic_id);
+
+
+--
+-- Name: phpbb_topics_watch_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_user_id ON public.phpbb_topics_watch USING btree (user_id);
+
+
+--
+-- Name: phpbb_user_group_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_group_id ON public.phpbb_user_group USING btree (group_id);
+
+
+--
+-- Name: phpbb_user_group_group_leader; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_group_leader ON public.phpbb_user_group USING btree (group_leader);
+
+
+--
+-- Name: phpbb_user_group_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_user_id ON public.phpbb_user_group USING btree (user_id);
+
+
+--
+-- Name: phpbb_users_user_birthday; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_birthday ON public.phpbb_users USING btree (user_birthday);
+
+
+--
+-- Name: phpbb_users_user_email_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_email_hash ON public.phpbb_users USING btree (user_email_hash);
+
+
+--
+-- Name: phpbb_users_user_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_type ON public.phpbb_users USING btree (user_type);
+
+
+--
+-- Name: phpbb_users_username_clean; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_users_username_clean ON public.phpbb_users USING btree (username_clean);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict GTMkagd19OiQgHar1zVSRTpFkcQivVqRjGIdyGD3gn3JkvPhNezeNTC4M5koogW
+

--- a/migrations/converters/spec/fixtures/phpbb/schemas/3.2/mysql.sql
+++ b/migrations/converters/spec/fixtures/phpbb/schemas/3.2/mysql.sql
@@ -1,0 +1,1105 @@
+/*M!999999\- enable the sandbox mode */ 
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  KEY `group_id` (`group_id`),
+  KEY `auth_opt_id` (`auth_option_id`),
+  KEY `auth_role_id` (`auth_role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_options` (
+  `auth_option_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `auth_option` varchar(50) NOT NULL DEFAULT '',
+  `is_global` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `is_local` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `founder_only` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`auth_option_id`),
+  UNIQUE KEY `auth_option` (`auth_option`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_roles` (
+  `role_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `role_name` varchar(255) NOT NULL DEFAULT '',
+  `role_description` text NOT NULL,
+  `role_type` varchar(10) NOT NULL DEFAULT '',
+  `role_order` smallint(4) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`role_id`),
+  KEY `role_type` (`role_type`),
+  KEY `role_order` (`role_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_roles_data` (
+  `role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`role_id`,`auth_option_id`),
+  KEY `ath_op_id` (`auth_option_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_users` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  KEY `user_id` (`user_id`),
+  KEY `auth_option_id` (`auth_option_id`),
+  KEY `auth_role_id` (`auth_role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_attachments` (
+  `attach_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `post_msg_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `in_message` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `poster_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `is_orphan` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `physical_filename` varchar(255) NOT NULL DEFAULT '',
+  `real_filename` varchar(255) NOT NULL DEFAULT '',
+  `download_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `attach_comment` text NOT NULL,
+  `extension` varchar(100) NOT NULL DEFAULT '',
+  `mimetype` varchar(100) NOT NULL DEFAULT '',
+  `filesize` int(20) unsigned NOT NULL DEFAULT 0,
+  `filetime` int(11) unsigned NOT NULL DEFAULT 0,
+  `thumbnail` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`attach_id`),
+  KEY `filetime` (`filetime`),
+  KEY `post_msg_id` (`post_msg_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `poster_id` (`poster_id`),
+  KEY `is_orphan` (`is_orphan`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_banlist` (
+  `ban_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `ban_userid` int(10) unsigned NOT NULL DEFAULT 0,
+  `ban_ip` varchar(40) NOT NULL DEFAULT '',
+  `ban_email` varchar(100) NOT NULL DEFAULT '',
+  `ban_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `ban_end` int(11) unsigned NOT NULL DEFAULT 0,
+  `ban_exclude` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `ban_reason` varchar(255) NOT NULL DEFAULT '',
+  `ban_give_reason` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`ban_id`),
+  KEY `ban_end` (`ban_end`),
+  KEY `ban_user` (`ban_userid`,`ban_exclude`),
+  KEY `ban_email` (`ban_email`,`ban_exclude`),
+  KEY `ban_ip` (`ban_ip`,`ban_exclude`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bbcodes` (
+  `bbcode_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `bbcode_tag` varchar(16) NOT NULL DEFAULT '',
+  `bbcode_helpline` varchar(255) NOT NULL DEFAULT '',
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_match` text NOT NULL,
+  `bbcode_tpl` mediumtext NOT NULL,
+  `first_pass_match` mediumtext NOT NULL,
+  `first_pass_replace` mediumtext NOT NULL,
+  `second_pass_match` mediumtext NOT NULL,
+  `second_pass_replace` mediumtext NOT NULL,
+  PRIMARY KEY (`bbcode_id`),
+  KEY `display_on_post` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bookmarks` (
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`topic_id`,`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bots` (
+  `bot_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `bot_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `bot_name` varchar(255) NOT NULL DEFAULT '',
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `bot_agent` varchar(255) NOT NULL DEFAULT '',
+  `bot_ip` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`bot_id`),
+  KEY `bot_active` (`bot_active`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_config` (
+  `config_name` varchar(255) NOT NULL DEFAULT '',
+  `config_value` varchar(255) NOT NULL DEFAULT '',
+  `is_dynamic` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`config_name`),
+  KEY `is_dynamic` (`is_dynamic`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_config_text` (
+  `config_name` varchar(255) NOT NULL DEFAULT '',
+  `config_value` mediumtext NOT NULL,
+  PRIMARY KEY (`config_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_confirm` (
+  `confirm_id` char(32) NOT NULL DEFAULT '',
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `confirm_type` tinyint(3) NOT NULL DEFAULT 0,
+  `code` varchar(8) NOT NULL DEFAULT '',
+  `seed` int(10) unsigned NOT NULL DEFAULT 0,
+  `attempts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`session_id`,`confirm_id`),
+  KEY `confirm_type` (`confirm_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_disallow` (
+  `disallow_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `disallow_username` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`disallow_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_drafts` (
+  `draft_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `save_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `draft_subject` varchar(255) NOT NULL DEFAULT '',
+  `draft_message` mediumtext NOT NULL,
+  PRIMARY KEY (`draft_id`),
+  KEY `save_time` (`save_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_ext` (
+  `ext_name` varchar(255) NOT NULL DEFAULT '',
+  `ext_active` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `ext_state` text NOT NULL,
+  UNIQUE KEY `ext_name` (`ext_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_extension_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `cat_id` tinyint(2) NOT NULL DEFAULT 0,
+  `allow_group` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `download_mode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `upload_icon` varchar(255) NOT NULL DEFAULT '',
+  `max_filesize` int(20) unsigned NOT NULL DEFAULT 0,
+  `allowed_forums` text NOT NULL,
+  `allow_in_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_extensions` (
+  `extension_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `extension` varchar(100) NOT NULL DEFAULT '',
+  PRIMARY KEY (`extension_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums` (
+  `forum_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `left_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `right_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_parents` mediumtext NOT NULL,
+  `forum_name` varchar(255) NOT NULL DEFAULT '',
+  `forum_desc` text NOT NULL,
+  `forum_desc_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `forum_desc_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `forum_desc_uid` varchar(8) NOT NULL DEFAULT '',
+  `forum_link` varchar(255) NOT NULL DEFAULT '',
+  `forum_password` varchar(255) NOT NULL DEFAULT '',
+  `forum_style` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_image` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules` text NOT NULL,
+  `forum_rules_link` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `forum_rules_uid` varchar(8) NOT NULL DEFAULT '',
+  `forum_topics_per_page` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `forum_type` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_status` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_last_post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_last_poster_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_last_post_subject` varchar(255) NOT NULL DEFAULT '',
+  `forum_last_post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `forum_last_poster_name` varchar(255) NOT NULL DEFAULT '',
+  `forum_last_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `forum_flags` tinyint(4) NOT NULL DEFAULT 32,
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_indexing` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_icons` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_prune` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `prune_next` int(11) unsigned NOT NULL DEFAULT 0,
+  `prune_days` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `prune_viewed` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `prune_freq` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_subforum_list` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `forum_options` int(20) unsigned NOT NULL DEFAULT 0,
+  `enable_shadow_prune` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `prune_shadow_days` mediumint(8) unsigned NOT NULL DEFAULT 7,
+  `prune_shadow_freq` mediumint(8) unsigned NOT NULL DEFAULT 1,
+  `prune_shadow_next` int(11) NOT NULL DEFAULT 0,
+  `forum_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_approved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_unapproved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`forum_id`),
+  KEY `left_right_id` (`left_id`,`right_id`),
+  KEY `forum_lastpost_id` (`forum_last_post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_access` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `session_id` char(32) NOT NULL DEFAULT '',
+  PRIMARY KEY (`forum_id`,`user_id`,`session_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_track` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `mark_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_watch` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `notify_status` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  KEY `forum_id` (`forum_id`),
+  KEY `user_id` (`user_id`),
+  KEY `notify_stat` (`notify_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_type` tinyint(4) NOT NULL DEFAULT 1,
+  `group_founder_manage` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_skip_auth` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `group_desc` text NOT NULL,
+  `group_desc_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `group_desc_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `group_desc_uid` varchar(8) NOT NULL DEFAULT '',
+  `group_display` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_avatar` varchar(255) NOT NULL DEFAULT '',
+  `group_avatar_type` varchar(255) NOT NULL DEFAULT '',
+  `group_avatar_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `group_avatar_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `group_rank` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_colour` varchar(6) NOT NULL DEFAULT '',
+  `group_sig_chars` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_receive_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_message_limit` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_legend` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_max_recipients` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`group_id`),
+  KEY `group_legend_name` (`group_legend`,`group_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_icons` (
+  `icons_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `icons_url` varchar(255) NOT NULL DEFAULT '',
+  `icons_width` tinyint(4) NOT NULL DEFAULT 0,
+  `icons_height` tinyint(4) NOT NULL DEFAULT 0,
+  `icons_alt` varchar(255) NOT NULL DEFAULT '',
+  `icons_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`icons_id`),
+  KEY `display_on_posting` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_lang` (
+  `lang_id` tinyint(4) NOT NULL AUTO_INCREMENT,
+  `lang_iso` varchar(30) NOT NULL DEFAULT '',
+  `lang_dir` varchar(30) NOT NULL DEFAULT '',
+  `lang_english_name` varchar(100) NOT NULL DEFAULT '',
+  `lang_local_name` varchar(255) NOT NULL DEFAULT '',
+  `lang_author` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`lang_id`),
+  KEY `lang_iso` (`lang_iso`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_log` (
+  `log_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `log_type` tinyint(4) NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `reportee_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `log_ip` varchar(40) NOT NULL DEFAULT '',
+  `log_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `log_operation` text NOT NULL,
+  `log_data` mediumtext NOT NULL,
+  PRIMARY KEY (`log_id`),
+  KEY `log_type` (`log_type`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `reportee_id` (`reportee_id`),
+  KEY `user_id` (`user_id`),
+  KEY `log_time` (`log_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_login_attempts` (
+  `attempt_ip` varchar(40) NOT NULL DEFAULT '',
+  `attempt_browser` varchar(150) NOT NULL DEFAULT '',
+  `attempt_forwarded_for` varchar(255) NOT NULL DEFAULT '',
+  `attempt_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '0',
+  `username_clean` varchar(255) NOT NULL DEFAULT '0',
+  KEY `att_ip` (`attempt_ip`,`attempt_time`),
+  KEY `att_for` (`attempt_forwarded_for`,`attempt_time`),
+  KEY `att_time` (`attempt_time`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_migrations` (
+  `migration_name` varchar(255) NOT NULL DEFAULT '',
+  `migration_depends_on` text NOT NULL,
+  `migration_schema_done` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `migration_data_done` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `migration_data_state` text NOT NULL,
+  `migration_start_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `migration_end_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`migration_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_moderator_cache` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '',
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  KEY `disp_idx` (`display_on_index`),
+  KEY `forum_id` (`forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_modules` (
+  `module_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `module_enabled` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `module_display` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `module_basename` varchar(255) NOT NULL DEFAULT '',
+  `module_class` varchar(10) NOT NULL DEFAULT '',
+  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `left_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `right_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `module_langname` varchar(255) NOT NULL DEFAULT '',
+  `module_mode` varchar(255) NOT NULL DEFAULT '',
+  `module_auth` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`module_id`),
+  KEY `left_right_id` (`left_id`,`right_id`),
+  KEY `module_enabled` (`module_enabled`),
+  KEY `class_left_id` (`module_class`,`left_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_notification_types` (
+  `notification_type_id` smallint(4) unsigned NOT NULL AUTO_INCREMENT,
+  `notification_type_name` varchar(255) NOT NULL DEFAULT '',
+  `notification_type_enabled` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`notification_type_id`),
+  UNIQUE KEY `type` (`notification_type_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_notifications` (
+  `notification_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `notification_type_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `item_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `item_parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `notification_read` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `notification_time` int(11) unsigned NOT NULL DEFAULT 1,
+  `notification_data` text NOT NULL,
+  PRIMARY KEY (`notification_id`),
+  KEY `item_ident` (`notification_type_id`,`item_id`),
+  KEY `user` (`user_id`,`notification_read`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_oauth_accounts` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `provider` varchar(255) NOT NULL DEFAULT '',
+  `oauth_provider_id` text NOT NULL,
+  PRIMARY KEY (`user_id`,`provider`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_oauth_states` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `provider` varchar(255) NOT NULL DEFAULT '',
+  `oauth_state` varchar(255) NOT NULL DEFAULT '',
+  KEY `user_id` (`user_id`),
+  KEY `provider` (`provider`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_oauth_tokens` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `provider` varchar(255) NOT NULL DEFAULT '',
+  `oauth_token` mediumtext NOT NULL,
+  KEY `user_id` (`user_id`),
+  KEY `provider` (`provider`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_poll_options` (
+  `poll_option_id` tinyint(4) NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `poll_option_text` text NOT NULL,
+  `poll_option_total` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  KEY `poll_opt_id` (`poll_option_id`),
+  KEY `topic_id` (`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_poll_votes` (
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `poll_option_id` tinyint(4) NOT NULL DEFAULT 0,
+  `vote_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `vote_user_ip` varchar(40) NOT NULL DEFAULT '',
+  KEY `topic_id` (`topic_id`),
+  KEY `vote_user_id` (`vote_user_id`),
+  KEY `vote_user_ip` (`vote_user_ip`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_posts` (
+  `post_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poster_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poster_ip` varchar(40) NOT NULL DEFAULT '',
+  `post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `post_username` varchar(255) NOT NULL DEFAULT '',
+  `post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `post_text` mediumtext NOT NULL,
+  `post_checksum` varchar(32) NOT NULL DEFAULT '',
+  `post_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `post_postcount` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `post_edit_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_edit_reason` varchar(255) NOT NULL DEFAULT '',
+  `post_edit_user` int(10) unsigned NOT NULL DEFAULT 0,
+  `post_edit_count` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `post_edit_locked` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `post_visibility` tinyint(3) NOT NULL DEFAULT 0,
+  `post_delete_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_delete_reason` varchar(255) NOT NULL DEFAULT '',
+  `post_delete_user` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`post_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `poster_ip` (`poster_ip`),
+  KEY `poster_id` (`poster_id`),
+  KEY `tid_post_time` (`topic_id`,`post_time`),
+  KEY `post_username` (`post_username`),
+  KEY `post_visibility` (`post_visibility`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs` (
+  `msg_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `root_level` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_ip` varchar(40) NOT NULL DEFAULT '',
+  `message_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `message_subject` varchar(255) NOT NULL DEFAULT '',
+  `message_text` mediumtext NOT NULL,
+  `message_edit_reason` varchar(255) NOT NULL DEFAULT '',
+  `message_edit_user` int(10) unsigned NOT NULL DEFAULT 0,
+  `message_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `message_edit_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `message_edit_count` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `to_address` text NOT NULL,
+  `bcc_address` text NOT NULL,
+  `message_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`msg_id`),
+  KEY `author_ip` (`author_ip`),
+  KEY `message_time` (`message_time`),
+  KEY `author_id` (`author_id`),
+  KEY `root_level` (`root_level`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_folder` (
+  `folder_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `folder_name` varchar(255) NOT NULL DEFAULT '',
+  `pm_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`folder_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_rules` (
+  `rule_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `rule_check` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_connection` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_string` varchar(255) NOT NULL DEFAULT '',
+  `rule_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `rule_group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_action` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_folder_id` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`rule_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_to` (
+  `msg_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `author_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `pm_deleted` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_new` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `pm_unread` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `pm_replied` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_marked` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_forwarded` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `folder_id` int(11) NOT NULL DEFAULT 0,
+  KEY `msg_id` (`msg_id`),
+  KEY `author_id` (`author_id`),
+  KEY `usr_flder_id` (`user_id`,`folder_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields` (
+  `field_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `field_name` varchar(255) NOT NULL DEFAULT '',
+  `field_type` varchar(100) NOT NULL DEFAULT '',
+  `field_ident` varchar(20) NOT NULL DEFAULT '',
+  `field_length` varchar(20) NOT NULL DEFAULT '',
+  `field_minlen` varchar(255) NOT NULL DEFAULT '',
+  `field_maxlen` varchar(255) NOT NULL DEFAULT '',
+  `field_novalue` varchar(255) NOT NULL DEFAULT '',
+  `field_default_value` varchar(255) NOT NULL DEFAULT '',
+  `field_validation` varchar(64) NOT NULL DEFAULT '',
+  `field_required` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_reg` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_hide` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_no_view` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_active` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `field_show_profile` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_vt` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_novalue` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_ml` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_is_contact` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_contact_desc` varchar(255) NOT NULL DEFAULT '',
+  `field_contact_url` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`),
+  KEY `fld_type` (`field_type`),
+  KEY `fld_ordr` (`field_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields_data` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `pf_phpbb_interests` mediumtext NOT NULL,
+  `pf_phpbb_occupation` mediumtext NOT NULL,
+  `pf_phpbb_facebook` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_googleplus` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_icq` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_location` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_skype` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_twitter` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_website` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_yahoo` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_youtube` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_aol` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields_lang` (
+  `field_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `field_type` varchar(100) NOT NULL DEFAULT '',
+  `lang_value` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`,`lang_id`,`option_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_lang` (
+  `field_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_name` varchar(255) NOT NULL DEFAULT '',
+  `lang_explain` text NOT NULL,
+  `lang_default_value` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`,`lang_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_ranks` (
+  `rank_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `rank_title` varchar(255) NOT NULL DEFAULT '',
+  `rank_min` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rank_special` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `rank_image` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`rank_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_reports` (
+  `report_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `reason_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `report_closed` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `report_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `report_text` mediumtext NOT NULL,
+  `pm_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `reported_post_enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `reported_post_enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `reported_post_enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `reported_post_text` mediumtext NOT NULL,
+  `reported_post_uid` varchar(8) NOT NULL DEFAULT '',
+  `reported_post_bitfield` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`report_id`),
+  KEY `post_id` (`post_id`),
+  KEY `pm_id` (`pm_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_reports_reasons` (
+  `reason_id` smallint(4) unsigned NOT NULL AUTO_INCREMENT,
+  `reason_title` varchar(255) NOT NULL DEFAULT '',
+  `reason_description` mediumtext NOT NULL,
+  `reason_order` smallint(4) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`reason_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_results` (
+  `search_key` varchar(32) NOT NULL DEFAULT '',
+  `search_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `search_keywords` mediumtext NOT NULL,
+  `search_authors` mediumtext NOT NULL,
+  PRIMARY KEY (`search_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_wordlist` (
+  `word_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `word_text` varchar(255) NOT NULL DEFAULT '',
+  `word_common` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `word_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`word_id`),
+  UNIQUE KEY `wrd_txt` (`word_text`),
+  KEY `wrd_cnt` (`word_count`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_wordmatch` (
+  `post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `word_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `title_match` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  UNIQUE KEY `un_mtch` (`word_id`,`post_id`,`title_match`),
+  KEY `word_id` (`word_id`),
+  KEY `post_id` (`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sessions` (
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `session_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `session_last_visit` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_ip` varchar(40) NOT NULL DEFAULT '',
+  `session_browser` varchar(150) NOT NULL DEFAULT '',
+  `session_forwarded_for` varchar(255) NOT NULL DEFAULT '',
+  `session_page` varchar(255) NOT NULL DEFAULT '',
+  `session_viewonline` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `session_autologin` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `session_admin` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `session_forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`session_id`),
+  KEY `session_time` (`session_time`),
+  KEY `session_user_id` (`session_user_id`),
+  KEY `session_fid` (`session_forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sessions_keys` (
+  `key_id` char(32) NOT NULL DEFAULT '',
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_ip` varchar(40) NOT NULL DEFAULT '',
+  `last_login` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`key_id`,`user_id`),
+  KEY `last_login` (`last_login`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sitelist` (
+  `site_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `site_ip` varchar(40) NOT NULL DEFAULT '',
+  `site_hostname` varchar(255) NOT NULL DEFAULT '',
+  `ip_exclude` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`site_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_smilies` (
+  `smiley_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(50) NOT NULL DEFAULT '',
+  `emotion` varchar(255) NOT NULL DEFAULT '',
+  `smiley_url` varchar(50) NOT NULL DEFAULT '',
+  `smiley_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `smiley_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `smiley_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`smiley_id`),
+  KEY `display_on_post` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_styles` (
+  `style_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `style_name` varchar(255) NOT NULL DEFAULT '',
+  `style_copyright` varchar(255) NOT NULL DEFAULT '',
+  `style_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `style_path` varchar(100) NOT NULL DEFAULT '',
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT 'kNg=',
+  `style_parent_id` int(4) unsigned NOT NULL DEFAULT 0,
+  `style_parent_tree` text NOT NULL,
+  PRIMARY KEY (`style_id`),
+  UNIQUE KEY `style_name` (`style_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_teampage` (
+  `teampage_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `teampage_name` varchar(255) NOT NULL DEFAULT '',
+  `teampage_position` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `teampage_parent` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`teampage_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics` (
+  `topic_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_title` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `topic_poster` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_time_limit` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_views` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_status` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_type` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_first_post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_first_poster_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `topic_first_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `topic_last_post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_last_poster_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_last_poster_name` varchar(255) NOT NULL DEFAULT '',
+  `topic_last_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `topic_last_post_subject` varchar(255) NOT NULL DEFAULT '',
+  `topic_last_post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_last_view_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_moved_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_bumped` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_bumper` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poll_title` varchar(255) NOT NULL DEFAULT '',
+  `poll_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_length` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_max_options` tinyint(4) NOT NULL DEFAULT 1,
+  `poll_last_vote` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_vote_change` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_visibility` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_delete_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_delete_reason` varchar(255) NOT NULL DEFAULT '',
+  `topic_delete_user` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`topic_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `forum_id_type` (`forum_id`,`topic_type`),
+  KEY `last_post_time` (`topic_last_post_time`),
+  KEY `fid_time_moved` (`forum_id`,`topic_last_post_time`,`topic_moved_id`),
+  KEY `topic_visibility` (`topic_visibility`),
+  KEY `forum_vis_last` (`forum_id`,`topic_visibility`,`topic_last_post_id`),
+  KEY `latest_topics` (`forum_id`,`topic_last_post_time`,`topic_last_post_id`,`topic_moved_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_posted` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_posted` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_track` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `mark_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`topic_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_watch` (
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `notify_status` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  KEY `topic_id` (`topic_id`),
+  KEY `user_id` (`user_id`),
+  KEY `notify_stat` (`notify_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_user_group` (
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `group_leader` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_pending` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  KEY `group_id` (`group_id`),
+  KEY `user_id` (`user_id`),
+  KEY `group_leader` (`group_leader`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_user_notifications` (
+  `item_type` varchar(165) NOT NULL DEFAULT '',
+  `item_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `method` varchar(165) NOT NULL DEFAULT '',
+  `notify` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  UNIQUE KEY `itm_usr_mthd` (`item_type`,`item_id`,`user_id`,`method`),
+  KEY `user_id` (`user_id`),
+  KEY `uid_itm_id` (`user_id`,`item_id`),
+  KEY `usr_itm_tpe` (`user_id`,`item_type`,`item_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_users` (
+  `user_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_type` tinyint(2) NOT NULL DEFAULT 0,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 3,
+  `user_permissions` mediumtext NOT NULL,
+  `user_perm_from` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_ip` varchar(40) NOT NULL DEFAULT '',
+  `user_regdate` int(11) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '',
+  `username_clean` varchar(255) NOT NULL DEFAULT '',
+  `user_password` varchar(255) NOT NULL DEFAULT '',
+  `user_passchg` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_email` varchar(100) NOT NULL DEFAULT '',
+  `user_email_hash` bigint(20) NOT NULL DEFAULT 0,
+  `user_birthday` varchar(10) NOT NULL DEFAULT '',
+  `user_lastvisit` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastmark` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastpost_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastpage` varchar(200) NOT NULL DEFAULT '',
+  `user_last_confirm_key` varchar(10) NOT NULL DEFAULT '',
+  `user_last_search` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_warnings` tinyint(4) NOT NULL DEFAULT 0,
+  `user_last_warning` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_login_attempts` tinyint(4) NOT NULL DEFAULT 0,
+  `user_inactive_reason` tinyint(2) NOT NULL DEFAULT 0,
+  `user_inactive_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_posts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_lang` varchar(30) NOT NULL DEFAULT '',
+  `user_timezone` varchar(100) NOT NULL DEFAULT '',
+  `user_dateformat` varchar(64) NOT NULL DEFAULT 'd M Y H:i',
+  `user_style` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_rank` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_colour` varchar(6) NOT NULL DEFAULT '',
+  `user_new_privmsg` int(4) NOT NULL DEFAULT 0,
+  `user_unread_privmsg` int(4) NOT NULL DEFAULT 0,
+  `user_last_privmsg` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_message_rules` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_full_folder` int(11) NOT NULL DEFAULT -3,
+  `user_emailtime` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_topic_show_days` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_topic_sortby_type` varchar(1) NOT NULL DEFAULT 't',
+  `user_topic_sortby_dir` varchar(1) NOT NULL DEFAULT 'd',
+  `user_post_show_days` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_post_sortby_type` varchar(1) NOT NULL DEFAULT 't',
+  `user_post_sortby_dir` varchar(1) NOT NULL DEFAULT 'a',
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_notify_pm` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_notify_type` tinyint(4) NOT NULL DEFAULT 0,
+  `user_allow_pm` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_viewonline` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_viewemail` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_massemail` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_options` int(11) unsigned NOT NULL DEFAULT 230271,
+  `user_avatar` varchar(255) NOT NULL DEFAULT '',
+  `user_avatar_type` varchar(255) NOT NULL DEFAULT '',
+  `user_avatar_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_avatar_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_sig` mediumtext NOT NULL,
+  `user_sig_bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `user_sig_bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `user_jabber` varchar(255) NOT NULL DEFAULT '',
+  `user_actkey` varchar(32) NOT NULL DEFAULT '',
+  `user_newpasswd` varchar(255) NOT NULL DEFAULT '',
+  `user_form_salt` varchar(32) NOT NULL DEFAULT '',
+  `user_new` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_reminded` tinyint(4) NOT NULL DEFAULT 0,
+  `user_reminded_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`),
+  UNIQUE KEY `username_clean` (`username_clean`),
+  KEY `user_birthday` (`user_birthday`),
+  KEY `user_email_hash` (`user_email_hash`),
+  KEY `user_type` (`user_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_warnings` (
+  `warning_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `log_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `warning_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`warning_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_words` (
+  `word_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `word` varchar(255) NOT NULL DEFAULT '',
+  `replacement` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`word_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_zebra` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `zebra_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `friend` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `foe` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`zebra_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;

--- a/migrations/converters/spec/fixtures/phpbb/schemas/3.2/postgres.sql
+++ b/migrations/converters/spec/fixtures/phpbb/schemas/3.2/postgres.sql
@@ -1,0 +1,3303 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict jUFXBXkU9OKeNgjjaU6XnUYZkk7P4W1XOv5NMSiwK1Pm27Idb9ameSsOEhPXnbj
+
+-- Dumped from database version 16.14 (Debian 16.14-1.pgdg13+1)
+-- Dumped by pg_dump version 16.14 (Debian 16.14-1.pgdg13+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: varchar_ci; Type: DOMAIN; Schema: public; Owner: -
+--
+
+CREATE DOMAIN public.varchar_ci AS character varying(255) NOT NULL DEFAULT ''::character varying;
+
+
+--
+-- Name: _varchar_ci_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) = LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_greater_equals(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_greater_equals(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) >= LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_greater_than(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_greater_than(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) > LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_less_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_less_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) <= LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_less_than(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_less_than(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) < LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_not_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_not_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) != LOWER($2)$_$;
+
+
+--
+-- Name: <; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.< (
+    FUNCTION = public._varchar_ci_less_than,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.>),
+    NEGATOR = OPERATOR(public.>=),
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+--
+-- Name: <=; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.<= (
+    FUNCTION = public._varchar_ci_less_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.>=),
+    NEGATOR = OPERATOR(public.>),
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+--
+-- Name: <>; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.<> (
+    FUNCTION = public._varchar_ci_not_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<>),
+    NEGATOR = OPERATOR(public.=),
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+
+
+--
+-- Name: =; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.= (
+    FUNCTION = public._varchar_ci_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.=),
+    NEGATOR = OPERATOR(public.<>),
+    MERGES,
+    HASHES,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel
+);
+
+
+--
+-- Name: >; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.> (
+    FUNCTION = public._varchar_ci_greater_than,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<),
+    NEGATOR = OPERATOR(public.<=),
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+--
+-- Name: >=; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.>= (
+    FUNCTION = public._varchar_ci_greater_equals,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<=),
+    NEGATOR = OPERATOR(public.<),
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: phpbb_acl_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_groups (
+    group_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_role_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_groups_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_auth_role_id_check CHECK ((auth_role_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_group_id_check CHECK ((group_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_options_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_acl_options_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_acl_options; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_options (
+    auth_option_id integer DEFAULT nextval('public.phpbb_acl_options_seq'::regclass) NOT NULL,
+    auth_option character varying(50) DEFAULT ''::character varying NOT NULL,
+    is_global smallint DEFAULT '0'::smallint NOT NULL,
+    is_local smallint DEFAULT '0'::smallint NOT NULL,
+    founder_only smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_options_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_options_founder_only_check CHECK ((founder_only >= 0)),
+    CONSTRAINT phpbb_acl_options_is_global_check CHECK ((is_global >= 0)),
+    CONSTRAINT phpbb_acl_options_is_local_check CHECK ((is_local >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_roles_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_acl_roles_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_acl_roles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_roles (
+    role_id integer DEFAULT nextval('public.phpbb_acl_roles_seq'::regclass) NOT NULL,
+    role_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    role_description character varying(4000) DEFAULT ''::character varying NOT NULL,
+    role_type character varying(10) DEFAULT ''::character varying NOT NULL,
+    role_order smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_roles_role_id_check CHECK ((role_id >= 0)),
+    CONSTRAINT phpbb_acl_roles_role_order_check CHECK ((role_order >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_roles_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_roles_data (
+    role_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_roles_data_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_roles_data_role_id_check CHECK ((role_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_users (
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_role_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_users_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_users_auth_role_id_check CHECK ((auth_role_id >= 0)),
+    CONSTRAINT phpbb_acl_users_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_acl_users_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_attachments_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_attachments_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_attachments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_attachments (
+    attach_id integer DEFAULT nextval('public.phpbb_attachments_seq'::regclass) NOT NULL,
+    post_msg_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    in_message smallint DEFAULT '0'::smallint NOT NULL,
+    poster_id integer DEFAULT 0 NOT NULL,
+    is_orphan smallint DEFAULT '1'::smallint NOT NULL,
+    physical_filename character varying(255) DEFAULT ''::character varying NOT NULL,
+    real_filename character varying(255) DEFAULT ''::character varying NOT NULL,
+    download_count integer DEFAULT 0 NOT NULL,
+    attach_comment character varying(4000) DEFAULT ''::character varying NOT NULL,
+    extension character varying(100) DEFAULT ''::character varying NOT NULL,
+    mimetype character varying(100) DEFAULT ''::character varying NOT NULL,
+    filesize integer DEFAULT 0 NOT NULL,
+    filetime integer DEFAULT 0 NOT NULL,
+    thumbnail smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_attachments_attach_id_check CHECK ((attach_id >= 0)),
+    CONSTRAINT phpbb_attachments_download_count_check CHECK ((download_count >= 0)),
+    CONSTRAINT phpbb_attachments_filesize_check CHECK ((filesize >= 0)),
+    CONSTRAINT phpbb_attachments_filetime_check CHECK ((filetime >= 0)),
+    CONSTRAINT phpbb_attachments_in_message_check CHECK ((in_message >= 0)),
+    CONSTRAINT phpbb_attachments_is_orphan_check CHECK ((is_orphan >= 0)),
+    CONSTRAINT phpbb_attachments_post_msg_id_check CHECK ((post_msg_id >= 0)),
+    CONSTRAINT phpbb_attachments_poster_id_check CHECK ((poster_id >= 0)),
+    CONSTRAINT phpbb_attachments_thumbnail_check CHECK ((thumbnail >= 0)),
+    CONSTRAINT phpbb_attachments_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_banlist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_banlist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_banlist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_banlist (
+    ban_id integer DEFAULT nextval('public.phpbb_banlist_seq'::regclass) NOT NULL,
+    ban_userid integer DEFAULT 0 NOT NULL,
+    ban_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    ban_email character varying(100) DEFAULT ''::character varying NOT NULL,
+    ban_start integer DEFAULT 0 NOT NULL,
+    ban_end integer DEFAULT 0 NOT NULL,
+    ban_exclude smallint DEFAULT '0'::smallint NOT NULL,
+    ban_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    ban_give_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_banlist_ban_end_check CHECK ((ban_end >= 0)),
+    CONSTRAINT phpbb_banlist_ban_exclude_check CHECK ((ban_exclude >= 0)),
+    CONSTRAINT phpbb_banlist_ban_id_check CHECK ((ban_id >= 0)),
+    CONSTRAINT phpbb_banlist_ban_start_check CHECK ((ban_start >= 0)),
+    CONSTRAINT phpbb_banlist_ban_userid_check CHECK ((ban_userid >= 0))
+);
+
+
+--
+-- Name: phpbb_bbcodes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bbcodes (
+    bbcode_id smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_tag character varying(16) DEFAULT ''::character varying NOT NULL,
+    bbcode_helpline character varying(255) DEFAULT ''::character varying NOT NULL,
+    display_on_posting smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_match character varying(4000) DEFAULT ''::character varying NOT NULL,
+    bbcode_tpl text DEFAULT ''::text NOT NULL,
+    first_pass_match text DEFAULT ''::text NOT NULL,
+    first_pass_replace text DEFAULT ''::text NOT NULL,
+    second_pass_match text DEFAULT ''::text NOT NULL,
+    second_pass_replace text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_bbcodes_bbcode_id_check CHECK ((bbcode_id >= 0)),
+    CONSTRAINT phpbb_bbcodes_display_on_posting_check CHECK ((display_on_posting >= 0))
+);
+
+
+--
+-- Name: phpbb_bookmarks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bookmarks (
+    topic_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_bookmarks_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_bookmarks_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_bots_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_bots_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_bots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bots (
+    bot_id integer DEFAULT nextval('public.phpbb_bots_seq'::regclass) NOT NULL,
+    bot_active smallint DEFAULT '1'::smallint NOT NULL,
+    bot_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    bot_agent character varying(255) DEFAULT ''::character varying NOT NULL,
+    bot_ip character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_bots_bot_active_check CHECK ((bot_active >= 0)),
+    CONSTRAINT phpbb_bots_bot_id_check CHECK ((bot_id >= 0)),
+    CONSTRAINT phpbb_bots_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_config; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_config (
+    config_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    config_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    is_dynamic smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_config_is_dynamic_check CHECK ((is_dynamic >= 0))
+);
+
+
+--
+-- Name: phpbb_config_text; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_config_text (
+    config_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    config_value text DEFAULT ''::text NOT NULL
+);
+
+
+--
+-- Name: phpbb_confirm; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_confirm (
+    confirm_id character(32) DEFAULT ''::bpchar NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    confirm_type smallint DEFAULT '0'::smallint NOT NULL,
+    code character varying(8) DEFAULT ''::character varying NOT NULL,
+    seed integer DEFAULT 0 NOT NULL,
+    attempts integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_confirm_attempts_check CHECK ((attempts >= 0)),
+    CONSTRAINT phpbb_confirm_seed_check CHECK ((seed >= 0))
+);
+
+
+--
+-- Name: phpbb_disallow_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_disallow_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_disallow; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_disallow (
+    disallow_id integer DEFAULT nextval('public.phpbb_disallow_seq'::regclass) NOT NULL,
+    disallow_username character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_disallow_disallow_id_check CHECK ((disallow_id >= 0))
+);
+
+
+--
+-- Name: phpbb_drafts_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_drafts_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_drafts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_drafts (
+    draft_id integer DEFAULT nextval('public.phpbb_drafts_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    save_time integer DEFAULT 0 NOT NULL,
+    draft_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    draft_message text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_drafts_draft_id_check CHECK ((draft_id >= 0)),
+    CONSTRAINT phpbb_drafts_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_drafts_save_time_check CHECK ((save_time >= 0)),
+    CONSTRAINT phpbb_drafts_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_drafts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_ext; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_ext (
+    ext_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    ext_active smallint DEFAULT '0'::smallint NOT NULL,
+    ext_state character varying(8000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_ext_ext_active_check CHECK ((ext_active >= 0))
+);
+
+
+--
+-- Name: phpbb_extension_groups_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_extension_groups_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_extension_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_extension_groups (
+    group_id integer DEFAULT nextval('public.phpbb_extension_groups_seq'::regclass) NOT NULL,
+    group_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    cat_id smallint DEFAULT '0'::smallint NOT NULL,
+    allow_group smallint DEFAULT '0'::smallint NOT NULL,
+    download_mode smallint DEFAULT '1'::smallint NOT NULL,
+    upload_icon character varying(255) DEFAULT ''::character varying NOT NULL,
+    max_filesize integer DEFAULT 0 NOT NULL,
+    allowed_forums character varying(8000) DEFAULT ''::character varying NOT NULL,
+    allow_in_pm smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_extension_groups_allow_group_check CHECK ((allow_group >= 0)),
+    CONSTRAINT phpbb_extension_groups_allow_in_pm_check CHECK ((allow_in_pm >= 0)),
+    CONSTRAINT phpbb_extension_groups_download_mode_check CHECK ((download_mode >= 0)),
+    CONSTRAINT phpbb_extension_groups_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_extension_groups_max_filesize_check CHECK ((max_filesize >= 0))
+);
+
+
+--
+-- Name: phpbb_extensions_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_extensions_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_extensions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_extensions (
+    extension_id integer DEFAULT nextval('public.phpbb_extensions_seq'::regclass) NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    extension character varying(100) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_extensions_extension_id_check CHECK ((extension_id >= 0)),
+    CONSTRAINT phpbb_extensions_group_id_check CHECK ((group_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_forums_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_forums; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums (
+    forum_id integer DEFAULT nextval('public.phpbb_forums_seq'::regclass) NOT NULL,
+    parent_id integer DEFAULT 0 NOT NULL,
+    left_id integer DEFAULT 0 NOT NULL,
+    right_id integer DEFAULT 0 NOT NULL,
+    forum_parents text DEFAULT ''::text NOT NULL,
+    forum_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_desc character varying(4000) DEFAULT ''::character varying NOT NULL,
+    forum_desc_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_desc_options integer DEFAULT 7 NOT NULL,
+    forum_desc_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    forum_link character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_password character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_style integer DEFAULT 0 NOT NULL,
+    forum_image character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules character varying(4000) DEFAULT ''::character varying NOT NULL,
+    forum_rules_link character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules_options integer DEFAULT 7 NOT NULL,
+    forum_rules_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    forum_topics_per_page smallint DEFAULT '0'::smallint NOT NULL,
+    forum_type smallint DEFAULT '0'::smallint NOT NULL,
+    forum_status smallint DEFAULT '0'::smallint NOT NULL,
+    forum_last_post_id integer DEFAULT 0 NOT NULL,
+    forum_last_poster_id integer DEFAULT 0 NOT NULL,
+    forum_last_post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_last_post_time integer DEFAULT 0 NOT NULL,
+    forum_last_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_last_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    forum_flags smallint DEFAULT '32'::smallint NOT NULL,
+    display_on_index smallint DEFAULT '1'::smallint NOT NULL,
+    enable_indexing smallint DEFAULT '1'::smallint NOT NULL,
+    enable_icons smallint DEFAULT '1'::smallint NOT NULL,
+    enable_prune smallint DEFAULT '0'::smallint NOT NULL,
+    prune_next integer DEFAULT 0 NOT NULL,
+    prune_days integer DEFAULT 0 NOT NULL,
+    prune_viewed integer DEFAULT 0 NOT NULL,
+    prune_freq integer DEFAULT 0 NOT NULL,
+    display_subforum_list smallint DEFAULT '1'::smallint NOT NULL,
+    forum_options integer DEFAULT 0 NOT NULL,
+    enable_shadow_prune smallint DEFAULT '0'::smallint NOT NULL,
+    prune_shadow_days integer DEFAULT 7 NOT NULL,
+    prune_shadow_freq integer DEFAULT 1 NOT NULL,
+    prune_shadow_next integer DEFAULT 0 NOT NULL,
+    forum_posts_approved integer DEFAULT 0 NOT NULL,
+    forum_posts_unapproved integer DEFAULT 0 NOT NULL,
+    forum_posts_softdeleted integer DEFAULT 0 NOT NULL,
+    forum_topics_approved integer DEFAULT 0 NOT NULL,
+    forum_topics_unapproved integer DEFAULT 0 NOT NULL,
+    forum_topics_softdeleted integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_forums_display_on_index_check CHECK ((display_on_index >= 0)),
+    CONSTRAINT phpbb_forums_display_subforum_list_check CHECK ((display_subforum_list >= 0)),
+    CONSTRAINT phpbb_forums_enable_icons_check CHECK ((enable_icons >= 0)),
+    CONSTRAINT phpbb_forums_enable_indexing_check CHECK ((enable_indexing >= 0)),
+    CONSTRAINT phpbb_forums_enable_prune_check CHECK ((enable_prune >= 0)),
+    CONSTRAINT phpbb_forums_enable_shadow_prune_check CHECK ((enable_shadow_prune >= 0)),
+    CONSTRAINT phpbb_forums_forum_desc_options_check CHECK ((forum_desc_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_post_id_check CHECK ((forum_last_post_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_post_time_check CHECK ((forum_last_post_time >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_poster_id_check CHECK ((forum_last_poster_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_options_check CHECK ((forum_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_approved_check CHECK ((forum_posts_approved >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_softdeleted_check CHECK ((forum_posts_softdeleted >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_unapproved_check CHECK ((forum_posts_unapproved >= 0)),
+    CONSTRAINT phpbb_forums_forum_rules_options_check CHECK ((forum_rules_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_style_check CHECK ((forum_style >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_approved_check CHECK ((forum_topics_approved >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_per_page_check CHECK ((forum_topics_per_page >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_softdeleted_check CHECK ((forum_topics_softdeleted >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_unapproved_check CHECK ((forum_topics_unapproved >= 0)),
+    CONSTRAINT phpbb_forums_left_id_check CHECK ((left_id >= 0)),
+    CONSTRAINT phpbb_forums_parent_id_check CHECK ((parent_id >= 0)),
+    CONSTRAINT phpbb_forums_prune_days_check CHECK ((prune_days >= 0)),
+    CONSTRAINT phpbb_forums_prune_freq_check CHECK ((prune_freq >= 0)),
+    CONSTRAINT phpbb_forums_prune_next_check CHECK ((prune_next >= 0)),
+    CONSTRAINT phpbb_forums_prune_shadow_days_check CHECK ((prune_shadow_days >= 0)),
+    CONSTRAINT phpbb_forums_prune_shadow_freq_check CHECK ((prune_shadow_freq >= 0)),
+    CONSTRAINT phpbb_forums_prune_viewed_check CHECK ((prune_viewed >= 0)),
+    CONSTRAINT phpbb_forums_right_id_check CHECK ((right_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_access; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_access (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    CONSTRAINT phpbb_forums_access_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_access_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_track; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_track (
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    mark_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_forums_track_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_track_mark_time_check CHECK ((mark_time >= 0)),
+    CONSTRAINT phpbb_forums_track_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_watch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_watch (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notify_status smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_forums_watch_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_watch_notify_status_check CHECK ((notify_status >= 0)),
+    CONSTRAINT phpbb_forums_watch_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_groups_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_groups_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_groups (
+    group_id integer DEFAULT nextval('public.phpbb_groups_seq'::regclass) NOT NULL,
+    group_type smallint DEFAULT '1'::smallint NOT NULL,
+    group_founder_manage smallint DEFAULT '0'::smallint NOT NULL,
+    group_skip_auth smallint DEFAULT '0'::smallint NOT NULL,
+    group_name public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    group_desc character varying(4000) DEFAULT ''::character varying NOT NULL,
+    group_desc_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_desc_options integer DEFAULT 7 NOT NULL,
+    group_desc_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    group_display smallint DEFAULT '0'::smallint NOT NULL,
+    group_avatar character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_avatar_type character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_avatar_width smallint DEFAULT '0'::smallint NOT NULL,
+    group_avatar_height smallint DEFAULT '0'::smallint NOT NULL,
+    group_rank integer DEFAULT 0 NOT NULL,
+    group_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    group_sig_chars integer DEFAULT 0 NOT NULL,
+    group_receive_pm smallint DEFAULT '0'::smallint NOT NULL,
+    group_message_limit integer DEFAULT 0 NOT NULL,
+    group_legend integer DEFAULT 0 NOT NULL,
+    group_max_recipients integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_groups_group_avatar_height_check CHECK ((group_avatar_height >= 0)),
+    CONSTRAINT phpbb_groups_group_avatar_width_check CHECK ((group_avatar_width >= 0)),
+    CONSTRAINT phpbb_groups_group_desc_options_check CHECK ((group_desc_options >= 0)),
+    CONSTRAINT phpbb_groups_group_display_check CHECK ((group_display >= 0)),
+    CONSTRAINT phpbb_groups_group_founder_manage_check CHECK ((group_founder_manage >= 0)),
+    CONSTRAINT phpbb_groups_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_groups_group_legend_check CHECK ((group_legend >= 0)),
+    CONSTRAINT phpbb_groups_group_max_recipients_check CHECK ((group_max_recipients >= 0)),
+    CONSTRAINT phpbb_groups_group_message_limit_check CHECK ((group_message_limit >= 0)),
+    CONSTRAINT phpbb_groups_group_rank_check CHECK ((group_rank >= 0)),
+    CONSTRAINT phpbb_groups_group_receive_pm_check CHECK ((group_receive_pm >= 0)),
+    CONSTRAINT phpbb_groups_group_sig_chars_check CHECK ((group_sig_chars >= 0)),
+    CONSTRAINT phpbb_groups_group_skip_auth_check CHECK ((group_skip_auth >= 0))
+);
+
+
+--
+-- Name: phpbb_icons_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_icons_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_icons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_icons (
+    icons_id integer DEFAULT nextval('public.phpbb_icons_seq'::regclass) NOT NULL,
+    icons_url character varying(255) DEFAULT ''::character varying NOT NULL,
+    icons_width smallint DEFAULT '0'::smallint NOT NULL,
+    icons_height smallint DEFAULT '0'::smallint NOT NULL,
+    icons_alt character varying(255) DEFAULT ''::character varying NOT NULL,
+    icons_order integer DEFAULT 0 NOT NULL,
+    display_on_posting smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_icons_display_on_posting_check CHECK ((display_on_posting >= 0)),
+    CONSTRAINT phpbb_icons_icons_id_check CHECK ((icons_id >= 0)),
+    CONSTRAINT phpbb_icons_icons_order_check CHECK ((icons_order >= 0))
+);
+
+
+--
+-- Name: phpbb_lang_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_lang_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_lang (
+    lang_id smallint DEFAULT nextval('public.phpbb_lang_seq'::regclass) NOT NULL,
+    lang_iso character varying(30) DEFAULT ''::character varying NOT NULL,
+    lang_dir character varying(30) DEFAULT ''::character varying NOT NULL,
+    lang_english_name character varying(100) DEFAULT ''::character varying NOT NULL,
+    lang_local_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    lang_author character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+--
+-- Name: phpbb_log_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_log_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_log (
+    log_id integer DEFAULT nextval('public.phpbb_log_seq'::regclass) NOT NULL,
+    log_type smallint DEFAULT '0'::smallint NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    reportee_id integer DEFAULT 0 NOT NULL,
+    log_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    log_time integer DEFAULT 0 NOT NULL,
+    log_operation character varying(4000) DEFAULT ''::character varying NOT NULL,
+    log_data text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_log_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_log_log_id_check CHECK ((log_id >= 0)),
+    CONSTRAINT phpbb_log_log_time_check CHECK ((log_time >= 0)),
+    CONSTRAINT phpbb_log_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_log_reportee_id_check CHECK ((reportee_id >= 0)),
+    CONSTRAINT phpbb_log_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_log_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_login_attempts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_login_attempts (
+    attempt_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    attempt_browser character varying(150) DEFAULT ''::character varying NOT NULL,
+    attempt_forwarded_for character varying(255) DEFAULT ''::character varying NOT NULL,
+    attempt_time integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    username character varying(255) DEFAULT '0'::character varying NOT NULL,
+    username_clean public.varchar_ci DEFAULT '0'::character varying NOT NULL,
+    CONSTRAINT phpbb_login_attempts_attempt_time_check CHECK ((attempt_time >= 0)),
+    CONSTRAINT phpbb_login_attempts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_migrations (
+    migration_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    migration_depends_on character varying(8000) DEFAULT ''::character varying NOT NULL,
+    migration_schema_done smallint DEFAULT '0'::smallint NOT NULL,
+    migration_data_done smallint DEFAULT '0'::smallint NOT NULL,
+    migration_data_state character varying(8000) DEFAULT ''::character varying NOT NULL,
+    migration_start_time integer DEFAULT 0 NOT NULL,
+    migration_end_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_migrations_migration_data_done_check CHECK ((migration_data_done >= 0)),
+    CONSTRAINT phpbb_migrations_migration_end_time_check CHECK ((migration_end_time >= 0)),
+    CONSTRAINT phpbb_migrations_migration_schema_done_check CHECK ((migration_schema_done >= 0)),
+    CONSTRAINT phpbb_migrations_migration_start_time_check CHECK ((migration_start_time >= 0))
+);
+
+
+--
+-- Name: phpbb_moderator_cache; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_moderator_cache (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    username character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    group_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    display_on_index smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_moderator_cache_display_on_index_check CHECK ((display_on_index >= 0)),
+    CONSTRAINT phpbb_moderator_cache_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_moderator_cache_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_moderator_cache_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_modules_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_modules_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_modules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_modules (
+    module_id integer DEFAULT nextval('public.phpbb_modules_seq'::regclass) NOT NULL,
+    module_enabled smallint DEFAULT '1'::smallint NOT NULL,
+    module_display smallint DEFAULT '1'::smallint NOT NULL,
+    module_basename character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_class character varying(10) DEFAULT ''::character varying NOT NULL,
+    parent_id integer DEFAULT 0 NOT NULL,
+    left_id integer DEFAULT 0 NOT NULL,
+    right_id integer DEFAULT 0 NOT NULL,
+    module_langname character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_mode character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_auth character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_modules_left_id_check CHECK ((left_id >= 0)),
+    CONSTRAINT phpbb_modules_module_display_check CHECK ((module_display >= 0)),
+    CONSTRAINT phpbb_modules_module_enabled_check CHECK ((module_enabled >= 0)),
+    CONSTRAINT phpbb_modules_module_id_check CHECK ((module_id >= 0)),
+    CONSTRAINT phpbb_modules_parent_id_check CHECK ((parent_id >= 0)),
+    CONSTRAINT phpbb_modules_right_id_check CHECK ((right_id >= 0))
+);
+
+
+--
+-- Name: phpbb_notification_types_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_notification_types_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_notification_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_notification_types (
+    notification_type_id smallint DEFAULT nextval('public.phpbb_notification_types_seq'::regclass) NOT NULL,
+    notification_type_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    notification_type_enabled smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_notification_types_notification_type_enabled_check CHECK ((notification_type_enabled >= 0)),
+    CONSTRAINT phpbb_notification_types_notification_type_id_check CHECK ((notification_type_id >= 0))
+);
+
+
+--
+-- Name: phpbb_notifications_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_notifications_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_notifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_notifications (
+    notification_id integer DEFAULT nextval('public.phpbb_notifications_seq'::regclass) NOT NULL,
+    notification_type_id smallint DEFAULT '0'::smallint NOT NULL,
+    item_id integer DEFAULT 0 NOT NULL,
+    item_parent_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notification_read smallint DEFAULT '0'::smallint NOT NULL,
+    notification_time integer DEFAULT 1 NOT NULL,
+    notification_data character varying(4000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_notifications_item_id_check CHECK ((item_id >= 0)),
+    CONSTRAINT phpbb_notifications_item_parent_id_check CHECK ((item_parent_id >= 0)),
+    CONSTRAINT phpbb_notifications_notification_id_check CHECK ((notification_id >= 0)),
+    CONSTRAINT phpbb_notifications_notification_read_check CHECK ((notification_read >= 0)),
+    CONSTRAINT phpbb_notifications_notification_time_check CHECK ((notification_time >= 0)),
+    CONSTRAINT phpbb_notifications_notification_type_id_check CHECK ((notification_type_id >= 0)),
+    CONSTRAINT phpbb_notifications_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_oauth_accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_oauth_accounts (
+    user_id integer DEFAULT 0 NOT NULL,
+    provider character varying(255) DEFAULT ''::character varying NOT NULL,
+    oauth_provider_id character varying(4000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_oauth_accounts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_oauth_states; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_oauth_states (
+    user_id integer DEFAULT 0 NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    provider character varying(255) DEFAULT ''::character varying NOT NULL,
+    oauth_state character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_oauth_states_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_oauth_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_oauth_tokens (
+    user_id integer DEFAULT 0 NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    provider character varying(255) DEFAULT ''::character varying NOT NULL,
+    oauth_token text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_oauth_tokens_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_poll_options; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_poll_options (
+    poll_option_id smallint DEFAULT '0'::smallint NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    poll_option_text character varying(4000) DEFAULT ''::character varying NOT NULL,
+    poll_option_total integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_poll_options_poll_option_total_check CHECK ((poll_option_total >= 0)),
+    CONSTRAINT phpbb_poll_options_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_poll_votes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_poll_votes (
+    topic_id integer DEFAULT 0 NOT NULL,
+    poll_option_id smallint DEFAULT '0'::smallint NOT NULL,
+    vote_user_id integer DEFAULT 0 NOT NULL,
+    vote_user_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_poll_votes_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_poll_votes_vote_user_id_check CHECK ((vote_user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_posts_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_posts_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_posts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_posts (
+    post_id integer DEFAULT nextval('public.phpbb_posts_seq'::regclass) NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    poster_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    poster_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    post_time integer DEFAULT 0 NOT NULL,
+    post_reported smallint DEFAULT '0'::smallint NOT NULL,
+    enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    enable_sig smallint DEFAULT '1'::smallint NOT NULL,
+    post_username character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_text text DEFAULT ''::text NOT NULL,
+    post_checksum character varying(32) DEFAULT ''::character varying NOT NULL,
+    post_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    post_postcount smallint DEFAULT '1'::smallint NOT NULL,
+    post_edit_time integer DEFAULT 0 NOT NULL,
+    post_edit_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_edit_user integer DEFAULT 0 NOT NULL,
+    post_edit_count smallint DEFAULT '0'::smallint NOT NULL,
+    post_edit_locked smallint DEFAULT '0'::smallint NOT NULL,
+    post_visibility smallint DEFAULT '0'::smallint NOT NULL,
+    post_delete_time integer DEFAULT 0 NOT NULL,
+    post_delete_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_delete_user integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_posts_enable_bbcode_check CHECK ((enable_bbcode >= 0)),
+    CONSTRAINT phpbb_posts_enable_magic_url_check CHECK ((enable_magic_url >= 0)),
+    CONSTRAINT phpbb_posts_enable_sig_check CHECK ((enable_sig >= 0)),
+    CONSTRAINT phpbb_posts_enable_smilies_check CHECK ((enable_smilies >= 0)),
+    CONSTRAINT phpbb_posts_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_posts_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_posts_post_attachment_check CHECK ((post_attachment >= 0)),
+    CONSTRAINT phpbb_posts_post_delete_time_check CHECK ((post_delete_time >= 0)),
+    CONSTRAINT phpbb_posts_post_delete_user_check CHECK ((post_delete_user >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_count_check CHECK ((post_edit_count >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_locked_check CHECK ((post_edit_locked >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_time_check CHECK ((post_edit_time >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_user_check CHECK ((post_edit_user >= 0)),
+    CONSTRAINT phpbb_posts_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_posts_post_postcount_check CHECK ((post_postcount >= 0)),
+    CONSTRAINT phpbb_posts_post_reported_check CHECK ((post_reported >= 0)),
+    CONSTRAINT phpbb_posts_post_time_check CHECK ((post_time >= 0)),
+    CONSTRAINT phpbb_posts_poster_id_check CHECK ((poster_id >= 0)),
+    CONSTRAINT phpbb_posts_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs (
+    msg_id integer DEFAULT nextval('public.phpbb_privmsgs_seq'::regclass) NOT NULL,
+    root_level integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    author_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    message_time integer DEFAULT 0 NOT NULL,
+    enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    enable_sig smallint DEFAULT '1'::smallint NOT NULL,
+    message_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    message_text text DEFAULT ''::text NOT NULL,
+    message_edit_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    message_edit_user integer DEFAULT 0 NOT NULL,
+    message_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    message_edit_time integer DEFAULT 0 NOT NULL,
+    message_edit_count smallint DEFAULT '0'::smallint NOT NULL,
+    to_address character varying(4000) DEFAULT ''::character varying NOT NULL,
+    bcc_address character varying(4000) DEFAULT ''::character varying NOT NULL,
+    message_reported smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_privmsgs_author_id_check CHECK ((author_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_bbcode_check CHECK ((enable_bbcode >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_magic_url_check CHECK ((enable_magic_url >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_sig_check CHECK ((enable_sig >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_smilies_check CHECK ((enable_smilies >= 0)),
+    CONSTRAINT phpbb_privmsgs_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_attachment_check CHECK ((message_attachment >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_count_check CHECK ((message_edit_count >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_time_check CHECK ((message_edit_time >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_user_check CHECK ((message_edit_user >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_reported_check CHECK ((message_reported >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_time_check CHECK ((message_time >= 0)),
+    CONSTRAINT phpbb_privmsgs_msg_id_check CHECK ((msg_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_root_level_check CHECK ((root_level >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_folder_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_folder_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs_folder; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_folder (
+    folder_id integer DEFAULT nextval('public.phpbb_privmsgs_folder_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    folder_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    pm_count integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_folder_folder_id_check CHECK ((folder_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_folder_pm_count_check CHECK ((pm_count >= 0)),
+    CONSTRAINT phpbb_privmsgs_folder_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_rules_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_rules_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs_rules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_rules (
+    rule_id integer DEFAULT nextval('public.phpbb_privmsgs_rules_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    rule_check integer DEFAULT 0 NOT NULL,
+    rule_connection integer DEFAULT 0 NOT NULL,
+    rule_string character varying(255) DEFAULT ''::character varying NOT NULL,
+    rule_user_id integer DEFAULT 0 NOT NULL,
+    rule_group_id integer DEFAULT 0 NOT NULL,
+    rule_action integer DEFAULT 0 NOT NULL,
+    rule_folder_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_rules_rule_action_check CHECK ((rule_action >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_check_check CHECK ((rule_check >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_connection_check CHECK ((rule_connection >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_group_id_check CHECK ((rule_group_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_id_check CHECK ((rule_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_user_id_check CHECK ((rule_user_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_to; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_to (
+    msg_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    pm_deleted smallint DEFAULT '0'::smallint NOT NULL,
+    pm_new smallint DEFAULT '1'::smallint NOT NULL,
+    pm_unread smallint DEFAULT '1'::smallint NOT NULL,
+    pm_replied smallint DEFAULT '0'::smallint NOT NULL,
+    pm_marked smallint DEFAULT '0'::smallint NOT NULL,
+    pm_forwarded smallint DEFAULT '0'::smallint NOT NULL,
+    folder_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_to_author_id_check CHECK ((author_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_msg_id_check CHECK ((msg_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_deleted_check CHECK ((pm_deleted >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_forwarded_check CHECK ((pm_forwarded >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_marked_check CHECK ((pm_marked >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_new_check CHECK ((pm_new >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_replied_check CHECK ((pm_replied >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_unread_check CHECK ((pm_unread >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_profile_fields_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_profile_fields; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields (
+    field_id integer DEFAULT nextval('public.phpbb_profile_fields_seq'::regclass) NOT NULL,
+    field_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_type character varying(100) DEFAULT ''::character varying NOT NULL,
+    field_ident character varying(20) DEFAULT ''::character varying NOT NULL,
+    field_length character varying(20) DEFAULT ''::character varying NOT NULL,
+    field_minlen character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_maxlen character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_novalue character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_default_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_validation character varying(64) DEFAULT ''::character varying NOT NULL,
+    field_required smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_reg smallint DEFAULT '0'::smallint NOT NULL,
+    field_hide smallint DEFAULT '0'::smallint NOT NULL,
+    field_no_view smallint DEFAULT '0'::smallint NOT NULL,
+    field_active smallint DEFAULT '0'::smallint NOT NULL,
+    field_order integer DEFAULT 0 NOT NULL,
+    field_show_profile smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_vt smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_novalue smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_pm smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_ml smallint DEFAULT '0'::smallint NOT NULL,
+    field_is_contact smallint DEFAULT '0'::smallint NOT NULL,
+    field_contact_desc character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_contact_url character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_field_active_check CHECK ((field_active >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_hide_check CHECK ((field_hide >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_is_contact_check CHECK ((field_is_contact >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_no_view_check CHECK ((field_no_view >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_order_check CHECK ((field_order >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_required_check CHECK ((field_required >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_novalue_check CHECK ((field_show_novalue >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_ml_check CHECK ((field_show_on_ml >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_pm_check CHECK ((field_show_on_pm >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_reg_check CHECK ((field_show_on_reg >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_vt_check CHECK ((field_show_on_vt >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_profile_check CHECK ((field_show_profile >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields_data (
+    user_id integer DEFAULT 0 NOT NULL,
+    pf_phpbb_interests text DEFAULT ''::text NOT NULL,
+    pf_phpbb_occupation text DEFAULT ''::text NOT NULL,
+    pf_phpbb_facebook character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_googleplus character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_icq character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_location character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_skype character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_twitter character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_website character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_yahoo character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_youtube character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_aol character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_data_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields_lang (
+    field_id integer DEFAULT 0 NOT NULL,
+    lang_id integer DEFAULT 0 NOT NULL,
+    option_id integer DEFAULT 0 NOT NULL,
+    field_type character varying(100) DEFAULT ''::character varying NOT NULL,
+    lang_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_lang_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_lang_lang_id_check CHECK ((lang_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_lang_option_id_check CHECK ((option_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_lang (
+    field_id integer DEFAULT 0 NOT NULL,
+    lang_id integer DEFAULT 0 NOT NULL,
+    lang_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    lang_explain character varying(4000) DEFAULT ''::character varying NOT NULL,
+    lang_default_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_lang_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_lang_lang_id_check CHECK ((lang_id >= 0))
+);
+
+
+--
+-- Name: phpbb_ranks_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_ranks_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_ranks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_ranks (
+    rank_id integer DEFAULT nextval('public.phpbb_ranks_seq'::regclass) NOT NULL,
+    rank_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    rank_min integer DEFAULT 0 NOT NULL,
+    rank_special smallint DEFAULT '0'::smallint NOT NULL,
+    rank_image character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_ranks_rank_id_check CHECK ((rank_id >= 0)),
+    CONSTRAINT phpbb_ranks_rank_min_check CHECK ((rank_min >= 0)),
+    CONSTRAINT phpbb_ranks_rank_special_check CHECK ((rank_special >= 0))
+);
+
+
+--
+-- Name: phpbb_reports_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_reports_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_reports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_reports (
+    report_id integer DEFAULT nextval('public.phpbb_reports_seq'::regclass) NOT NULL,
+    reason_id smallint DEFAULT '0'::smallint NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    user_notify smallint DEFAULT '0'::smallint NOT NULL,
+    report_closed smallint DEFAULT '0'::smallint NOT NULL,
+    report_time integer DEFAULT 0 NOT NULL,
+    report_text text DEFAULT ''::text NOT NULL,
+    pm_id integer DEFAULT 0 NOT NULL,
+    reported_post_enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    reported_post_enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    reported_post_enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    reported_post_text text DEFAULT ''::text NOT NULL,
+    reported_post_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    reported_post_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_reports_pm_id_check CHECK ((pm_id >= 0)),
+    CONSTRAINT phpbb_reports_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_reports_reason_id_check CHECK ((reason_id >= 0)),
+    CONSTRAINT phpbb_reports_report_closed_check CHECK ((report_closed >= 0)),
+    CONSTRAINT phpbb_reports_report_id_check CHECK ((report_id >= 0)),
+    CONSTRAINT phpbb_reports_report_time_check CHECK ((report_time >= 0)),
+    CONSTRAINT phpbb_reports_reported_post_enable_bbcode_check CHECK ((reported_post_enable_bbcode >= 0)),
+    CONSTRAINT phpbb_reports_reported_post_enable_magic_url_check CHECK ((reported_post_enable_magic_url >= 0)),
+    CONSTRAINT phpbb_reports_reported_post_enable_smilies_check CHECK ((reported_post_enable_smilies >= 0)),
+    CONSTRAINT phpbb_reports_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_reports_user_notify_check CHECK ((user_notify >= 0))
+);
+
+
+--
+-- Name: phpbb_reports_reasons_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_reports_reasons_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_reports_reasons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_reports_reasons (
+    reason_id smallint DEFAULT nextval('public.phpbb_reports_reasons_seq'::regclass) NOT NULL,
+    reason_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    reason_description text DEFAULT ''::text NOT NULL,
+    reason_order smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_reports_reasons_reason_id_check CHECK ((reason_id >= 0)),
+    CONSTRAINT phpbb_reports_reasons_reason_order_check CHECK ((reason_order >= 0))
+);
+
+
+--
+-- Name: phpbb_search_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_results (
+    search_key character varying(32) DEFAULT ''::character varying NOT NULL,
+    search_time integer DEFAULT 0 NOT NULL,
+    search_keywords text DEFAULT ''::text NOT NULL,
+    search_authors text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_search_results_search_time_check CHECK ((search_time >= 0))
+);
+
+
+--
+-- Name: phpbb_search_wordlist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_search_wordlist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_search_wordlist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_wordlist (
+    word_id integer DEFAULT nextval('public.phpbb_search_wordlist_seq'::regclass) NOT NULL,
+    word_text character varying(255) DEFAULT ''::character varying NOT NULL,
+    word_common smallint DEFAULT '0'::smallint NOT NULL,
+    word_count integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_search_wordlist_word_common_check CHECK ((word_common >= 0)),
+    CONSTRAINT phpbb_search_wordlist_word_count_check CHECK ((word_count >= 0)),
+    CONSTRAINT phpbb_search_wordlist_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_search_wordmatch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_wordmatch (
+    post_id integer DEFAULT 0 NOT NULL,
+    word_id integer DEFAULT 0 NOT NULL,
+    title_match smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_search_wordmatch_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_search_wordmatch_title_match_check CHECK ((title_match >= 0)),
+    CONSTRAINT phpbb_search_wordmatch_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sessions (
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    session_user_id integer DEFAULT 0 NOT NULL,
+    session_last_visit integer DEFAULT 0 NOT NULL,
+    session_start integer DEFAULT 0 NOT NULL,
+    session_time integer DEFAULT 0 NOT NULL,
+    session_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    session_browser character varying(150) DEFAULT ''::character varying NOT NULL,
+    session_forwarded_for character varying(255) DEFAULT ''::character varying NOT NULL,
+    session_page character varying(255) DEFAULT ''::character varying NOT NULL,
+    session_viewonline smallint DEFAULT '1'::smallint NOT NULL,
+    session_autologin smallint DEFAULT '0'::smallint NOT NULL,
+    session_admin smallint DEFAULT '0'::smallint NOT NULL,
+    session_forum_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_sessions_session_admin_check CHECK ((session_admin >= 0)),
+    CONSTRAINT phpbb_sessions_session_autologin_check CHECK ((session_autologin >= 0)),
+    CONSTRAINT phpbb_sessions_session_forum_id_check CHECK ((session_forum_id >= 0)),
+    CONSTRAINT phpbb_sessions_session_last_visit_check CHECK ((session_last_visit >= 0)),
+    CONSTRAINT phpbb_sessions_session_start_check CHECK ((session_start >= 0)),
+    CONSTRAINT phpbb_sessions_session_time_check CHECK ((session_time >= 0)),
+    CONSTRAINT phpbb_sessions_session_user_id_check CHECK ((session_user_id >= 0)),
+    CONSTRAINT phpbb_sessions_session_viewonline_check CHECK ((session_viewonline >= 0))
+);
+
+
+--
+-- Name: phpbb_sessions_keys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sessions_keys (
+    key_id character(32) DEFAULT ''::bpchar NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    last_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    last_login integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_sessions_keys_last_login_check CHECK ((last_login >= 0)),
+    CONSTRAINT phpbb_sessions_keys_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_sitelist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_sitelist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_sitelist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sitelist (
+    site_id integer DEFAULT nextval('public.phpbb_sitelist_seq'::regclass) NOT NULL,
+    site_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    site_hostname character varying(255) DEFAULT ''::character varying NOT NULL,
+    ip_exclude smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_sitelist_ip_exclude_check CHECK ((ip_exclude >= 0)),
+    CONSTRAINT phpbb_sitelist_site_id_check CHECK ((site_id >= 0))
+);
+
+
+--
+-- Name: phpbb_smilies_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_smilies_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_smilies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_smilies (
+    smiley_id integer DEFAULT nextval('public.phpbb_smilies_seq'::regclass) NOT NULL,
+    code character varying(50) DEFAULT ''::character varying NOT NULL,
+    emotion character varying(255) DEFAULT ''::character varying NOT NULL,
+    smiley_url character varying(50) DEFAULT ''::character varying NOT NULL,
+    smiley_width smallint DEFAULT '0'::smallint NOT NULL,
+    smiley_height smallint DEFAULT '0'::smallint NOT NULL,
+    smiley_order integer DEFAULT 0 NOT NULL,
+    display_on_posting smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_smilies_display_on_posting_check CHECK ((display_on_posting >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_height_check CHECK ((smiley_height >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_id_check CHECK ((smiley_id >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_order_check CHECK ((smiley_order >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_width_check CHECK ((smiley_width >= 0))
+);
+
+
+--
+-- Name: phpbb_styles_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_styles_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_styles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_styles (
+    style_id integer DEFAULT nextval('public.phpbb_styles_seq'::regclass) NOT NULL,
+    style_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    style_copyright character varying(255) DEFAULT ''::character varying NOT NULL,
+    style_active smallint DEFAULT '1'::smallint NOT NULL,
+    style_path character varying(100) DEFAULT ''::character varying NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT 'kNg='::character varying NOT NULL,
+    style_parent_id integer DEFAULT 0 NOT NULL,
+    style_parent_tree character varying(8000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_styles_style_active_check CHECK ((style_active >= 0)),
+    CONSTRAINT phpbb_styles_style_id_check CHECK ((style_id >= 0)),
+    CONSTRAINT phpbb_styles_style_parent_id_check CHECK ((style_parent_id >= 0))
+);
+
+
+--
+-- Name: phpbb_teampage_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_teampage_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_teampage; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_teampage (
+    teampage_id integer DEFAULT nextval('public.phpbb_teampage_seq'::regclass) NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    teampage_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    teampage_position integer DEFAULT 0 NOT NULL,
+    teampage_parent integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_teampage_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_teampage_teampage_id_check CHECK ((teampage_id >= 0)),
+    CONSTRAINT phpbb_teampage_teampage_parent_check CHECK ((teampage_parent >= 0)),
+    CONSTRAINT phpbb_teampage_teampage_position_check CHECK ((teampage_position >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_topics_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_topics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics (
+    topic_id integer DEFAULT nextval('public.phpbb_topics_seq'::regclass) NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    topic_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    topic_reported smallint DEFAULT '0'::smallint NOT NULL,
+    topic_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_poster integer DEFAULT 0 NOT NULL,
+    topic_time integer DEFAULT 0 NOT NULL,
+    topic_time_limit integer DEFAULT 0 NOT NULL,
+    topic_views integer DEFAULT 0 NOT NULL,
+    topic_status smallint DEFAULT '0'::smallint NOT NULL,
+    topic_type smallint DEFAULT '0'::smallint NOT NULL,
+    topic_first_post_id integer DEFAULT 0 NOT NULL,
+    topic_first_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_first_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_id integer DEFAULT 0 NOT NULL,
+    topic_last_poster_id integer DEFAULT 0 NOT NULL,
+    topic_last_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_last_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_time integer DEFAULT 0 NOT NULL,
+    topic_last_view_time integer DEFAULT 0 NOT NULL,
+    topic_moved_id integer DEFAULT 0 NOT NULL,
+    topic_bumped smallint DEFAULT '0'::smallint NOT NULL,
+    topic_bumper integer DEFAULT 0 NOT NULL,
+    poll_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    poll_start integer DEFAULT 0 NOT NULL,
+    poll_length integer DEFAULT 0 NOT NULL,
+    poll_max_options smallint DEFAULT '1'::smallint NOT NULL,
+    poll_last_vote integer DEFAULT 0 NOT NULL,
+    poll_vote_change smallint DEFAULT '0'::smallint NOT NULL,
+    topic_visibility smallint DEFAULT '0'::smallint NOT NULL,
+    topic_delete_time integer DEFAULT 0 NOT NULL,
+    topic_delete_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_delete_user integer DEFAULT 0 NOT NULL,
+    topic_posts_approved integer DEFAULT 0 NOT NULL,
+    topic_posts_unapproved integer DEFAULT 0 NOT NULL,
+    topic_posts_softdeleted integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_topics_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_topics_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_topics_poll_last_vote_check CHECK ((poll_last_vote >= 0)),
+    CONSTRAINT phpbb_topics_poll_length_check CHECK ((poll_length >= 0)),
+    CONSTRAINT phpbb_topics_poll_start_check CHECK ((poll_start >= 0)),
+    CONSTRAINT phpbb_topics_poll_vote_change_check CHECK ((poll_vote_change >= 0)),
+    CONSTRAINT phpbb_topics_topic_attachment_check CHECK ((topic_attachment >= 0)),
+    CONSTRAINT phpbb_topics_topic_bumped_check CHECK ((topic_bumped >= 0)),
+    CONSTRAINT phpbb_topics_topic_bumper_check CHECK ((topic_bumper >= 0)),
+    CONSTRAINT phpbb_topics_topic_delete_time_check CHECK ((topic_delete_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_delete_user_check CHECK ((topic_delete_user >= 0)),
+    CONSTRAINT phpbb_topics_topic_first_post_id_check CHECK ((topic_first_post_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_post_id_check CHECK ((topic_last_post_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_post_time_check CHECK ((topic_last_post_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_poster_id_check CHECK ((topic_last_poster_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_view_time_check CHECK ((topic_last_view_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_moved_id_check CHECK ((topic_moved_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_poster_check CHECK ((topic_poster >= 0)),
+    CONSTRAINT phpbb_topics_topic_posts_approved_check CHECK ((topic_posts_approved >= 0)),
+    CONSTRAINT phpbb_topics_topic_posts_softdeleted_check CHECK ((topic_posts_softdeleted >= 0)),
+    CONSTRAINT phpbb_topics_topic_posts_unapproved_check CHECK ((topic_posts_unapproved >= 0)),
+    CONSTRAINT phpbb_topics_topic_reported_check CHECK ((topic_reported >= 0)),
+    CONSTRAINT phpbb_topics_topic_time_check CHECK ((topic_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_time_limit_check CHECK ((topic_time_limit >= 0)),
+    CONSTRAINT phpbb_topics_topic_views_check CHECK ((topic_views >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_posted; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_posted (
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    topic_posted smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_topics_posted_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_posted_topic_posted_check CHECK ((topic_posted >= 0)),
+    CONSTRAINT phpbb_topics_posted_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_track; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_track (
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    mark_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_topics_track_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_topics_track_mark_time_check CHECK ((mark_time >= 0)),
+    CONSTRAINT phpbb_topics_track_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_track_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_watch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_watch (
+    topic_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notify_status smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_topics_watch_notify_status_check CHECK ((notify_status >= 0)),
+    CONSTRAINT phpbb_topics_watch_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_watch_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_user_group; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_user_group (
+    group_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    group_leader smallint DEFAULT '0'::smallint NOT NULL,
+    user_pending smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_user_group_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_user_group_group_leader_check CHECK ((group_leader >= 0)),
+    CONSTRAINT phpbb_user_group_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_user_group_user_pending_check CHECK ((user_pending >= 0))
+);
+
+
+--
+-- Name: phpbb_user_notifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_user_notifications (
+    item_type character varying(165) DEFAULT ''::character varying NOT NULL,
+    item_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    method character varying(165) DEFAULT ''::character varying NOT NULL,
+    notify smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_user_notifications_item_id_check CHECK ((item_id >= 0)),
+    CONSTRAINT phpbb_user_notifications_notify_check CHECK ((notify >= 0)),
+    CONSTRAINT phpbb_user_notifications_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_users_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_users_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_users (
+    user_id integer DEFAULT nextval('public.phpbb_users_seq'::regclass) NOT NULL,
+    user_type smallint DEFAULT '0'::smallint NOT NULL,
+    group_id integer DEFAULT 3 NOT NULL,
+    user_permissions text DEFAULT ''::text NOT NULL,
+    user_perm_from integer DEFAULT 0 NOT NULL,
+    user_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    user_regdate integer DEFAULT 0 NOT NULL,
+    username public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    username_clean public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    user_password character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_passchg integer DEFAULT 0 NOT NULL,
+    user_email character varying(100) DEFAULT ''::character varying NOT NULL,
+    user_email_hash bigint DEFAULT '0'::bigint NOT NULL,
+    user_birthday character varying(10) DEFAULT ''::character varying NOT NULL,
+    user_lastvisit integer DEFAULT 0 NOT NULL,
+    user_lastmark integer DEFAULT 0 NOT NULL,
+    user_lastpost_time integer DEFAULT 0 NOT NULL,
+    user_lastpage character varying(200) DEFAULT ''::character varying NOT NULL,
+    user_last_confirm_key character varying(10) DEFAULT ''::character varying NOT NULL,
+    user_last_search integer DEFAULT 0 NOT NULL,
+    user_warnings smallint DEFAULT '0'::smallint NOT NULL,
+    user_last_warning integer DEFAULT 0 NOT NULL,
+    user_login_attempts smallint DEFAULT '0'::smallint NOT NULL,
+    user_inactive_reason smallint DEFAULT '0'::smallint NOT NULL,
+    user_inactive_time integer DEFAULT 0 NOT NULL,
+    user_posts integer DEFAULT 0 NOT NULL,
+    user_lang character varying(30) DEFAULT ''::character varying NOT NULL,
+    user_timezone character varying(100) DEFAULT ''::character varying NOT NULL,
+    user_dateformat character varying(64) DEFAULT 'd M Y H:i'::character varying NOT NULL,
+    user_style integer DEFAULT 0 NOT NULL,
+    user_rank integer DEFAULT 0 NOT NULL,
+    user_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    user_new_privmsg integer DEFAULT 0 NOT NULL,
+    user_unread_privmsg integer DEFAULT 0 NOT NULL,
+    user_last_privmsg integer DEFAULT 0 NOT NULL,
+    user_message_rules smallint DEFAULT '0'::smallint NOT NULL,
+    user_full_folder integer DEFAULT '-3'::integer NOT NULL,
+    user_emailtime integer DEFAULT 0 NOT NULL,
+    user_topic_show_days smallint DEFAULT '0'::smallint NOT NULL,
+    user_topic_sortby_type character varying(1) DEFAULT 't'::character varying NOT NULL,
+    user_topic_sortby_dir character varying(1) DEFAULT 'd'::character varying NOT NULL,
+    user_post_show_days smallint DEFAULT '0'::smallint NOT NULL,
+    user_post_sortby_type character varying(1) DEFAULT 't'::character varying NOT NULL,
+    user_post_sortby_dir character varying(1) DEFAULT 'a'::character varying NOT NULL,
+    user_notify smallint DEFAULT '0'::smallint NOT NULL,
+    user_notify_pm smallint DEFAULT '1'::smallint NOT NULL,
+    user_notify_type smallint DEFAULT '0'::smallint NOT NULL,
+    user_allow_pm smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_viewonline smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_viewemail smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_massemail smallint DEFAULT '1'::smallint NOT NULL,
+    user_options integer DEFAULT 230271 NOT NULL,
+    user_avatar character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_avatar_type character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_avatar_width smallint DEFAULT '0'::smallint NOT NULL,
+    user_avatar_height smallint DEFAULT '0'::smallint NOT NULL,
+    user_sig text DEFAULT ''::text NOT NULL,
+    user_sig_bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    user_sig_bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_jabber character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_actkey character varying(32) DEFAULT ''::character varying NOT NULL,
+    user_newpasswd character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_form_salt character varying(32) DEFAULT ''::character varying NOT NULL,
+    user_new smallint DEFAULT '1'::smallint NOT NULL,
+    user_reminded smallint DEFAULT '0'::smallint NOT NULL,
+    user_reminded_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_users_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_users_user_allow_massemail_check CHECK ((user_allow_massemail >= 0)),
+    CONSTRAINT phpbb_users_user_allow_pm_check CHECK ((user_allow_pm >= 0)),
+    CONSTRAINT phpbb_users_user_allow_viewemail_check CHECK ((user_allow_viewemail >= 0)),
+    CONSTRAINT phpbb_users_user_allow_viewonline_check CHECK ((user_allow_viewonline >= 0)),
+    CONSTRAINT phpbb_users_user_avatar_height_check CHECK ((user_avatar_height >= 0)),
+    CONSTRAINT phpbb_users_user_avatar_width_check CHECK ((user_avatar_width >= 0)),
+    CONSTRAINT phpbb_users_user_emailtime_check CHECK ((user_emailtime >= 0)),
+    CONSTRAINT phpbb_users_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_users_user_inactive_time_check CHECK ((user_inactive_time >= 0)),
+    CONSTRAINT phpbb_users_user_last_privmsg_check CHECK ((user_last_privmsg >= 0)),
+    CONSTRAINT phpbb_users_user_last_search_check CHECK ((user_last_search >= 0)),
+    CONSTRAINT phpbb_users_user_last_warning_check CHECK ((user_last_warning >= 0)),
+    CONSTRAINT phpbb_users_user_lastmark_check CHECK ((user_lastmark >= 0)),
+    CONSTRAINT phpbb_users_user_lastpost_time_check CHECK ((user_lastpost_time >= 0)),
+    CONSTRAINT phpbb_users_user_lastvisit_check CHECK ((user_lastvisit >= 0)),
+    CONSTRAINT phpbb_users_user_message_rules_check CHECK ((user_message_rules >= 0)),
+    CONSTRAINT phpbb_users_user_new_check CHECK ((user_new >= 0)),
+    CONSTRAINT phpbb_users_user_notify_check CHECK ((user_notify >= 0)),
+    CONSTRAINT phpbb_users_user_notify_pm_check CHECK ((user_notify_pm >= 0)),
+    CONSTRAINT phpbb_users_user_options_check CHECK ((user_options >= 0)),
+    CONSTRAINT phpbb_users_user_passchg_check CHECK ((user_passchg >= 0)),
+    CONSTRAINT phpbb_users_user_perm_from_check CHECK ((user_perm_from >= 0)),
+    CONSTRAINT phpbb_users_user_post_show_days_check CHECK ((user_post_show_days >= 0)),
+    CONSTRAINT phpbb_users_user_posts_check CHECK ((user_posts >= 0)),
+    CONSTRAINT phpbb_users_user_rank_check CHECK ((user_rank >= 0)),
+    CONSTRAINT phpbb_users_user_regdate_check CHECK ((user_regdate >= 0)),
+    CONSTRAINT phpbb_users_user_reminded_time_check CHECK ((user_reminded_time >= 0)),
+    CONSTRAINT phpbb_users_user_style_check CHECK ((user_style >= 0)),
+    CONSTRAINT phpbb_users_user_topic_show_days_check CHECK ((user_topic_show_days >= 0))
+);
+
+
+--
+-- Name: phpbb_warnings_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_warnings_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_warnings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_warnings (
+    warning_id integer DEFAULT nextval('public.phpbb_warnings_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    log_id integer DEFAULT 0 NOT NULL,
+    warning_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_warnings_log_id_check CHECK ((log_id >= 0)),
+    CONSTRAINT phpbb_warnings_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_warnings_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_warnings_warning_id_check CHECK ((warning_id >= 0)),
+    CONSTRAINT phpbb_warnings_warning_time_check CHECK ((warning_time >= 0))
+);
+
+
+--
+-- Name: phpbb_words_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_words_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_words; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_words (
+    word_id integer DEFAULT nextval('public.phpbb_words_seq'::regclass) NOT NULL,
+    word character varying(255) DEFAULT ''::character varying NOT NULL,
+    replacement character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_words_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_zebra; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_zebra (
+    user_id integer DEFAULT 0 NOT NULL,
+    zebra_id integer DEFAULT 0 NOT NULL,
+    friend smallint DEFAULT '0'::smallint NOT NULL,
+    foe smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_zebra_foe_check CHECK ((foe >= 0)),
+    CONSTRAINT phpbb_zebra_friend_check CHECK ((friend >= 0)),
+    CONSTRAINT phpbb_zebra_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_zebra_zebra_id_check CHECK ((zebra_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_options phpbb_acl_options_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_options
+    ADD CONSTRAINT phpbb_acl_options_pkey PRIMARY KEY (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles_data phpbb_acl_roles_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_roles_data
+    ADD CONSTRAINT phpbb_acl_roles_data_pkey PRIMARY KEY (role_id, auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles phpbb_acl_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_roles
+    ADD CONSTRAINT phpbb_acl_roles_pkey PRIMARY KEY (role_id);
+
+
+--
+-- Name: phpbb_attachments phpbb_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_attachments
+    ADD CONSTRAINT phpbb_attachments_pkey PRIMARY KEY (attach_id);
+
+
+--
+-- Name: phpbb_banlist phpbb_banlist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_banlist
+    ADD CONSTRAINT phpbb_banlist_pkey PRIMARY KEY (ban_id);
+
+
+--
+-- Name: phpbb_bbcodes phpbb_bbcodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bbcodes
+    ADD CONSTRAINT phpbb_bbcodes_pkey PRIMARY KEY (bbcode_id);
+
+
+--
+-- Name: phpbb_bookmarks phpbb_bookmarks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bookmarks
+    ADD CONSTRAINT phpbb_bookmarks_pkey PRIMARY KEY (topic_id, user_id);
+
+
+--
+-- Name: phpbb_bots phpbb_bots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bots
+    ADD CONSTRAINT phpbb_bots_pkey PRIMARY KEY (bot_id);
+
+
+--
+-- Name: phpbb_config phpbb_config_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_config
+    ADD CONSTRAINT phpbb_config_pkey PRIMARY KEY (config_name);
+
+
+--
+-- Name: phpbb_config_text phpbb_config_text_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_config_text
+    ADD CONSTRAINT phpbb_config_text_pkey PRIMARY KEY (config_name);
+
+
+--
+-- Name: phpbb_confirm phpbb_confirm_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_confirm
+    ADD CONSTRAINT phpbb_confirm_pkey PRIMARY KEY (session_id, confirm_id);
+
+
+--
+-- Name: phpbb_disallow phpbb_disallow_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_disallow
+    ADD CONSTRAINT phpbb_disallow_pkey PRIMARY KEY (disallow_id);
+
+
+--
+-- Name: phpbb_drafts phpbb_drafts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_drafts
+    ADD CONSTRAINT phpbb_drafts_pkey PRIMARY KEY (draft_id);
+
+
+--
+-- Name: phpbb_extension_groups phpbb_extension_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_extension_groups
+    ADD CONSTRAINT phpbb_extension_groups_pkey PRIMARY KEY (group_id);
+
+
+--
+-- Name: phpbb_extensions phpbb_extensions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_extensions
+    ADD CONSTRAINT phpbb_extensions_pkey PRIMARY KEY (extension_id);
+
+
+--
+-- Name: phpbb_forums_access phpbb_forums_access_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums_access
+    ADD CONSTRAINT phpbb_forums_access_pkey PRIMARY KEY (forum_id, user_id, session_id);
+
+
+--
+-- Name: phpbb_forums phpbb_forums_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums
+    ADD CONSTRAINT phpbb_forums_pkey PRIMARY KEY (forum_id);
+
+
+--
+-- Name: phpbb_forums_track phpbb_forums_track_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums_track
+    ADD CONSTRAINT phpbb_forums_track_pkey PRIMARY KEY (user_id, forum_id);
+
+
+--
+-- Name: phpbb_groups phpbb_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_groups
+    ADD CONSTRAINT phpbb_groups_pkey PRIMARY KEY (group_id);
+
+
+--
+-- Name: phpbb_icons phpbb_icons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_icons
+    ADD CONSTRAINT phpbb_icons_pkey PRIMARY KEY (icons_id);
+
+
+--
+-- Name: phpbb_lang phpbb_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_lang
+    ADD CONSTRAINT phpbb_lang_pkey PRIMARY KEY (lang_id);
+
+
+--
+-- Name: phpbb_log phpbb_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_log
+    ADD CONSTRAINT phpbb_log_pkey PRIMARY KEY (log_id);
+
+
+--
+-- Name: phpbb_migrations phpbb_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_migrations
+    ADD CONSTRAINT phpbb_migrations_pkey PRIMARY KEY (migration_name);
+
+
+--
+-- Name: phpbb_modules phpbb_modules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_modules
+    ADD CONSTRAINT phpbb_modules_pkey PRIMARY KEY (module_id);
+
+
+--
+-- Name: phpbb_notification_types phpbb_notification_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_notification_types
+    ADD CONSTRAINT phpbb_notification_types_pkey PRIMARY KEY (notification_type_id);
+
+
+--
+-- Name: phpbb_notifications phpbb_notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_notifications
+    ADD CONSTRAINT phpbb_notifications_pkey PRIMARY KEY (notification_id);
+
+
+--
+-- Name: phpbb_oauth_accounts phpbb_oauth_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_oauth_accounts
+    ADD CONSTRAINT phpbb_oauth_accounts_pkey PRIMARY KEY (user_id, provider);
+
+
+--
+-- Name: phpbb_posts phpbb_posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_posts
+    ADD CONSTRAINT phpbb_posts_pkey PRIMARY KEY (post_id);
+
+
+--
+-- Name: phpbb_privmsgs_folder phpbb_privmsgs_folder_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs_folder
+    ADD CONSTRAINT phpbb_privmsgs_folder_pkey PRIMARY KEY (folder_id);
+
+
+--
+-- Name: phpbb_privmsgs phpbb_privmsgs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs
+    ADD CONSTRAINT phpbb_privmsgs_pkey PRIMARY KEY (msg_id);
+
+
+--
+-- Name: phpbb_privmsgs_rules phpbb_privmsgs_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs_rules
+    ADD CONSTRAINT phpbb_privmsgs_rules_pkey PRIMARY KEY (rule_id);
+
+
+--
+-- Name: phpbb_profile_fields_data phpbb_profile_fields_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields_data
+    ADD CONSTRAINT phpbb_profile_fields_data_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: phpbb_profile_fields_lang phpbb_profile_fields_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields_lang
+    ADD CONSTRAINT phpbb_profile_fields_lang_pkey PRIMARY KEY (field_id, lang_id, option_id);
+
+
+--
+-- Name: phpbb_profile_fields phpbb_profile_fields_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields
+    ADD CONSTRAINT phpbb_profile_fields_pkey PRIMARY KEY (field_id);
+
+
+--
+-- Name: phpbb_profile_lang phpbb_profile_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_lang
+    ADD CONSTRAINT phpbb_profile_lang_pkey PRIMARY KEY (field_id, lang_id);
+
+
+--
+-- Name: phpbb_ranks phpbb_ranks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_ranks
+    ADD CONSTRAINT phpbb_ranks_pkey PRIMARY KEY (rank_id);
+
+
+--
+-- Name: phpbb_reports phpbb_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_reports
+    ADD CONSTRAINT phpbb_reports_pkey PRIMARY KEY (report_id);
+
+
+--
+-- Name: phpbb_reports_reasons phpbb_reports_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_reports_reasons
+    ADD CONSTRAINT phpbb_reports_reasons_pkey PRIMARY KEY (reason_id);
+
+
+--
+-- Name: phpbb_search_results phpbb_search_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_search_results
+    ADD CONSTRAINT phpbb_search_results_pkey PRIMARY KEY (search_key);
+
+
+--
+-- Name: phpbb_search_wordlist phpbb_search_wordlist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_search_wordlist
+    ADD CONSTRAINT phpbb_search_wordlist_pkey PRIMARY KEY (word_id);
+
+
+--
+-- Name: phpbb_sessions_keys phpbb_sessions_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sessions_keys
+    ADD CONSTRAINT phpbb_sessions_keys_pkey PRIMARY KEY (key_id, user_id);
+
+
+--
+-- Name: phpbb_sessions phpbb_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sessions
+    ADD CONSTRAINT phpbb_sessions_pkey PRIMARY KEY (session_id);
+
+
+--
+-- Name: phpbb_sitelist phpbb_sitelist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sitelist
+    ADD CONSTRAINT phpbb_sitelist_pkey PRIMARY KEY (site_id);
+
+
+--
+-- Name: phpbb_smilies phpbb_smilies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_smilies
+    ADD CONSTRAINT phpbb_smilies_pkey PRIMARY KEY (smiley_id);
+
+
+--
+-- Name: phpbb_styles phpbb_styles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_styles
+    ADD CONSTRAINT phpbb_styles_pkey PRIMARY KEY (style_id);
+
+
+--
+-- Name: phpbb_teampage phpbb_teampage_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_teampage
+    ADD CONSTRAINT phpbb_teampage_pkey PRIMARY KEY (teampage_id);
+
+
+--
+-- Name: phpbb_topics phpbb_topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics
+    ADD CONSTRAINT phpbb_topics_pkey PRIMARY KEY (topic_id);
+
+
+--
+-- Name: phpbb_topics_posted phpbb_topics_posted_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics_posted
+    ADD CONSTRAINT phpbb_topics_posted_pkey PRIMARY KEY (user_id, topic_id);
+
+
+--
+-- Name: phpbb_topics_track phpbb_topics_track_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics_track
+    ADD CONSTRAINT phpbb_topics_track_pkey PRIMARY KEY (user_id, topic_id);
+
+
+--
+-- Name: phpbb_users phpbb_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_users
+    ADD CONSTRAINT phpbb_users_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: phpbb_warnings phpbb_warnings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_warnings
+    ADD CONSTRAINT phpbb_warnings_pkey PRIMARY KEY (warning_id);
+
+
+--
+-- Name: phpbb_words phpbb_words_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_words
+    ADD CONSTRAINT phpbb_words_pkey PRIMARY KEY (word_id);
+
+
+--
+-- Name: phpbb_zebra phpbb_zebra_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_zebra
+    ADD CONSTRAINT phpbb_zebra_pkey PRIMARY KEY (user_id, zebra_id);
+
+
+--
+-- Name: phpbb_acl_groups_auth_opt_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_auth_opt_id ON public.phpbb_acl_groups USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_groups_auth_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_auth_role_id ON public.phpbb_acl_groups USING btree (auth_role_id);
+
+
+--
+-- Name: phpbb_acl_groups_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_group_id ON public.phpbb_acl_groups USING btree (group_id);
+
+
+--
+-- Name: phpbb_acl_options_auth_option; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_acl_options_auth_option ON public.phpbb_acl_options USING btree (auth_option);
+
+
+--
+-- Name: phpbb_acl_roles_data_ath_op_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_data_ath_op_id ON public.phpbb_acl_roles_data USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles_role_order; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_role_order ON public.phpbb_acl_roles USING btree (role_order);
+
+
+--
+-- Name: phpbb_acl_roles_role_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_role_type ON public.phpbb_acl_roles USING btree (role_type);
+
+
+--
+-- Name: phpbb_acl_users_auth_option_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_auth_option_id ON public.phpbb_acl_users USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_users_auth_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_auth_role_id ON public.phpbb_acl_users USING btree (auth_role_id);
+
+
+--
+-- Name: phpbb_acl_users_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_user_id ON public.phpbb_acl_users USING btree (user_id);
+
+
+--
+-- Name: phpbb_attachments_filetime; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_filetime ON public.phpbb_attachments USING btree (filetime);
+
+
+--
+-- Name: phpbb_attachments_is_orphan; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_is_orphan ON public.phpbb_attachments USING btree (is_orphan);
+
+
+--
+-- Name: phpbb_attachments_post_msg_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_post_msg_id ON public.phpbb_attachments USING btree (post_msg_id);
+
+
+--
+-- Name: phpbb_attachments_poster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_poster_id ON public.phpbb_attachments USING btree (poster_id);
+
+
+--
+-- Name: phpbb_attachments_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_topic_id ON public.phpbb_attachments USING btree (topic_id);
+
+
+--
+-- Name: phpbb_banlist_ban_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_email ON public.phpbb_banlist USING btree (ban_email, ban_exclude);
+
+
+--
+-- Name: phpbb_banlist_ban_end; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_end ON public.phpbb_banlist USING btree (ban_end);
+
+
+--
+-- Name: phpbb_banlist_ban_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_ip ON public.phpbb_banlist USING btree (ban_ip, ban_exclude);
+
+
+--
+-- Name: phpbb_banlist_ban_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_user ON public.phpbb_banlist USING btree (ban_userid, ban_exclude);
+
+
+--
+-- Name: phpbb_bbcodes_display_on_post; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_bbcodes_display_on_post ON public.phpbb_bbcodes USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_bots_bot_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_bots_bot_active ON public.phpbb_bots USING btree (bot_active);
+
+
+--
+-- Name: phpbb_config_is_dynamic; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_config_is_dynamic ON public.phpbb_config USING btree (is_dynamic);
+
+
+--
+-- Name: phpbb_confirm_confirm_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_confirm_confirm_type ON public.phpbb_confirm USING btree (confirm_type);
+
+
+--
+-- Name: phpbb_drafts_save_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_drafts_save_time ON public.phpbb_drafts USING btree (save_time);
+
+
+--
+-- Name: phpbb_ext_ext_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_ext_ext_name ON public.phpbb_ext USING btree (ext_name);
+
+
+--
+-- Name: phpbb_forums_forum_lastpost_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_forum_lastpost_id ON public.phpbb_forums USING btree (forum_last_post_id);
+
+
+--
+-- Name: phpbb_forums_left_right_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_left_right_id ON public.phpbb_forums USING btree (left_id, right_id);
+
+
+--
+-- Name: phpbb_forums_watch_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_forum_id ON public.phpbb_forums_watch USING btree (forum_id);
+
+
+--
+-- Name: phpbb_forums_watch_notify_stat; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_notify_stat ON public.phpbb_forums_watch USING btree (notify_status);
+
+
+--
+-- Name: phpbb_forums_watch_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_user_id ON public.phpbb_forums_watch USING btree (user_id);
+
+
+--
+-- Name: phpbb_groups_group_legend_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_groups_group_legend_name ON public.phpbb_groups USING btree (group_legend, group_name);
+
+
+--
+-- Name: phpbb_icons_display_on_posting; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_icons_display_on_posting ON public.phpbb_icons USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_lang_lang_iso; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_lang_lang_iso ON public.phpbb_lang USING btree (lang_iso);
+
+
+--
+-- Name: phpbb_log_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_forum_id ON public.phpbb_log USING btree (forum_id);
+
+
+--
+-- Name: phpbb_log_log_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_log_time ON public.phpbb_log USING btree (log_time);
+
+
+--
+-- Name: phpbb_log_log_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_log_type ON public.phpbb_log USING btree (log_type);
+
+
+--
+-- Name: phpbb_log_reportee_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_reportee_id ON public.phpbb_log USING btree (reportee_id);
+
+
+--
+-- Name: phpbb_log_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_topic_id ON public.phpbb_log USING btree (topic_id);
+
+
+--
+-- Name: phpbb_log_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_user_id ON public.phpbb_log USING btree (user_id);
+
+
+--
+-- Name: phpbb_login_attempts_att_for; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_for ON public.phpbb_login_attempts USING btree (attempt_forwarded_for, attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_att_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_ip ON public.phpbb_login_attempts USING btree (attempt_ip, attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_att_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_time ON public.phpbb_login_attempts USING btree (attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_user_id ON public.phpbb_login_attempts USING btree (user_id);
+
+
+--
+-- Name: phpbb_moderator_cache_disp_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_moderator_cache_disp_idx ON public.phpbb_moderator_cache USING btree (display_on_index);
+
+
+--
+-- Name: phpbb_moderator_cache_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_moderator_cache_forum_id ON public.phpbb_moderator_cache USING btree (forum_id);
+
+
+--
+-- Name: phpbb_modules_class_left_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_class_left_id ON public.phpbb_modules USING btree (module_class, left_id);
+
+
+--
+-- Name: phpbb_modules_left_right_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_left_right_id ON public.phpbb_modules USING btree (left_id, right_id);
+
+
+--
+-- Name: phpbb_modules_module_enabled; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_module_enabled ON public.phpbb_modules USING btree (module_enabled);
+
+
+--
+-- Name: phpbb_notification_types_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_notification_types_type ON public.phpbb_notification_types USING btree (notification_type_name);
+
+
+--
+-- Name: phpbb_notifications_item_ident; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_notifications_item_ident ON public.phpbb_notifications USING btree (notification_type_id, item_id);
+
+
+--
+-- Name: phpbb_notifications_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_notifications_user ON public.phpbb_notifications USING btree (user_id, notification_read);
+
+
+--
+-- Name: phpbb_oauth_states_provider; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_states_provider ON public.phpbb_oauth_states USING btree (provider);
+
+
+--
+-- Name: phpbb_oauth_states_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_states_user_id ON public.phpbb_oauth_states USING btree (user_id);
+
+
+--
+-- Name: phpbb_oauth_tokens_provider; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_tokens_provider ON public.phpbb_oauth_tokens USING btree (provider);
+
+
+--
+-- Name: phpbb_oauth_tokens_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_tokens_user_id ON public.phpbb_oauth_tokens USING btree (user_id);
+
+
+--
+-- Name: phpbb_poll_options_poll_opt_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_options_poll_opt_id ON public.phpbb_poll_options USING btree (poll_option_id);
+
+
+--
+-- Name: phpbb_poll_options_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_options_topic_id ON public.phpbb_poll_options USING btree (topic_id);
+
+
+--
+-- Name: phpbb_poll_votes_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_topic_id ON public.phpbb_poll_votes USING btree (topic_id);
+
+
+--
+-- Name: phpbb_poll_votes_vote_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_vote_user_id ON public.phpbb_poll_votes USING btree (vote_user_id);
+
+
+--
+-- Name: phpbb_poll_votes_vote_user_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_vote_user_ip ON public.phpbb_poll_votes USING btree (vote_user_ip);
+
+
+--
+-- Name: phpbb_posts_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_forum_id ON public.phpbb_posts USING btree (forum_id);
+
+
+--
+-- Name: phpbb_posts_post_username; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_post_username ON public.phpbb_posts USING btree (post_username);
+
+
+--
+-- Name: phpbb_posts_post_visibility; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_post_visibility ON public.phpbb_posts USING btree (post_visibility);
+
+
+--
+-- Name: phpbb_posts_poster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_poster_id ON public.phpbb_posts USING btree (poster_id);
+
+
+--
+-- Name: phpbb_posts_poster_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_poster_ip ON public.phpbb_posts USING btree (poster_ip);
+
+
+--
+-- Name: phpbb_posts_tid_post_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_tid_post_time ON public.phpbb_posts USING btree (topic_id, post_time);
+
+
+--
+-- Name: phpbb_posts_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_topic_id ON public.phpbb_posts USING btree (topic_id);
+
+
+--
+-- Name: phpbb_privmsgs_author_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_author_id ON public.phpbb_privmsgs USING btree (author_id);
+
+
+--
+-- Name: phpbb_privmsgs_author_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_author_ip ON public.phpbb_privmsgs USING btree (author_ip);
+
+
+--
+-- Name: phpbb_privmsgs_folder_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_folder_user_id ON public.phpbb_privmsgs_folder USING btree (user_id);
+
+
+--
+-- Name: phpbb_privmsgs_message_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_message_time ON public.phpbb_privmsgs USING btree (message_time);
+
+
+--
+-- Name: phpbb_privmsgs_root_level; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_root_level ON public.phpbb_privmsgs USING btree (root_level);
+
+
+--
+-- Name: phpbb_privmsgs_rules_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_rules_user_id ON public.phpbb_privmsgs_rules USING btree (user_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_author_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_author_id ON public.phpbb_privmsgs_to USING btree (author_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_msg_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_msg_id ON public.phpbb_privmsgs_to USING btree (msg_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_usr_flder_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_usr_flder_id ON public.phpbb_privmsgs_to USING btree (user_id, folder_id);
+
+
+--
+-- Name: phpbb_profile_fields_fld_ordr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_profile_fields_fld_ordr ON public.phpbb_profile_fields USING btree (field_order);
+
+
+--
+-- Name: phpbb_profile_fields_fld_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_profile_fields_fld_type ON public.phpbb_profile_fields USING btree (field_type);
+
+
+--
+-- Name: phpbb_reports_pm_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_reports_pm_id ON public.phpbb_reports USING btree (pm_id);
+
+
+--
+-- Name: phpbb_reports_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_reports_post_id ON public.phpbb_reports USING btree (post_id);
+
+
+--
+-- Name: phpbb_search_wordlist_wrd_cnt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordlist_wrd_cnt ON public.phpbb_search_wordlist USING btree (word_count);
+
+
+--
+-- Name: phpbb_search_wordlist_wrd_txt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_search_wordlist_wrd_txt ON public.phpbb_search_wordlist USING btree (word_text);
+
+
+--
+-- Name: phpbb_search_wordmatch_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordmatch_post_id ON public.phpbb_search_wordmatch USING btree (post_id);
+
+
+--
+-- Name: phpbb_search_wordmatch_un_mtch; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_search_wordmatch_un_mtch ON public.phpbb_search_wordmatch USING btree (word_id, post_id, title_match);
+
+
+--
+-- Name: phpbb_search_wordmatch_word_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordmatch_word_id ON public.phpbb_search_wordmatch USING btree (word_id);
+
+
+--
+-- Name: phpbb_sessions_keys_last_login; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_keys_last_login ON public.phpbb_sessions_keys USING btree (last_login);
+
+
+--
+-- Name: phpbb_sessions_session_fid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_fid ON public.phpbb_sessions USING btree (session_forum_id);
+
+
+--
+-- Name: phpbb_sessions_session_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_time ON public.phpbb_sessions USING btree (session_time);
+
+
+--
+-- Name: phpbb_sessions_session_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_user_id ON public.phpbb_sessions USING btree (session_user_id);
+
+
+--
+-- Name: phpbb_smilies_display_on_post; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_smilies_display_on_post ON public.phpbb_smilies USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_styles_style_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_styles_style_name ON public.phpbb_styles USING btree (style_name);
+
+
+--
+-- Name: phpbb_topics_fid_time_moved; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_fid_time_moved ON public.phpbb_topics USING btree (forum_id, topic_last_post_time, topic_moved_id);
+
+
+--
+-- Name: phpbb_topics_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_id ON public.phpbb_topics USING btree (forum_id);
+
+
+--
+-- Name: phpbb_topics_forum_id_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_id_type ON public.phpbb_topics USING btree (forum_id, topic_type);
+
+
+--
+-- Name: phpbb_topics_forum_vis_last; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_vis_last ON public.phpbb_topics USING btree (forum_id, topic_visibility, topic_last_post_id);
+
+
+--
+-- Name: phpbb_topics_last_post_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_last_post_time ON public.phpbb_topics USING btree (topic_last_post_time);
+
+
+--
+-- Name: phpbb_topics_latest_topics; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_latest_topics ON public.phpbb_topics USING btree (forum_id, topic_last_post_time, topic_last_post_id, topic_moved_id);
+
+
+--
+-- Name: phpbb_topics_topic_visibility; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_topic_visibility ON public.phpbb_topics USING btree (topic_visibility);
+
+
+--
+-- Name: phpbb_topics_track_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_track_forum_id ON public.phpbb_topics_track USING btree (forum_id);
+
+
+--
+-- Name: phpbb_topics_track_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_track_topic_id ON public.phpbb_topics_track USING btree (topic_id);
+
+
+--
+-- Name: phpbb_topics_watch_notify_stat; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_notify_stat ON public.phpbb_topics_watch USING btree (notify_status);
+
+
+--
+-- Name: phpbb_topics_watch_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_topic_id ON public.phpbb_topics_watch USING btree (topic_id);
+
+
+--
+-- Name: phpbb_topics_watch_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_user_id ON public.phpbb_topics_watch USING btree (user_id);
+
+
+--
+-- Name: phpbb_user_group_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_group_id ON public.phpbb_user_group USING btree (group_id);
+
+
+--
+-- Name: phpbb_user_group_group_leader; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_group_leader ON public.phpbb_user_group USING btree (group_leader);
+
+
+--
+-- Name: phpbb_user_group_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_user_id ON public.phpbb_user_group USING btree (user_id);
+
+
+--
+-- Name: phpbb_user_notifications_itm_usr_mthd; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_user_notifications_itm_usr_mthd ON public.phpbb_user_notifications USING btree (item_type, item_id, user_id, method);
+
+
+--
+-- Name: phpbb_user_notifications_uid_itm_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_notifications_uid_itm_id ON public.phpbb_user_notifications USING btree (user_id, item_id);
+
+
+--
+-- Name: phpbb_user_notifications_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_notifications_user_id ON public.phpbb_user_notifications USING btree (user_id);
+
+
+--
+-- Name: phpbb_user_notifications_usr_itm_tpe; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_notifications_usr_itm_tpe ON public.phpbb_user_notifications USING btree (user_id, item_type, item_id);
+
+
+--
+-- Name: phpbb_users_user_birthday; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_birthday ON public.phpbb_users USING btree (user_birthday);
+
+
+--
+-- Name: phpbb_users_user_email_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_email_hash ON public.phpbb_users USING btree (user_email_hash);
+
+
+--
+-- Name: phpbb_users_user_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_type ON public.phpbb_users USING btree (user_type);
+
+
+--
+-- Name: phpbb_users_username_clean; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_users_username_clean ON public.phpbb_users USING btree (username_clean);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict jUFXBXkU9OKeNgjjaU6XnUYZkk7P4W1XOv5NMSiwK1Pm27Idb9ameSsOEhPXnbj
+

--- a/migrations/converters/spec/fixtures/phpbb/schemas/3.3/mysql.sql
+++ b/migrations/converters/spec/fixtures/phpbb/schemas/3.3/mysql.sql
@@ -1,0 +1,1119 @@
+/*M!999999\- enable the sandbox mode */ 
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  KEY `group_id` (`group_id`),
+  KEY `auth_opt_id` (`auth_option_id`),
+  KEY `auth_role_id` (`auth_role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_options` (
+  `auth_option_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `auth_option` varchar(50) NOT NULL DEFAULT '',
+  `is_global` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `is_local` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `founder_only` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`auth_option_id`),
+  UNIQUE KEY `auth_option` (`auth_option`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_roles` (
+  `role_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `role_name` varchar(255) NOT NULL DEFAULT '',
+  `role_description` text NOT NULL,
+  `role_type` varchar(10) NOT NULL DEFAULT '',
+  `role_order` smallint(4) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`role_id`),
+  KEY `role_type` (`role_type`),
+  KEY `role_order` (`role_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_roles_data` (
+  `role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`role_id`,`auth_option_id`),
+  KEY `ath_op_id` (`auth_option_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_acl_users` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_role_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `auth_setting` tinyint(2) NOT NULL DEFAULT 0,
+  KEY `user_id` (`user_id`),
+  KEY `auth_option_id` (`auth_option_id`),
+  KEY `auth_role_id` (`auth_role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_attachments` (
+  `attach_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `post_msg_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `in_message` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `poster_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `is_orphan` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `physical_filename` varchar(255) NOT NULL DEFAULT '',
+  `real_filename` varchar(255) NOT NULL DEFAULT '',
+  `download_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `attach_comment` text NOT NULL,
+  `extension` varchar(100) NOT NULL DEFAULT '',
+  `mimetype` varchar(100) NOT NULL DEFAULT '',
+  `filesize` int(20) unsigned NOT NULL DEFAULT 0,
+  `filetime` int(11) unsigned NOT NULL DEFAULT 0,
+  `thumbnail` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`attach_id`),
+  KEY `filetime` (`filetime`),
+  KEY `post_msg_id` (`post_msg_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `poster_id` (`poster_id`),
+  KEY `is_orphan` (`is_orphan`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_banlist` (
+  `ban_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `ban_userid` int(10) unsigned NOT NULL DEFAULT 0,
+  `ban_ip` varchar(40) NOT NULL DEFAULT '',
+  `ban_email` varchar(100) NOT NULL DEFAULT '',
+  `ban_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `ban_end` int(11) unsigned NOT NULL DEFAULT 0,
+  `ban_exclude` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `ban_reason` varchar(255) NOT NULL DEFAULT '',
+  `ban_give_reason` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`ban_id`),
+  KEY `ban_end` (`ban_end`),
+  KEY `ban_user` (`ban_userid`,`ban_exclude`),
+  KEY `ban_email` (`ban_email`,`ban_exclude`),
+  KEY `ban_ip` (`ban_ip`,`ban_exclude`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bbcodes` (
+  `bbcode_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `bbcode_tag` varchar(16) NOT NULL DEFAULT '',
+  `bbcode_helpline` text NOT NULL,
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_match` text NOT NULL,
+  `bbcode_tpl` mediumtext NOT NULL,
+  `first_pass_match` mediumtext NOT NULL,
+  `first_pass_replace` mediumtext NOT NULL,
+  `second_pass_match` mediumtext NOT NULL,
+  `second_pass_replace` mediumtext NOT NULL,
+  PRIMARY KEY (`bbcode_id`),
+  KEY `display_on_post` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bookmarks` (
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`topic_id`,`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_bots` (
+  `bot_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `bot_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `bot_name` varchar(255) NOT NULL DEFAULT '',
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `bot_agent` varchar(255) NOT NULL DEFAULT '',
+  `bot_ip` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`bot_id`),
+  KEY `bot_active` (`bot_active`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_config` (
+  `config_name` varchar(255) NOT NULL DEFAULT '',
+  `config_value` varchar(255) NOT NULL DEFAULT '',
+  `is_dynamic` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`config_name`),
+  KEY `is_dynamic` (`is_dynamic`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_config_text` (
+  `config_name` varchar(255) NOT NULL DEFAULT '',
+  `config_value` mediumtext NOT NULL,
+  PRIMARY KEY (`config_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_confirm` (
+  `confirm_id` char(32) NOT NULL DEFAULT '',
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `confirm_type` tinyint(3) NOT NULL DEFAULT 0,
+  `code` varchar(8) NOT NULL DEFAULT '',
+  `seed` int(10) unsigned NOT NULL DEFAULT 0,
+  `attempts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`session_id`,`confirm_id`),
+  KEY `confirm_type` (`confirm_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_disallow` (
+  `disallow_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `disallow_username` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`disallow_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_drafts` (
+  `draft_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `save_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `draft_subject` varchar(255) NOT NULL DEFAULT '',
+  `draft_message` mediumtext NOT NULL,
+  PRIMARY KEY (`draft_id`),
+  KEY `save_time` (`save_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_ext` (
+  `ext_name` varchar(255) NOT NULL DEFAULT '',
+  `ext_active` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `ext_state` text NOT NULL,
+  UNIQUE KEY `ext_name` (`ext_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_extension_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `cat_id` tinyint(2) NOT NULL DEFAULT 0,
+  `allow_group` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `download_mode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `upload_icon` varchar(255) NOT NULL DEFAULT '',
+  `max_filesize` int(20) unsigned NOT NULL DEFAULT 0,
+  `allowed_forums` text NOT NULL,
+  `allow_in_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`group_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_extensions` (
+  `extension_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `extension` varchar(100) NOT NULL DEFAULT '',
+  PRIMARY KEY (`extension_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums` (
+  `forum_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `left_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `right_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_parents` mediumtext NOT NULL,
+  `forum_name` varchar(255) NOT NULL DEFAULT '',
+  `forum_desc` text NOT NULL,
+  `forum_desc_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `forum_desc_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `forum_desc_uid` varchar(8) NOT NULL DEFAULT '',
+  `forum_link` varchar(255) NOT NULL DEFAULT '',
+  `forum_password` varchar(255) NOT NULL DEFAULT '',
+  `forum_style` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_image` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules` text NOT NULL,
+  `forum_rules_link` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `forum_rules_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `forum_rules_uid` varchar(8) NOT NULL DEFAULT '',
+  `forum_topics_per_page` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `forum_type` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_status` tinyint(4) NOT NULL DEFAULT 0,
+  `forum_last_post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_last_poster_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_last_post_subject` varchar(255) NOT NULL DEFAULT '',
+  `forum_last_post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `forum_last_poster_name` varchar(255) NOT NULL DEFAULT '',
+  `forum_last_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `forum_flags` tinyint(4) NOT NULL DEFAULT 32,
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_indexing` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_icons` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_prune` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `prune_next` int(11) unsigned NOT NULL DEFAULT 0,
+  `prune_days` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `prune_viewed` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `prune_freq` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_subforum_list` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `display_subforum_limit` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `forum_options` int(20) unsigned NOT NULL DEFAULT 0,
+  `enable_shadow_prune` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `prune_shadow_days` mediumint(8) unsigned NOT NULL DEFAULT 7,
+  `prune_shadow_freq` mediumint(8) unsigned NOT NULL DEFAULT 1,
+  `prune_shadow_next` int(11) NOT NULL DEFAULT 0,
+  `forum_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_approved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_unapproved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `forum_topics_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`forum_id`),
+  KEY `left_right_id` (`left_id`,`right_id`),
+  KEY `forum_lastpost_id` (`forum_last_post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_access` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `session_id` char(32) NOT NULL DEFAULT '',
+  PRIMARY KEY (`forum_id`,`user_id`,`session_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_track` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `mark_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_forums_watch` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `notify_status` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  KEY `forum_id` (`forum_id`),
+  KEY `user_id` (`user_id`),
+  KEY `notify_stat` (`notify_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_groups` (
+  `group_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_type` tinyint(4) NOT NULL DEFAULT 1,
+  `group_founder_manage` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_skip_auth` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `group_desc` text NOT NULL,
+  `group_desc_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `group_desc_options` int(11) unsigned NOT NULL DEFAULT 7,
+  `group_desc_uid` varchar(8) NOT NULL DEFAULT '',
+  `group_display` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_avatar` varchar(255) NOT NULL DEFAULT '',
+  `group_avatar_type` varchar(255) NOT NULL DEFAULT '',
+  `group_avatar_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `group_avatar_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `group_rank` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_colour` varchar(6) NOT NULL DEFAULT '',
+  `group_sig_chars` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_receive_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `group_message_limit` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_legend` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_max_recipients` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`group_id`),
+  KEY `group_legend_name` (`group_legend`,`group_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_icons` (
+  `icons_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `icons_url` varchar(255) NOT NULL DEFAULT '',
+  `icons_width` tinyint(4) NOT NULL DEFAULT 0,
+  `icons_height` tinyint(4) NOT NULL DEFAULT 0,
+  `icons_alt` varchar(255) NOT NULL DEFAULT '',
+  `icons_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`icons_id`),
+  KEY `display_on_posting` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_lang` (
+  `lang_id` tinyint(4) NOT NULL AUTO_INCREMENT,
+  `lang_iso` varchar(30) NOT NULL DEFAULT '',
+  `lang_dir` varchar(30) NOT NULL DEFAULT '',
+  `lang_english_name` varchar(100) NOT NULL DEFAULT '',
+  `lang_local_name` varchar(255) NOT NULL DEFAULT '',
+  `lang_author` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`lang_id`),
+  KEY `lang_iso` (`lang_iso`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_log` (
+  `log_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `log_type` tinyint(4) NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `reportee_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `log_ip` varchar(40) NOT NULL DEFAULT '',
+  `log_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `log_operation` text NOT NULL,
+  `log_data` mediumtext NOT NULL,
+  PRIMARY KEY (`log_id`),
+  KEY `log_type` (`log_type`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `reportee_id` (`reportee_id`),
+  KEY `user_id` (`user_id`),
+  KEY `log_time` (`log_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_login_attempts` (
+  `attempt_ip` varchar(40) NOT NULL DEFAULT '',
+  `attempt_browser` varchar(150) NOT NULL DEFAULT '',
+  `attempt_forwarded_for` varchar(255) NOT NULL DEFAULT '',
+  `attempt_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '0',
+  `username_clean` varchar(255) NOT NULL DEFAULT '0',
+  KEY `att_ip` (`attempt_ip`,`attempt_time`),
+  KEY `att_for` (`attempt_forwarded_for`,`attempt_time`),
+  KEY `att_time` (`attempt_time`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_migrations` (
+  `migration_name` varchar(255) NOT NULL DEFAULT '',
+  `migration_depends_on` text NOT NULL,
+  `migration_schema_done` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `migration_data_done` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `migration_data_state` text NOT NULL,
+  `migration_start_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `migration_end_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`migration_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_moderator_cache` (
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '',
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `group_name` varchar(255) NOT NULL DEFAULT '',
+  `display_on_index` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  KEY `disp_idx` (`display_on_index`),
+  KEY `forum_id` (`forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_modules` (
+  `module_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `module_enabled` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `module_display` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `module_basename` varchar(255) NOT NULL DEFAULT '',
+  `module_class` varchar(10) NOT NULL DEFAULT '',
+  `parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `left_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `right_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `module_langname` varchar(255) NOT NULL DEFAULT '',
+  `module_mode` varchar(255) NOT NULL DEFAULT '',
+  `module_auth` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`module_id`),
+  KEY `left_right_id` (`left_id`,`right_id`),
+  KEY `module_enabled` (`module_enabled`),
+  KEY `class_left_id` (`module_class`,`left_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_notification_emails` (
+  `notification_type_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `item_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `item_parent_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`notification_type_id`,`item_id`,`item_parent_id`,`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_notification_types` (
+  `notification_type_id` smallint(4) unsigned NOT NULL AUTO_INCREMENT,
+  `notification_type_name` varchar(255) NOT NULL DEFAULT '',
+  `notification_type_enabled` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`notification_type_id`),
+  UNIQUE KEY `type` (`notification_type_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_notifications` (
+  `notification_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `notification_type_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `item_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `item_parent_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `notification_read` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `notification_time` int(11) unsigned NOT NULL DEFAULT 1,
+  `notification_data` text NOT NULL,
+  PRIMARY KEY (`notification_id`),
+  KEY `item_ident` (`notification_type_id`,`item_id`),
+  KEY `user` (`user_id`,`notification_read`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_oauth_accounts` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `provider` varchar(255) NOT NULL DEFAULT '',
+  `oauth_provider_id` text NOT NULL,
+  PRIMARY KEY (`user_id`,`provider`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_oauth_states` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `provider` varchar(255) NOT NULL DEFAULT '',
+  `oauth_state` varchar(255) NOT NULL DEFAULT '',
+  `state_time` int(11) unsigned NOT NULL DEFAULT 0,
+  KEY `user_id` (`user_id`),
+  KEY `provider` (`provider`),
+  KEY `state_time` (`state_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_oauth_tokens` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `provider` varchar(255) NOT NULL DEFAULT '',
+  `oauth_token` mediumtext NOT NULL,
+  KEY `user_id` (`user_id`),
+  KEY `provider` (`provider`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_poll_options` (
+  `poll_option_id` tinyint(4) NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `poll_option_text` text NOT NULL,
+  `poll_option_total` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  KEY `poll_opt_id` (`poll_option_id`),
+  KEY `topic_id` (`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_poll_votes` (
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `poll_option_id` tinyint(4) NOT NULL DEFAULT 0,
+  `vote_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `vote_user_ip` varchar(40) NOT NULL DEFAULT '',
+  KEY `topic_id` (`topic_id`),
+  KEY `vote_user_id` (`vote_user_id`),
+  KEY `vote_user_ip` (`vote_user_ip`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_posts` (
+  `post_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poster_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poster_ip` varchar(40) NOT NULL DEFAULT '',
+  `post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `post_username` varchar(255) NOT NULL DEFAULT '',
+  `post_subject` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `post_text` mediumtext NOT NULL,
+  `post_checksum` varchar(32) NOT NULL DEFAULT '',
+  `post_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `post_postcount` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `post_edit_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_edit_reason` varchar(255) NOT NULL DEFAULT '',
+  `post_edit_user` int(10) unsigned NOT NULL DEFAULT 0,
+  `post_edit_count` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `post_edit_locked` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `post_visibility` tinyint(3) NOT NULL DEFAULT 0,
+  `post_delete_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `post_delete_reason` varchar(255) NOT NULL DEFAULT '',
+  `post_delete_user` int(10) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`post_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`),
+  KEY `poster_ip` (`poster_ip`),
+  KEY `poster_id` (`poster_id`),
+  KEY `tid_post_time` (`topic_id`,`post_time`),
+  KEY `post_username` (`post_username`),
+  KEY `post_visibility` (`post_visibility`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs` (
+  `msg_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `root_level` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `author_ip` varchar(40) NOT NULL DEFAULT '',
+  `message_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `enable_sig` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `message_subject` varchar(255) NOT NULL DEFAULT '',
+  `message_text` mediumtext NOT NULL,
+  `message_edit_reason` varchar(255) NOT NULL DEFAULT '',
+  `message_edit_user` int(10) unsigned NOT NULL DEFAULT 0,
+  `message_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `message_edit_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `message_edit_count` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `to_address` text NOT NULL,
+  `bcc_address` text NOT NULL,
+  `message_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`msg_id`),
+  KEY `author_ip` (`author_ip`),
+  KEY `message_time` (`message_time`),
+  KEY `author_id` (`author_id`),
+  KEY `root_level` (`root_level`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_folder` (
+  `folder_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `folder_name` varchar(255) NOT NULL DEFAULT '',
+  `pm_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`folder_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_rules` (
+  `rule_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `rule_check` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_connection` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_string` varchar(255) NOT NULL DEFAULT '',
+  `rule_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `rule_group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_action` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rule_folder_id` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`rule_id`),
+  KEY `user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_privmsgs_to` (
+  `msg_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `author_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `pm_deleted` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_new` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `pm_unread` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `pm_replied` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_marked` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `pm_forwarded` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `folder_id` int(11) NOT NULL DEFAULT 0,
+  KEY `msg_id` (`msg_id`),
+  KEY `author_id` (`author_id`),
+  KEY `usr_flder_id` (`user_id`,`folder_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields` (
+  `field_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `field_name` varchar(255) NOT NULL DEFAULT '',
+  `field_type` varchar(100) NOT NULL DEFAULT '',
+  `field_ident` varchar(20) NOT NULL DEFAULT '',
+  `field_length` varchar(20) NOT NULL DEFAULT '',
+  `field_minlen` varchar(255) NOT NULL DEFAULT '',
+  `field_maxlen` varchar(255) NOT NULL DEFAULT '',
+  `field_novalue` varchar(255) NOT NULL DEFAULT '',
+  `field_default_value` varchar(255) NOT NULL DEFAULT '',
+  `field_validation` varchar(128) NOT NULL DEFAULT '',
+  `field_required` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_reg` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_hide` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_no_view` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_active` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `field_show_profile` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_vt` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_novalue` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_pm` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_show_on_ml` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_is_contact` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `field_contact_desc` varchar(255) NOT NULL DEFAULT '',
+  `field_contact_url` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`),
+  KEY `fld_type` (`field_type`),
+  KEY `fld_ordr` (`field_order`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields_data` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `pf_phpbb_interests` mediumtext NOT NULL,
+  `pf_phpbb_occupation` mediumtext NOT NULL,
+  `pf_phpbb_facebook` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_icq` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_location` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_skype` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_twitter` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_website` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_yahoo` varchar(255) NOT NULL DEFAULT '',
+  `pf_phpbb_youtube` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_fields_lang` (
+  `field_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `option_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `field_type` varchar(100) NOT NULL DEFAULT '',
+  `lang_value` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`,`lang_id`,`option_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_profile_lang` (
+  `field_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `lang_name` varchar(255) NOT NULL DEFAULT '',
+  `lang_explain` text NOT NULL,
+  `lang_default_value` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`field_id`,`lang_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_ranks` (
+  `rank_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `rank_title` varchar(255) NOT NULL DEFAULT '',
+  `rank_min` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `rank_special` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `rank_image` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`rank_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_reports` (
+  `report_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `reason_id` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `report_closed` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `report_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `report_text` mediumtext NOT NULL,
+  `pm_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `reported_post_enable_bbcode` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `reported_post_enable_smilies` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `reported_post_enable_magic_url` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `reported_post_text` mediumtext NOT NULL,
+  `reported_post_uid` varchar(8) NOT NULL DEFAULT '',
+  `reported_post_bitfield` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`report_id`),
+  KEY `post_id` (`post_id`),
+  KEY `pm_id` (`pm_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_reports_reasons` (
+  `reason_id` smallint(4) unsigned NOT NULL AUTO_INCREMENT,
+  `reason_title` varchar(255) NOT NULL DEFAULT '',
+  `reason_description` mediumtext NOT NULL,
+  `reason_order` smallint(4) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`reason_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_results` (
+  `search_key` varchar(32) NOT NULL DEFAULT '',
+  `search_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `search_keywords` mediumtext NOT NULL,
+  `search_authors` mediumtext NOT NULL,
+  PRIMARY KEY (`search_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_wordlist` (
+  `word_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `word_text` varchar(255) NOT NULL DEFAULT '',
+  `word_common` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `word_count` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`word_id`),
+  UNIQUE KEY `wrd_txt` (`word_text`),
+  KEY `wrd_cnt` (`word_count`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_search_wordmatch` (
+  `post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `word_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `title_match` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  UNIQUE KEY `un_mtch` (`word_id`,`post_id`,`title_match`),
+  KEY `word_id` (`word_id`),
+  KEY `post_id` (`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sessions` (
+  `session_id` char(32) NOT NULL DEFAULT '',
+  `session_user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `session_last_visit` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `session_ip` varchar(40) NOT NULL DEFAULT '',
+  `session_browser` varchar(150) NOT NULL DEFAULT '',
+  `session_forwarded_for` varchar(255) NOT NULL DEFAULT '',
+  `session_page` varchar(255) NOT NULL DEFAULT '',
+  `session_viewonline` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `session_autologin` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `session_admin` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `session_forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`session_id`),
+  KEY `session_time` (`session_time`),
+  KEY `session_user_id` (`session_user_id`),
+  KEY `session_fid` (`session_forum_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sessions_keys` (
+  `key_id` char(32) NOT NULL DEFAULT '',
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `last_ip` varchar(40) NOT NULL DEFAULT '',
+  `last_login` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`key_id`,`user_id`),
+  KEY `last_login` (`last_login`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_sitelist` (
+  `site_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `site_ip` varchar(40) NOT NULL DEFAULT '',
+  `site_hostname` varchar(255) NOT NULL DEFAULT '',
+  `ip_exclude` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`site_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_smilies` (
+  `smiley_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(50) NOT NULL DEFAULT '',
+  `emotion` varchar(255) NOT NULL DEFAULT '',
+  `smiley_url` varchar(50) NOT NULL DEFAULT '',
+  `smiley_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `smiley_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `smiley_order` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `display_on_posting` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  PRIMARY KEY (`smiley_id`),
+  KEY `display_on_post` (`display_on_posting`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_styles` (
+  `style_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `style_name` varchar(255) NOT NULL DEFAULT '',
+  `style_copyright` varchar(255) NOT NULL DEFAULT '',
+  `style_active` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `style_path` varchar(100) NOT NULL DEFAULT '',
+  `bbcode_bitfield` varchar(255) NOT NULL DEFAULT 'kNg=',
+  `style_parent_id` int(4) unsigned NOT NULL DEFAULT 0,
+  `style_parent_tree` text NOT NULL,
+  PRIMARY KEY (`style_id`),
+  UNIQUE KEY `style_name` (`style_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_teampage` (
+  `teampage_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `teampage_name` varchar(255) NOT NULL DEFAULT '',
+  `teampage_position` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `teampage_parent` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`teampage_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics` (
+  `topic_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `icon_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_attachment` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_reported` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_title` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `topic_poster` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_time_limit` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_views` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_status` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_type` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_first_post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_first_poster_name` varchar(255) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT '',
+  `topic_first_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `topic_last_post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_last_poster_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_last_poster_name` varchar(255) NOT NULL DEFAULT '',
+  `topic_last_poster_colour` varchar(6) NOT NULL DEFAULT '',
+  `topic_last_post_subject` varchar(255) NOT NULL DEFAULT '',
+  `topic_last_post_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_last_view_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_moved_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_bumped` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_bumper` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `poll_title` varchar(255) NOT NULL DEFAULT '',
+  `poll_start` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_length` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_max_options` tinyint(4) NOT NULL DEFAULT 1,
+  `poll_last_vote` int(11) unsigned NOT NULL DEFAULT 0,
+  `poll_vote_change` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `topic_visibility` tinyint(3) NOT NULL DEFAULT 0,
+  `topic_delete_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `topic_delete_reason` varchar(255) NOT NULL DEFAULT '',
+  `topic_delete_user` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_posts_approved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_posts_unapproved` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `topic_posts_softdeleted` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`topic_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `forum_id_type` (`forum_id`,`topic_type`),
+  KEY `last_post_time` (`topic_last_post_time`),
+  KEY `fid_time_moved` (`forum_id`,`topic_last_post_time`,`topic_moved_id`),
+  KEY `topic_visibility` (`topic_visibility`),
+  KEY `forum_vis_last` (`forum_id`,`topic_visibility`,`topic_last_post_id`),
+  KEY `latest_topics` (`forum_id`,`topic_last_post_time`,`topic_last_post_id`,`topic_moved_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_posted` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_posted` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_track` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `forum_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `mark_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`topic_id`),
+  KEY `forum_id` (`forum_id`),
+  KEY `topic_id` (`topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_topics_watch` (
+  `topic_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `notify_status` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  KEY `topic_id` (`topic_id`),
+  KEY `user_id` (`user_id`),
+  KEY `notify_stat` (`notify_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_user_group` (
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `group_leader` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_pending` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  KEY `group_id` (`group_id`),
+  KEY `user_id` (`user_id`),
+  KEY `group_leader` (`group_leader`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_user_notifications` (
+  `item_type` varchar(165) NOT NULL DEFAULT '',
+  `item_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `method` varchar(165) NOT NULL DEFAULT '',
+  `notify` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  UNIQUE KEY `itm_usr_mthd` (`item_type`,`item_id`,`user_id`,`method`),
+  KEY `user_id` (`user_id`),
+  KEY `uid_itm_id` (`user_id`,`item_id`),
+  KEY `usr_itm_tpe` (`user_id`,`item_type`,`item_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_users` (
+  `user_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_type` tinyint(2) NOT NULL DEFAULT 0,
+  `group_id` mediumint(8) unsigned NOT NULL DEFAULT 3,
+  `user_permissions` mediumtext NOT NULL,
+  `user_perm_from` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_ip` varchar(40) NOT NULL DEFAULT '',
+  `user_regdate` int(11) unsigned NOT NULL DEFAULT 0,
+  `username` varchar(255) NOT NULL DEFAULT '',
+  `username_clean` varchar(255) NOT NULL DEFAULT '',
+  `user_password` varchar(255) NOT NULL DEFAULT '',
+  `user_passchg` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_email` varchar(100) NOT NULL DEFAULT '',
+  `user_birthday` varchar(10) NOT NULL DEFAULT '',
+  `user_lastvisit` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_last_active` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastmark` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastpost_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_lastpage` varchar(200) NOT NULL DEFAULT '',
+  `user_last_confirm_key` varchar(10) NOT NULL DEFAULT '',
+  `user_last_search` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_warnings` tinyint(4) NOT NULL DEFAULT 0,
+  `user_last_warning` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_login_attempts` tinyint(4) NOT NULL DEFAULT 0,
+  `user_inactive_reason` tinyint(2) NOT NULL DEFAULT 0,
+  `user_inactive_time` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_posts` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_lang` varchar(30) NOT NULL DEFAULT '',
+  `user_timezone` varchar(100) NOT NULL DEFAULT '',
+  `user_dateformat` varchar(64) NOT NULL DEFAULT 'd M Y H:i',
+  `user_style` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_rank` mediumint(8) unsigned NOT NULL DEFAULT 0,
+  `user_colour` varchar(6) NOT NULL DEFAULT '',
+  `user_new_privmsg` int(4) NOT NULL DEFAULT 0,
+  `user_unread_privmsg` int(4) NOT NULL DEFAULT 0,
+  `user_last_privmsg` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_message_rules` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_full_folder` int(11) NOT NULL DEFAULT -3,
+  `user_emailtime` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_topic_show_days` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_topic_sortby_type` varchar(1) NOT NULL DEFAULT 't',
+  `user_topic_sortby_dir` varchar(1) NOT NULL DEFAULT 'd',
+  `user_post_show_days` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_post_sortby_type` varchar(1) NOT NULL DEFAULT 't',
+  `user_post_sortby_dir` varchar(1) NOT NULL DEFAULT 'a',
+  `user_notify` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `user_notify_pm` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_notify_type` tinyint(4) NOT NULL DEFAULT 0,
+  `user_allow_pm` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_viewonline` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_viewemail` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_allow_massemail` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_options` int(11) unsigned NOT NULL DEFAULT 230271,
+  `user_avatar` varchar(255) NOT NULL DEFAULT '',
+  `user_avatar_type` varchar(255) NOT NULL DEFAULT '',
+  `user_avatar_width` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_avatar_height` smallint(4) unsigned NOT NULL DEFAULT 0,
+  `user_sig` mediumtext NOT NULL,
+  `user_sig_bbcode_uid` varchar(8) NOT NULL DEFAULT '',
+  `user_sig_bbcode_bitfield` varchar(255) NOT NULL DEFAULT '',
+  `user_jabber` varchar(255) NOT NULL DEFAULT '',
+  `user_actkey` varchar(32) NOT NULL DEFAULT '',
+  `user_actkey_expiration` int(11) unsigned NOT NULL DEFAULT 0,
+  `reset_token` varchar(64) NOT NULL DEFAULT '',
+  `reset_token_expiration` int(11) unsigned NOT NULL DEFAULT 0,
+  `user_newpasswd` varchar(255) NOT NULL DEFAULT '',
+  `user_form_salt` varchar(32) NOT NULL DEFAULT '',
+  `user_new` tinyint(1) unsigned NOT NULL DEFAULT 1,
+  `user_reminded` tinyint(4) NOT NULL DEFAULT 0,
+  `user_reminded_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`),
+  UNIQUE KEY `username_clean` (`username_clean`),
+  KEY `user_birthday` (`user_birthday`),
+  KEY `user_type` (`user_type`),
+  KEY `user_email` (`user_email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_warnings` (
+  `warning_id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `post_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `log_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `warning_time` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`warning_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_words` (
+  `word_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `word` varchar(255) NOT NULL DEFAULT '',
+  `replacement` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (`word_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `phpbb_zebra` (
+  `user_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `zebra_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `friend` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  `foe` tinyint(1) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`user_id`,`zebra_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;

--- a/migrations/converters/spec/fixtures/phpbb/schemas/3.3/postgres.sql
+++ b/migrations/converters/spec/fixtures/phpbb/schemas/3.3/postgres.sql
@@ -1,0 +1,3342 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict Z8ypjMKMNeTqLacgtMJ7JmOyacCaQkfzsZEbQBfdsvJo0tA2iNvS7OPYyZCYlUd
+
+-- Dumped from database version 16.14 (Debian 16.14-1.pgdg13+1)
+-- Dumped by pg_dump version 16.14 (Debian 16.14-1.pgdg13+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: varchar_ci; Type: DOMAIN; Schema: public; Owner: -
+--
+
+CREATE DOMAIN public.varchar_ci AS character varying(255) NOT NULL DEFAULT ''::character varying;
+
+
+--
+-- Name: _varchar_ci_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) = LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_greater_equals(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_greater_equals(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) >= LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_greater_than(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_greater_than(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) > LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_less_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_less_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) <= LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_less_than(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_less_than(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) < LOWER($2)$_$;
+
+
+--
+-- Name: _varchar_ci_not_equal(public.varchar_ci, public.varchar_ci); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public._varchar_ci_not_equal(public.varchar_ci, public.varchar_ci) RETURNS boolean
+    LANGUAGE sql STRICT
+    AS $_$SELECT LOWER($1) != LOWER($2)$_$;
+
+
+--
+-- Name: <; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.< (
+    FUNCTION = public._varchar_ci_less_than,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.>),
+    NEGATOR = OPERATOR(public.>=),
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+--
+-- Name: <=; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.<= (
+    FUNCTION = public._varchar_ci_less_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.>=),
+    NEGATOR = OPERATOR(public.>),
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+--
+-- Name: <>; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.<> (
+    FUNCTION = public._varchar_ci_not_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<>),
+    NEGATOR = OPERATOR(public.=),
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel
+);
+
+
+--
+-- Name: =; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.= (
+    FUNCTION = public._varchar_ci_equal,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.=),
+    NEGATOR = OPERATOR(public.<>),
+    MERGES,
+    HASHES,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel
+);
+
+
+--
+-- Name: >; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.> (
+    FUNCTION = public._varchar_ci_greater_than,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<),
+    NEGATOR = OPERATOR(public.<=),
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+--
+-- Name: >=; Type: OPERATOR; Schema: public; Owner: -
+--
+
+CREATE OPERATOR public.>= (
+    FUNCTION = public._varchar_ci_greater_equals,
+    LEFTARG = public.varchar_ci,
+    RIGHTARG = public.varchar_ci,
+    COMMUTATOR = OPERATOR(public.<=),
+    NEGATOR = OPERATOR(public.<),
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: phpbb_acl_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_groups (
+    group_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_role_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_groups_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_auth_role_id_check CHECK ((auth_role_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_acl_groups_group_id_check CHECK ((group_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_options_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_acl_options_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_acl_options; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_options (
+    auth_option_id integer DEFAULT nextval('public.phpbb_acl_options_seq'::regclass) NOT NULL,
+    auth_option character varying(50) DEFAULT ''::character varying NOT NULL,
+    is_global smallint DEFAULT '0'::smallint NOT NULL,
+    is_local smallint DEFAULT '0'::smallint NOT NULL,
+    founder_only smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_options_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_options_founder_only_check CHECK ((founder_only >= 0)),
+    CONSTRAINT phpbb_acl_options_is_global_check CHECK ((is_global >= 0)),
+    CONSTRAINT phpbb_acl_options_is_local_check CHECK ((is_local >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_roles_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_acl_roles_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_acl_roles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_roles (
+    role_id integer DEFAULT nextval('public.phpbb_acl_roles_seq'::regclass) NOT NULL,
+    role_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    role_description character varying(4000) DEFAULT ''::character varying NOT NULL,
+    role_type character varying(10) DEFAULT ''::character varying NOT NULL,
+    role_order smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_roles_role_id_check CHECK ((role_id >= 0)),
+    CONSTRAINT phpbb_acl_roles_role_order_check CHECK ((role_order >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_roles_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_roles_data (
+    role_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_roles_data_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_roles_data_role_id_check CHECK ((role_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_acl_users (
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    auth_option_id integer DEFAULT 0 NOT NULL,
+    auth_role_id integer DEFAULT 0 NOT NULL,
+    auth_setting smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_acl_users_auth_option_id_check CHECK ((auth_option_id >= 0)),
+    CONSTRAINT phpbb_acl_users_auth_role_id_check CHECK ((auth_role_id >= 0)),
+    CONSTRAINT phpbb_acl_users_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_acl_users_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_attachments_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_attachments_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_attachments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_attachments (
+    attach_id integer DEFAULT nextval('public.phpbb_attachments_seq'::regclass) NOT NULL,
+    post_msg_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    in_message smallint DEFAULT '0'::smallint NOT NULL,
+    poster_id integer DEFAULT 0 NOT NULL,
+    is_orphan smallint DEFAULT '1'::smallint NOT NULL,
+    physical_filename character varying(255) DEFAULT ''::character varying NOT NULL,
+    real_filename character varying(255) DEFAULT ''::character varying NOT NULL,
+    download_count integer DEFAULT 0 NOT NULL,
+    attach_comment character varying(4000) DEFAULT ''::character varying NOT NULL,
+    extension character varying(100) DEFAULT ''::character varying NOT NULL,
+    mimetype character varying(100) DEFAULT ''::character varying NOT NULL,
+    filesize integer DEFAULT 0 NOT NULL,
+    filetime integer DEFAULT 0 NOT NULL,
+    thumbnail smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_attachments_attach_id_check CHECK ((attach_id >= 0)),
+    CONSTRAINT phpbb_attachments_download_count_check CHECK ((download_count >= 0)),
+    CONSTRAINT phpbb_attachments_filesize_check CHECK ((filesize >= 0)),
+    CONSTRAINT phpbb_attachments_filetime_check CHECK ((filetime >= 0)),
+    CONSTRAINT phpbb_attachments_in_message_check CHECK ((in_message >= 0)),
+    CONSTRAINT phpbb_attachments_is_orphan_check CHECK ((is_orphan >= 0)),
+    CONSTRAINT phpbb_attachments_post_msg_id_check CHECK ((post_msg_id >= 0)),
+    CONSTRAINT phpbb_attachments_poster_id_check CHECK ((poster_id >= 0)),
+    CONSTRAINT phpbb_attachments_thumbnail_check CHECK ((thumbnail >= 0)),
+    CONSTRAINT phpbb_attachments_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_banlist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_banlist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_banlist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_banlist (
+    ban_id integer DEFAULT nextval('public.phpbb_banlist_seq'::regclass) NOT NULL,
+    ban_userid integer DEFAULT 0 NOT NULL,
+    ban_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    ban_email character varying(100) DEFAULT ''::character varying NOT NULL,
+    ban_start integer DEFAULT 0 NOT NULL,
+    ban_end integer DEFAULT 0 NOT NULL,
+    ban_exclude smallint DEFAULT '0'::smallint NOT NULL,
+    ban_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    ban_give_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_banlist_ban_end_check CHECK ((ban_end >= 0)),
+    CONSTRAINT phpbb_banlist_ban_exclude_check CHECK ((ban_exclude >= 0)),
+    CONSTRAINT phpbb_banlist_ban_id_check CHECK ((ban_id >= 0)),
+    CONSTRAINT phpbb_banlist_ban_start_check CHECK ((ban_start >= 0)),
+    CONSTRAINT phpbb_banlist_ban_userid_check CHECK ((ban_userid >= 0))
+);
+
+
+--
+-- Name: phpbb_bbcodes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bbcodes (
+    bbcode_id smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_tag character varying(16) DEFAULT ''::character varying NOT NULL,
+    bbcode_helpline character varying(4000) DEFAULT ''::character varying NOT NULL,
+    display_on_posting smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_match character varying(4000) DEFAULT ''::character varying NOT NULL,
+    bbcode_tpl text DEFAULT ''::text NOT NULL,
+    first_pass_match text DEFAULT ''::text NOT NULL,
+    first_pass_replace text DEFAULT ''::text NOT NULL,
+    second_pass_match text DEFAULT ''::text NOT NULL,
+    second_pass_replace text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_bbcodes_bbcode_id_check CHECK ((bbcode_id >= 0)),
+    CONSTRAINT phpbb_bbcodes_display_on_posting_check CHECK ((display_on_posting >= 0))
+);
+
+
+--
+-- Name: phpbb_bookmarks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bookmarks (
+    topic_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_bookmarks_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_bookmarks_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_bots_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_bots_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_bots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_bots (
+    bot_id integer DEFAULT nextval('public.phpbb_bots_seq'::regclass) NOT NULL,
+    bot_active smallint DEFAULT '1'::smallint NOT NULL,
+    bot_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    bot_agent character varying(255) DEFAULT ''::character varying NOT NULL,
+    bot_ip character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_bots_bot_active_check CHECK ((bot_active >= 0)),
+    CONSTRAINT phpbb_bots_bot_id_check CHECK ((bot_id >= 0)),
+    CONSTRAINT phpbb_bots_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_config; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_config (
+    config_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    config_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    is_dynamic smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_config_is_dynamic_check CHECK ((is_dynamic >= 0))
+);
+
+
+--
+-- Name: phpbb_config_text; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_config_text (
+    config_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    config_value text DEFAULT ''::text NOT NULL
+);
+
+
+--
+-- Name: phpbb_confirm; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_confirm (
+    confirm_id character(32) DEFAULT ''::bpchar NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    confirm_type smallint DEFAULT '0'::smallint NOT NULL,
+    code character varying(8) DEFAULT ''::character varying NOT NULL,
+    seed integer DEFAULT 0 NOT NULL,
+    attempts integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_confirm_attempts_check CHECK ((attempts >= 0)),
+    CONSTRAINT phpbb_confirm_seed_check CHECK ((seed >= 0))
+);
+
+
+--
+-- Name: phpbb_disallow_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_disallow_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_disallow; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_disallow (
+    disallow_id integer DEFAULT nextval('public.phpbb_disallow_seq'::regclass) NOT NULL,
+    disallow_username character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_disallow_disallow_id_check CHECK ((disallow_id >= 0))
+);
+
+
+--
+-- Name: phpbb_drafts_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_drafts_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_drafts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_drafts (
+    draft_id integer DEFAULT nextval('public.phpbb_drafts_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    save_time integer DEFAULT 0 NOT NULL,
+    draft_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    draft_message text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_drafts_draft_id_check CHECK ((draft_id >= 0)),
+    CONSTRAINT phpbb_drafts_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_drafts_save_time_check CHECK ((save_time >= 0)),
+    CONSTRAINT phpbb_drafts_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_drafts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_ext; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_ext (
+    ext_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    ext_active smallint DEFAULT '0'::smallint NOT NULL,
+    ext_state character varying(8000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_ext_ext_active_check CHECK ((ext_active >= 0))
+);
+
+
+--
+-- Name: phpbb_extension_groups_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_extension_groups_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_extension_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_extension_groups (
+    group_id integer DEFAULT nextval('public.phpbb_extension_groups_seq'::regclass) NOT NULL,
+    group_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    cat_id smallint DEFAULT '0'::smallint NOT NULL,
+    allow_group smallint DEFAULT '0'::smallint NOT NULL,
+    download_mode smallint DEFAULT '1'::smallint NOT NULL,
+    upload_icon character varying(255) DEFAULT ''::character varying NOT NULL,
+    max_filesize integer DEFAULT 0 NOT NULL,
+    allowed_forums character varying(8000) DEFAULT ''::character varying NOT NULL,
+    allow_in_pm smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_extension_groups_allow_group_check CHECK ((allow_group >= 0)),
+    CONSTRAINT phpbb_extension_groups_allow_in_pm_check CHECK ((allow_in_pm >= 0)),
+    CONSTRAINT phpbb_extension_groups_download_mode_check CHECK ((download_mode >= 0)),
+    CONSTRAINT phpbb_extension_groups_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_extension_groups_max_filesize_check CHECK ((max_filesize >= 0))
+);
+
+
+--
+-- Name: phpbb_extensions_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_extensions_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_extensions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_extensions (
+    extension_id integer DEFAULT nextval('public.phpbb_extensions_seq'::regclass) NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    extension character varying(100) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_extensions_extension_id_check CHECK ((extension_id >= 0)),
+    CONSTRAINT phpbb_extensions_group_id_check CHECK ((group_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_forums_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_forums; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums (
+    forum_id integer DEFAULT nextval('public.phpbb_forums_seq'::regclass) NOT NULL,
+    parent_id integer DEFAULT 0 NOT NULL,
+    left_id integer DEFAULT 0 NOT NULL,
+    right_id integer DEFAULT 0 NOT NULL,
+    forum_parents text DEFAULT ''::text NOT NULL,
+    forum_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_desc character varying(4000) DEFAULT ''::character varying NOT NULL,
+    forum_desc_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_desc_options integer DEFAULT 7 NOT NULL,
+    forum_desc_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    forum_link character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_password character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_style integer DEFAULT 0 NOT NULL,
+    forum_image character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules character varying(4000) DEFAULT ''::character varying NOT NULL,
+    forum_rules_link character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_rules_options integer DEFAULT 7 NOT NULL,
+    forum_rules_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    forum_topics_per_page smallint DEFAULT '0'::smallint NOT NULL,
+    forum_type smallint DEFAULT '0'::smallint NOT NULL,
+    forum_status smallint DEFAULT '0'::smallint NOT NULL,
+    forum_last_post_id integer DEFAULT 0 NOT NULL,
+    forum_last_poster_id integer DEFAULT 0 NOT NULL,
+    forum_last_post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_last_post_time integer DEFAULT 0 NOT NULL,
+    forum_last_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    forum_last_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    forum_flags smallint DEFAULT '32'::smallint NOT NULL,
+    display_on_index smallint DEFAULT '1'::smallint NOT NULL,
+    enable_indexing smallint DEFAULT '1'::smallint NOT NULL,
+    enable_icons smallint DEFAULT '1'::smallint NOT NULL,
+    enable_prune smallint DEFAULT '0'::smallint NOT NULL,
+    prune_next integer DEFAULT 0 NOT NULL,
+    prune_days integer DEFAULT 0 NOT NULL,
+    prune_viewed integer DEFAULT 0 NOT NULL,
+    prune_freq integer DEFAULT 0 NOT NULL,
+    display_subforum_list smallint DEFAULT '1'::smallint NOT NULL,
+    display_subforum_limit smallint DEFAULT '0'::smallint NOT NULL,
+    forum_options integer DEFAULT 0 NOT NULL,
+    enable_shadow_prune smallint DEFAULT '0'::smallint NOT NULL,
+    prune_shadow_days integer DEFAULT 7 NOT NULL,
+    prune_shadow_freq integer DEFAULT 1 NOT NULL,
+    prune_shadow_next integer DEFAULT 0 NOT NULL,
+    forum_posts_approved integer DEFAULT 0 NOT NULL,
+    forum_posts_unapproved integer DEFAULT 0 NOT NULL,
+    forum_posts_softdeleted integer DEFAULT 0 NOT NULL,
+    forum_topics_approved integer DEFAULT 0 NOT NULL,
+    forum_topics_unapproved integer DEFAULT 0 NOT NULL,
+    forum_topics_softdeleted integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_forums_display_on_index_check CHECK ((display_on_index >= 0)),
+    CONSTRAINT phpbb_forums_display_subforum_limit_check CHECK ((display_subforum_limit >= 0)),
+    CONSTRAINT phpbb_forums_display_subforum_list_check CHECK ((display_subforum_list >= 0)),
+    CONSTRAINT phpbb_forums_enable_icons_check CHECK ((enable_icons >= 0)),
+    CONSTRAINT phpbb_forums_enable_indexing_check CHECK ((enable_indexing >= 0)),
+    CONSTRAINT phpbb_forums_enable_prune_check CHECK ((enable_prune >= 0)),
+    CONSTRAINT phpbb_forums_enable_shadow_prune_check CHECK ((enable_shadow_prune >= 0)),
+    CONSTRAINT phpbb_forums_forum_desc_options_check CHECK ((forum_desc_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_post_id_check CHECK ((forum_last_post_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_post_time_check CHECK ((forum_last_post_time >= 0)),
+    CONSTRAINT phpbb_forums_forum_last_poster_id_check CHECK ((forum_last_poster_id >= 0)),
+    CONSTRAINT phpbb_forums_forum_options_check CHECK ((forum_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_approved_check CHECK ((forum_posts_approved >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_softdeleted_check CHECK ((forum_posts_softdeleted >= 0)),
+    CONSTRAINT phpbb_forums_forum_posts_unapproved_check CHECK ((forum_posts_unapproved >= 0)),
+    CONSTRAINT phpbb_forums_forum_rules_options_check CHECK ((forum_rules_options >= 0)),
+    CONSTRAINT phpbb_forums_forum_style_check CHECK ((forum_style >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_approved_check CHECK ((forum_topics_approved >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_per_page_check CHECK ((forum_topics_per_page >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_softdeleted_check CHECK ((forum_topics_softdeleted >= 0)),
+    CONSTRAINT phpbb_forums_forum_topics_unapproved_check CHECK ((forum_topics_unapproved >= 0)),
+    CONSTRAINT phpbb_forums_left_id_check CHECK ((left_id >= 0)),
+    CONSTRAINT phpbb_forums_parent_id_check CHECK ((parent_id >= 0)),
+    CONSTRAINT phpbb_forums_prune_days_check CHECK ((prune_days >= 0)),
+    CONSTRAINT phpbb_forums_prune_freq_check CHECK ((prune_freq >= 0)),
+    CONSTRAINT phpbb_forums_prune_next_check CHECK ((prune_next >= 0)),
+    CONSTRAINT phpbb_forums_prune_shadow_days_check CHECK ((prune_shadow_days >= 0)),
+    CONSTRAINT phpbb_forums_prune_shadow_freq_check CHECK ((prune_shadow_freq >= 0)),
+    CONSTRAINT phpbb_forums_prune_viewed_check CHECK ((prune_viewed >= 0)),
+    CONSTRAINT phpbb_forums_right_id_check CHECK ((right_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_access; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_access (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    CONSTRAINT phpbb_forums_access_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_access_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_track; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_track (
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    mark_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_forums_track_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_track_mark_time_check CHECK ((mark_time >= 0)),
+    CONSTRAINT phpbb_forums_track_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_forums_watch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_forums_watch (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notify_status smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_forums_watch_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_forums_watch_notify_status_check CHECK ((notify_status >= 0)),
+    CONSTRAINT phpbb_forums_watch_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_groups_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_groups_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_groups (
+    group_id integer DEFAULT nextval('public.phpbb_groups_seq'::regclass) NOT NULL,
+    group_type smallint DEFAULT '1'::smallint NOT NULL,
+    group_founder_manage smallint DEFAULT '0'::smallint NOT NULL,
+    group_skip_auth smallint DEFAULT '0'::smallint NOT NULL,
+    group_name public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    group_desc character varying(4000) DEFAULT ''::character varying NOT NULL,
+    group_desc_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_desc_options integer DEFAULT 7 NOT NULL,
+    group_desc_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    group_display smallint DEFAULT '0'::smallint NOT NULL,
+    group_avatar character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_avatar_type character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_avatar_width smallint DEFAULT '0'::smallint NOT NULL,
+    group_avatar_height smallint DEFAULT '0'::smallint NOT NULL,
+    group_rank integer DEFAULT 0 NOT NULL,
+    group_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    group_sig_chars integer DEFAULT 0 NOT NULL,
+    group_receive_pm smallint DEFAULT '0'::smallint NOT NULL,
+    group_message_limit integer DEFAULT 0 NOT NULL,
+    group_legend integer DEFAULT 0 NOT NULL,
+    group_max_recipients integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_groups_group_avatar_height_check CHECK ((group_avatar_height >= 0)),
+    CONSTRAINT phpbb_groups_group_avatar_width_check CHECK ((group_avatar_width >= 0)),
+    CONSTRAINT phpbb_groups_group_desc_options_check CHECK ((group_desc_options >= 0)),
+    CONSTRAINT phpbb_groups_group_display_check CHECK ((group_display >= 0)),
+    CONSTRAINT phpbb_groups_group_founder_manage_check CHECK ((group_founder_manage >= 0)),
+    CONSTRAINT phpbb_groups_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_groups_group_legend_check CHECK ((group_legend >= 0)),
+    CONSTRAINT phpbb_groups_group_max_recipients_check CHECK ((group_max_recipients >= 0)),
+    CONSTRAINT phpbb_groups_group_message_limit_check CHECK ((group_message_limit >= 0)),
+    CONSTRAINT phpbb_groups_group_rank_check CHECK ((group_rank >= 0)),
+    CONSTRAINT phpbb_groups_group_receive_pm_check CHECK ((group_receive_pm >= 0)),
+    CONSTRAINT phpbb_groups_group_sig_chars_check CHECK ((group_sig_chars >= 0)),
+    CONSTRAINT phpbb_groups_group_skip_auth_check CHECK ((group_skip_auth >= 0))
+);
+
+
+--
+-- Name: phpbb_icons_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_icons_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_icons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_icons (
+    icons_id integer DEFAULT nextval('public.phpbb_icons_seq'::regclass) NOT NULL,
+    icons_url character varying(255) DEFAULT ''::character varying NOT NULL,
+    icons_width smallint DEFAULT '0'::smallint NOT NULL,
+    icons_height smallint DEFAULT '0'::smallint NOT NULL,
+    icons_alt character varying(255) DEFAULT ''::character varying NOT NULL,
+    icons_order integer DEFAULT 0 NOT NULL,
+    display_on_posting smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_icons_display_on_posting_check CHECK ((display_on_posting >= 0)),
+    CONSTRAINT phpbb_icons_icons_id_check CHECK ((icons_id >= 0)),
+    CONSTRAINT phpbb_icons_icons_order_check CHECK ((icons_order >= 0))
+);
+
+
+--
+-- Name: phpbb_lang_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_lang_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_lang (
+    lang_id smallint DEFAULT nextval('public.phpbb_lang_seq'::regclass) NOT NULL,
+    lang_iso character varying(30) DEFAULT ''::character varying NOT NULL,
+    lang_dir character varying(30) DEFAULT ''::character varying NOT NULL,
+    lang_english_name character varying(100) DEFAULT ''::character varying NOT NULL,
+    lang_local_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    lang_author character varying(255) DEFAULT ''::character varying NOT NULL
+);
+
+
+--
+-- Name: phpbb_log_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_log_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_log; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_log (
+    log_id integer DEFAULT nextval('public.phpbb_log_seq'::regclass) NOT NULL,
+    log_type smallint DEFAULT '0'::smallint NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    reportee_id integer DEFAULT 0 NOT NULL,
+    log_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    log_time integer DEFAULT 0 NOT NULL,
+    log_operation character varying(4000) DEFAULT ''::character varying NOT NULL,
+    log_data text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_log_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_log_log_id_check CHECK ((log_id >= 0)),
+    CONSTRAINT phpbb_log_log_time_check CHECK ((log_time >= 0)),
+    CONSTRAINT phpbb_log_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_log_reportee_id_check CHECK ((reportee_id >= 0)),
+    CONSTRAINT phpbb_log_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_log_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_login_attempts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_login_attempts (
+    attempt_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    attempt_browser character varying(150) DEFAULT ''::character varying NOT NULL,
+    attempt_forwarded_for character varying(255) DEFAULT ''::character varying NOT NULL,
+    attempt_time integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    username character varying(255) DEFAULT '0'::character varying NOT NULL,
+    username_clean public.varchar_ci DEFAULT '0'::character varying NOT NULL,
+    CONSTRAINT phpbb_login_attempts_attempt_time_check CHECK ((attempt_time >= 0)),
+    CONSTRAINT phpbb_login_attempts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_migrations (
+    migration_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    migration_depends_on character varying(8000) DEFAULT ''::character varying NOT NULL,
+    migration_schema_done smallint DEFAULT '0'::smallint NOT NULL,
+    migration_data_done smallint DEFAULT '0'::smallint NOT NULL,
+    migration_data_state character varying(8000) DEFAULT ''::character varying NOT NULL,
+    migration_start_time integer DEFAULT 0 NOT NULL,
+    migration_end_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_migrations_migration_data_done_check CHECK ((migration_data_done >= 0)),
+    CONSTRAINT phpbb_migrations_migration_end_time_check CHECK ((migration_end_time >= 0)),
+    CONSTRAINT phpbb_migrations_migration_schema_done_check CHECK ((migration_schema_done >= 0)),
+    CONSTRAINT phpbb_migrations_migration_start_time_check CHECK ((migration_start_time >= 0))
+);
+
+
+--
+-- Name: phpbb_moderator_cache; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_moderator_cache (
+    forum_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    username character varying(255) DEFAULT ''::character varying NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    group_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    display_on_index smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_moderator_cache_display_on_index_check CHECK ((display_on_index >= 0)),
+    CONSTRAINT phpbb_moderator_cache_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_moderator_cache_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_moderator_cache_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_modules_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_modules_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_modules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_modules (
+    module_id integer DEFAULT nextval('public.phpbb_modules_seq'::regclass) NOT NULL,
+    module_enabled smallint DEFAULT '1'::smallint NOT NULL,
+    module_display smallint DEFAULT '1'::smallint NOT NULL,
+    module_basename character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_class character varying(10) DEFAULT ''::character varying NOT NULL,
+    parent_id integer DEFAULT 0 NOT NULL,
+    left_id integer DEFAULT 0 NOT NULL,
+    right_id integer DEFAULT 0 NOT NULL,
+    module_langname character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_mode character varying(255) DEFAULT ''::character varying NOT NULL,
+    module_auth character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_modules_left_id_check CHECK ((left_id >= 0)),
+    CONSTRAINT phpbb_modules_module_display_check CHECK ((module_display >= 0)),
+    CONSTRAINT phpbb_modules_module_enabled_check CHECK ((module_enabled >= 0)),
+    CONSTRAINT phpbb_modules_module_id_check CHECK ((module_id >= 0)),
+    CONSTRAINT phpbb_modules_parent_id_check CHECK ((parent_id >= 0)),
+    CONSTRAINT phpbb_modules_right_id_check CHECK ((right_id >= 0))
+);
+
+
+--
+-- Name: phpbb_notification_emails; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_notification_emails (
+    notification_type_id smallint DEFAULT '0'::smallint NOT NULL,
+    item_id integer DEFAULT 0 NOT NULL,
+    item_parent_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_notification_emails_item_id_check CHECK ((item_id >= 0)),
+    CONSTRAINT phpbb_notification_emails_item_parent_id_check CHECK ((item_parent_id >= 0)),
+    CONSTRAINT phpbb_notification_emails_notification_type_id_check CHECK ((notification_type_id >= 0)),
+    CONSTRAINT phpbb_notification_emails_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_notification_types_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_notification_types_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_notification_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_notification_types (
+    notification_type_id smallint DEFAULT nextval('public.phpbb_notification_types_seq'::regclass) NOT NULL,
+    notification_type_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    notification_type_enabled smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_notification_types_notification_type_enabled_check CHECK ((notification_type_enabled >= 0)),
+    CONSTRAINT phpbb_notification_types_notification_type_id_check CHECK ((notification_type_id >= 0))
+);
+
+
+--
+-- Name: phpbb_notifications_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_notifications_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_notifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_notifications (
+    notification_id integer DEFAULT nextval('public.phpbb_notifications_seq'::regclass) NOT NULL,
+    notification_type_id smallint DEFAULT '0'::smallint NOT NULL,
+    item_id integer DEFAULT 0 NOT NULL,
+    item_parent_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notification_read smallint DEFAULT '0'::smallint NOT NULL,
+    notification_time integer DEFAULT 1 NOT NULL,
+    notification_data character varying(4000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_notifications_item_id_check CHECK ((item_id >= 0)),
+    CONSTRAINT phpbb_notifications_item_parent_id_check CHECK ((item_parent_id >= 0)),
+    CONSTRAINT phpbb_notifications_notification_id_check CHECK ((notification_id >= 0)),
+    CONSTRAINT phpbb_notifications_notification_read_check CHECK ((notification_read >= 0)),
+    CONSTRAINT phpbb_notifications_notification_time_check CHECK ((notification_time >= 0)),
+    CONSTRAINT phpbb_notifications_notification_type_id_check CHECK ((notification_type_id >= 0)),
+    CONSTRAINT phpbb_notifications_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_oauth_accounts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_oauth_accounts (
+    user_id integer DEFAULT 0 NOT NULL,
+    provider character varying(255) DEFAULT ''::character varying NOT NULL,
+    oauth_provider_id character varying(4000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_oauth_accounts_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_oauth_states; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_oauth_states (
+    user_id integer DEFAULT 0 NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    provider character varying(255) DEFAULT ''::character varying NOT NULL,
+    oauth_state character varying(255) DEFAULT ''::character varying NOT NULL,
+    state_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_oauth_states_state_time_check CHECK ((state_time >= 0)),
+    CONSTRAINT phpbb_oauth_states_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_oauth_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_oauth_tokens (
+    user_id integer DEFAULT 0 NOT NULL,
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    provider character varying(255) DEFAULT ''::character varying NOT NULL,
+    oauth_token text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_oauth_tokens_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_poll_options; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_poll_options (
+    poll_option_id smallint DEFAULT '0'::smallint NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    poll_option_text character varying(4000) DEFAULT ''::character varying NOT NULL,
+    poll_option_total integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_poll_options_poll_option_total_check CHECK ((poll_option_total >= 0)),
+    CONSTRAINT phpbb_poll_options_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_poll_votes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_poll_votes (
+    topic_id integer DEFAULT 0 NOT NULL,
+    poll_option_id smallint DEFAULT '0'::smallint NOT NULL,
+    vote_user_id integer DEFAULT 0 NOT NULL,
+    vote_user_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_poll_votes_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_poll_votes_vote_user_id_check CHECK ((vote_user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_posts_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_posts_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_posts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_posts (
+    post_id integer DEFAULT nextval('public.phpbb_posts_seq'::regclass) NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    poster_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    poster_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    post_time integer DEFAULT 0 NOT NULL,
+    post_reported smallint DEFAULT '0'::smallint NOT NULL,
+    enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    enable_sig smallint DEFAULT '1'::smallint NOT NULL,
+    post_username character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_text text DEFAULT ''::text NOT NULL,
+    post_checksum character varying(32) DEFAULT ''::character varying NOT NULL,
+    post_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    post_postcount smallint DEFAULT '1'::smallint NOT NULL,
+    post_edit_time integer DEFAULT 0 NOT NULL,
+    post_edit_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_edit_user integer DEFAULT 0 NOT NULL,
+    post_edit_count smallint DEFAULT '0'::smallint NOT NULL,
+    post_edit_locked smallint DEFAULT '0'::smallint NOT NULL,
+    post_visibility smallint DEFAULT '0'::smallint NOT NULL,
+    post_delete_time integer DEFAULT 0 NOT NULL,
+    post_delete_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    post_delete_user integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_posts_enable_bbcode_check CHECK ((enable_bbcode >= 0)),
+    CONSTRAINT phpbb_posts_enable_magic_url_check CHECK ((enable_magic_url >= 0)),
+    CONSTRAINT phpbb_posts_enable_sig_check CHECK ((enable_sig >= 0)),
+    CONSTRAINT phpbb_posts_enable_smilies_check CHECK ((enable_smilies >= 0)),
+    CONSTRAINT phpbb_posts_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_posts_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_posts_post_attachment_check CHECK ((post_attachment >= 0)),
+    CONSTRAINT phpbb_posts_post_delete_time_check CHECK ((post_delete_time >= 0)),
+    CONSTRAINT phpbb_posts_post_delete_user_check CHECK ((post_delete_user >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_count_check CHECK ((post_edit_count >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_locked_check CHECK ((post_edit_locked >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_time_check CHECK ((post_edit_time >= 0)),
+    CONSTRAINT phpbb_posts_post_edit_user_check CHECK ((post_edit_user >= 0)),
+    CONSTRAINT phpbb_posts_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_posts_post_postcount_check CHECK ((post_postcount >= 0)),
+    CONSTRAINT phpbb_posts_post_reported_check CHECK ((post_reported >= 0)),
+    CONSTRAINT phpbb_posts_post_time_check CHECK ((post_time >= 0)),
+    CONSTRAINT phpbb_posts_poster_id_check CHECK ((poster_id >= 0)),
+    CONSTRAINT phpbb_posts_topic_id_check CHECK ((topic_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs (
+    msg_id integer DEFAULT nextval('public.phpbb_privmsgs_seq'::regclass) NOT NULL,
+    root_level integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    author_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    message_time integer DEFAULT 0 NOT NULL,
+    enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    enable_sig smallint DEFAULT '1'::smallint NOT NULL,
+    message_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    message_text text DEFAULT ''::text NOT NULL,
+    message_edit_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    message_edit_user integer DEFAULT 0 NOT NULL,
+    message_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    message_edit_time integer DEFAULT 0 NOT NULL,
+    message_edit_count smallint DEFAULT '0'::smallint NOT NULL,
+    to_address character varying(4000) DEFAULT ''::character varying NOT NULL,
+    bcc_address character varying(4000) DEFAULT ''::character varying NOT NULL,
+    message_reported smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_privmsgs_author_id_check CHECK ((author_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_bbcode_check CHECK ((enable_bbcode >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_magic_url_check CHECK ((enable_magic_url >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_sig_check CHECK ((enable_sig >= 0)),
+    CONSTRAINT phpbb_privmsgs_enable_smilies_check CHECK ((enable_smilies >= 0)),
+    CONSTRAINT phpbb_privmsgs_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_attachment_check CHECK ((message_attachment >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_count_check CHECK ((message_edit_count >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_time_check CHECK ((message_edit_time >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_edit_user_check CHECK ((message_edit_user >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_reported_check CHECK ((message_reported >= 0)),
+    CONSTRAINT phpbb_privmsgs_message_time_check CHECK ((message_time >= 0)),
+    CONSTRAINT phpbb_privmsgs_msg_id_check CHECK ((msg_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_root_level_check CHECK ((root_level >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_folder_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_folder_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs_folder; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_folder (
+    folder_id integer DEFAULT nextval('public.phpbb_privmsgs_folder_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    folder_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    pm_count integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_folder_folder_id_check CHECK ((folder_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_folder_pm_count_check CHECK ((pm_count >= 0)),
+    CONSTRAINT phpbb_privmsgs_folder_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_rules_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_privmsgs_rules_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_privmsgs_rules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_rules (
+    rule_id integer DEFAULT nextval('public.phpbb_privmsgs_rules_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    rule_check integer DEFAULT 0 NOT NULL,
+    rule_connection integer DEFAULT 0 NOT NULL,
+    rule_string character varying(255) DEFAULT ''::character varying NOT NULL,
+    rule_user_id integer DEFAULT 0 NOT NULL,
+    rule_group_id integer DEFAULT 0 NOT NULL,
+    rule_action integer DEFAULT 0 NOT NULL,
+    rule_folder_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_rules_rule_action_check CHECK ((rule_action >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_check_check CHECK ((rule_check >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_connection_check CHECK ((rule_connection >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_group_id_check CHECK ((rule_group_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_id_check CHECK ((rule_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_rule_user_id_check CHECK ((rule_user_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_rules_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_privmsgs_to; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_privmsgs_to (
+    msg_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    author_id integer DEFAULT 0 NOT NULL,
+    pm_deleted smallint DEFAULT '0'::smallint NOT NULL,
+    pm_new smallint DEFAULT '1'::smallint NOT NULL,
+    pm_unread smallint DEFAULT '1'::smallint NOT NULL,
+    pm_replied smallint DEFAULT '0'::smallint NOT NULL,
+    pm_marked smallint DEFAULT '0'::smallint NOT NULL,
+    pm_forwarded smallint DEFAULT '0'::smallint NOT NULL,
+    folder_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_privmsgs_to_author_id_check CHECK ((author_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_msg_id_check CHECK ((msg_id >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_deleted_check CHECK ((pm_deleted >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_forwarded_check CHECK ((pm_forwarded >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_marked_check CHECK ((pm_marked >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_new_check CHECK ((pm_new >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_replied_check CHECK ((pm_replied >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_pm_unread_check CHECK ((pm_unread >= 0)),
+    CONSTRAINT phpbb_privmsgs_to_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_profile_fields_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_profile_fields; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields (
+    field_id integer DEFAULT nextval('public.phpbb_profile_fields_seq'::regclass) NOT NULL,
+    field_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_type character varying(100) DEFAULT ''::character varying NOT NULL,
+    field_ident character varying(20) DEFAULT ''::character varying NOT NULL,
+    field_length character varying(20) DEFAULT ''::character varying NOT NULL,
+    field_minlen character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_maxlen character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_novalue character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_default_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_validation character varying(128) DEFAULT ''::character varying NOT NULL,
+    field_required smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_reg smallint DEFAULT '0'::smallint NOT NULL,
+    field_hide smallint DEFAULT '0'::smallint NOT NULL,
+    field_no_view smallint DEFAULT '0'::smallint NOT NULL,
+    field_active smallint DEFAULT '0'::smallint NOT NULL,
+    field_order integer DEFAULT 0 NOT NULL,
+    field_show_profile smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_vt smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_novalue smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_pm smallint DEFAULT '0'::smallint NOT NULL,
+    field_show_on_ml smallint DEFAULT '0'::smallint NOT NULL,
+    field_is_contact smallint DEFAULT '0'::smallint NOT NULL,
+    field_contact_desc character varying(255) DEFAULT ''::character varying NOT NULL,
+    field_contact_url character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_field_active_check CHECK ((field_active >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_hide_check CHECK ((field_hide >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_is_contact_check CHECK ((field_is_contact >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_no_view_check CHECK ((field_no_view >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_order_check CHECK ((field_order >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_required_check CHECK ((field_required >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_novalue_check CHECK ((field_show_novalue >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_ml_check CHECK ((field_show_on_ml >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_pm_check CHECK ((field_show_on_pm >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_reg_check CHECK ((field_show_on_reg >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_on_vt_check CHECK ((field_show_on_vt >= 0)),
+    CONSTRAINT phpbb_profile_fields_field_show_profile_check CHECK ((field_show_profile >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_data; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields_data (
+    user_id integer DEFAULT 0 NOT NULL,
+    pf_phpbb_interests text DEFAULT ''::text NOT NULL,
+    pf_phpbb_occupation text DEFAULT ''::text NOT NULL,
+    pf_phpbb_facebook character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_icq character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_location character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_skype character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_twitter character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_website character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_yahoo character varying(255) DEFAULT ''::character varying NOT NULL,
+    pf_phpbb_youtube character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_data_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_fields_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_fields_lang (
+    field_id integer DEFAULT 0 NOT NULL,
+    lang_id integer DEFAULT 0 NOT NULL,
+    option_id integer DEFAULT 0 NOT NULL,
+    field_type character varying(100) DEFAULT ''::character varying NOT NULL,
+    lang_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_fields_lang_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_lang_lang_id_check CHECK ((lang_id >= 0)),
+    CONSTRAINT phpbb_profile_fields_lang_option_id_check CHECK ((option_id >= 0))
+);
+
+
+--
+-- Name: phpbb_profile_lang; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_profile_lang (
+    field_id integer DEFAULT 0 NOT NULL,
+    lang_id integer DEFAULT 0 NOT NULL,
+    lang_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    lang_explain character varying(4000) DEFAULT ''::character varying NOT NULL,
+    lang_default_value character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_profile_lang_field_id_check CHECK ((field_id >= 0)),
+    CONSTRAINT phpbb_profile_lang_lang_id_check CHECK ((lang_id >= 0))
+);
+
+
+--
+-- Name: phpbb_ranks_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_ranks_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_ranks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_ranks (
+    rank_id integer DEFAULT nextval('public.phpbb_ranks_seq'::regclass) NOT NULL,
+    rank_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    rank_min integer DEFAULT 0 NOT NULL,
+    rank_special smallint DEFAULT '0'::smallint NOT NULL,
+    rank_image character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_ranks_rank_id_check CHECK ((rank_id >= 0)),
+    CONSTRAINT phpbb_ranks_rank_min_check CHECK ((rank_min >= 0)),
+    CONSTRAINT phpbb_ranks_rank_special_check CHECK ((rank_special >= 0))
+);
+
+
+--
+-- Name: phpbb_reports_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_reports_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_reports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_reports (
+    report_id integer DEFAULT nextval('public.phpbb_reports_seq'::regclass) NOT NULL,
+    reason_id smallint DEFAULT '0'::smallint NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    user_notify smallint DEFAULT '0'::smallint NOT NULL,
+    report_closed smallint DEFAULT '0'::smallint NOT NULL,
+    report_time integer DEFAULT 0 NOT NULL,
+    report_text text DEFAULT ''::text NOT NULL,
+    pm_id integer DEFAULT 0 NOT NULL,
+    reported_post_enable_bbcode smallint DEFAULT '1'::smallint NOT NULL,
+    reported_post_enable_smilies smallint DEFAULT '1'::smallint NOT NULL,
+    reported_post_enable_magic_url smallint DEFAULT '1'::smallint NOT NULL,
+    reported_post_text text DEFAULT ''::text NOT NULL,
+    reported_post_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    reported_post_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_reports_pm_id_check CHECK ((pm_id >= 0)),
+    CONSTRAINT phpbb_reports_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_reports_reason_id_check CHECK ((reason_id >= 0)),
+    CONSTRAINT phpbb_reports_report_closed_check CHECK ((report_closed >= 0)),
+    CONSTRAINT phpbb_reports_report_id_check CHECK ((report_id >= 0)),
+    CONSTRAINT phpbb_reports_report_time_check CHECK ((report_time >= 0)),
+    CONSTRAINT phpbb_reports_reported_post_enable_bbcode_check CHECK ((reported_post_enable_bbcode >= 0)),
+    CONSTRAINT phpbb_reports_reported_post_enable_magic_url_check CHECK ((reported_post_enable_magic_url >= 0)),
+    CONSTRAINT phpbb_reports_reported_post_enable_smilies_check CHECK ((reported_post_enable_smilies >= 0)),
+    CONSTRAINT phpbb_reports_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_reports_user_notify_check CHECK ((user_notify >= 0))
+);
+
+
+--
+-- Name: phpbb_reports_reasons_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_reports_reasons_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_reports_reasons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_reports_reasons (
+    reason_id smallint DEFAULT nextval('public.phpbb_reports_reasons_seq'::regclass) NOT NULL,
+    reason_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    reason_description text DEFAULT ''::text NOT NULL,
+    reason_order smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_reports_reasons_reason_id_check CHECK ((reason_id >= 0)),
+    CONSTRAINT phpbb_reports_reasons_reason_order_check CHECK ((reason_order >= 0))
+);
+
+
+--
+-- Name: phpbb_search_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_results (
+    search_key character varying(32) DEFAULT ''::character varying NOT NULL,
+    search_time integer DEFAULT 0 NOT NULL,
+    search_keywords text DEFAULT ''::text NOT NULL,
+    search_authors text DEFAULT ''::text NOT NULL,
+    CONSTRAINT phpbb_search_results_search_time_check CHECK ((search_time >= 0))
+);
+
+
+--
+-- Name: phpbb_search_wordlist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_search_wordlist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_search_wordlist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_wordlist (
+    word_id integer DEFAULT nextval('public.phpbb_search_wordlist_seq'::regclass) NOT NULL,
+    word_text character varying(255) DEFAULT ''::character varying NOT NULL,
+    word_common smallint DEFAULT '0'::smallint NOT NULL,
+    word_count integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_search_wordlist_word_common_check CHECK ((word_common >= 0)),
+    CONSTRAINT phpbb_search_wordlist_word_count_check CHECK ((word_count >= 0)),
+    CONSTRAINT phpbb_search_wordlist_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_search_wordmatch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_search_wordmatch (
+    post_id integer DEFAULT 0 NOT NULL,
+    word_id integer DEFAULT 0 NOT NULL,
+    title_match smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_search_wordmatch_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_search_wordmatch_title_match_check CHECK ((title_match >= 0)),
+    CONSTRAINT phpbb_search_wordmatch_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sessions (
+    session_id character(32) DEFAULT ''::bpchar NOT NULL,
+    session_user_id integer DEFAULT 0 NOT NULL,
+    session_last_visit integer DEFAULT 0 NOT NULL,
+    session_start integer DEFAULT 0 NOT NULL,
+    session_time integer DEFAULT 0 NOT NULL,
+    session_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    session_browser character varying(150) DEFAULT ''::character varying NOT NULL,
+    session_forwarded_for character varying(255) DEFAULT ''::character varying NOT NULL,
+    session_page character varying(255) DEFAULT ''::character varying NOT NULL,
+    session_viewonline smallint DEFAULT '1'::smallint NOT NULL,
+    session_autologin smallint DEFAULT '0'::smallint NOT NULL,
+    session_admin smallint DEFAULT '0'::smallint NOT NULL,
+    session_forum_id integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_sessions_session_admin_check CHECK ((session_admin >= 0)),
+    CONSTRAINT phpbb_sessions_session_autologin_check CHECK ((session_autologin >= 0)),
+    CONSTRAINT phpbb_sessions_session_forum_id_check CHECK ((session_forum_id >= 0)),
+    CONSTRAINT phpbb_sessions_session_last_visit_check CHECK ((session_last_visit >= 0)),
+    CONSTRAINT phpbb_sessions_session_start_check CHECK ((session_start >= 0)),
+    CONSTRAINT phpbb_sessions_session_time_check CHECK ((session_time >= 0)),
+    CONSTRAINT phpbb_sessions_session_user_id_check CHECK ((session_user_id >= 0)),
+    CONSTRAINT phpbb_sessions_session_viewonline_check CHECK ((session_viewonline >= 0))
+);
+
+
+--
+-- Name: phpbb_sessions_keys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sessions_keys (
+    key_id character(32) DEFAULT ''::bpchar NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    last_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    last_login integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_sessions_keys_last_login_check CHECK ((last_login >= 0)),
+    CONSTRAINT phpbb_sessions_keys_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_sitelist_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_sitelist_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_sitelist; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_sitelist (
+    site_id integer DEFAULT nextval('public.phpbb_sitelist_seq'::regclass) NOT NULL,
+    site_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    site_hostname character varying(255) DEFAULT ''::character varying NOT NULL,
+    ip_exclude smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_sitelist_ip_exclude_check CHECK ((ip_exclude >= 0)),
+    CONSTRAINT phpbb_sitelist_site_id_check CHECK ((site_id >= 0))
+);
+
+
+--
+-- Name: phpbb_smilies_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_smilies_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_smilies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_smilies (
+    smiley_id integer DEFAULT nextval('public.phpbb_smilies_seq'::regclass) NOT NULL,
+    code character varying(50) DEFAULT ''::character varying NOT NULL,
+    emotion character varying(255) DEFAULT ''::character varying NOT NULL,
+    smiley_url character varying(50) DEFAULT ''::character varying NOT NULL,
+    smiley_width smallint DEFAULT '0'::smallint NOT NULL,
+    smiley_height smallint DEFAULT '0'::smallint NOT NULL,
+    smiley_order integer DEFAULT 0 NOT NULL,
+    display_on_posting smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_smilies_display_on_posting_check CHECK ((display_on_posting >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_height_check CHECK ((smiley_height >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_id_check CHECK ((smiley_id >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_order_check CHECK ((smiley_order >= 0)),
+    CONSTRAINT phpbb_smilies_smiley_width_check CHECK ((smiley_width >= 0))
+);
+
+
+--
+-- Name: phpbb_styles_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_styles_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_styles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_styles (
+    style_id integer DEFAULT nextval('public.phpbb_styles_seq'::regclass) NOT NULL,
+    style_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    style_copyright character varying(255) DEFAULT ''::character varying NOT NULL,
+    style_active smallint DEFAULT '1'::smallint NOT NULL,
+    style_path character varying(100) DEFAULT ''::character varying NOT NULL,
+    bbcode_bitfield character varying(255) DEFAULT 'kNg='::character varying NOT NULL,
+    style_parent_id integer DEFAULT 0 NOT NULL,
+    style_parent_tree character varying(8000) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_styles_style_active_check CHECK ((style_active >= 0)),
+    CONSTRAINT phpbb_styles_style_id_check CHECK ((style_id >= 0)),
+    CONSTRAINT phpbb_styles_style_parent_id_check CHECK ((style_parent_id >= 0))
+);
+
+
+--
+-- Name: phpbb_teampage_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_teampage_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_teampage; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_teampage (
+    teampage_id integer DEFAULT nextval('public.phpbb_teampage_seq'::regclass) NOT NULL,
+    group_id integer DEFAULT 0 NOT NULL,
+    teampage_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    teampage_position integer DEFAULT 0 NOT NULL,
+    teampage_parent integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_teampage_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_teampage_teampage_id_check CHECK ((teampage_id >= 0)),
+    CONSTRAINT phpbb_teampage_teampage_parent_check CHECK ((teampage_parent >= 0)),
+    CONSTRAINT phpbb_teampage_teampage_position_check CHECK ((teampage_position >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_topics_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_topics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics (
+    topic_id integer DEFAULT nextval('public.phpbb_topics_seq'::regclass) NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    icon_id integer DEFAULT 0 NOT NULL,
+    topic_attachment smallint DEFAULT '0'::smallint NOT NULL,
+    topic_reported smallint DEFAULT '0'::smallint NOT NULL,
+    topic_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_poster integer DEFAULT 0 NOT NULL,
+    topic_time integer DEFAULT 0 NOT NULL,
+    topic_time_limit integer DEFAULT 0 NOT NULL,
+    topic_views integer DEFAULT 0 NOT NULL,
+    topic_status smallint DEFAULT '0'::smallint NOT NULL,
+    topic_type smallint DEFAULT '0'::smallint NOT NULL,
+    topic_first_post_id integer DEFAULT 0 NOT NULL,
+    topic_first_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_first_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_id integer DEFAULT 0 NOT NULL,
+    topic_last_poster_id integer DEFAULT 0 NOT NULL,
+    topic_last_poster_name character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_last_poster_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_subject character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_last_post_time integer DEFAULT 0 NOT NULL,
+    topic_last_view_time integer DEFAULT 0 NOT NULL,
+    topic_moved_id integer DEFAULT 0 NOT NULL,
+    topic_bumped smallint DEFAULT '0'::smallint NOT NULL,
+    topic_bumper integer DEFAULT 0 NOT NULL,
+    poll_title character varying(255) DEFAULT ''::character varying NOT NULL,
+    poll_start integer DEFAULT 0 NOT NULL,
+    poll_length integer DEFAULT 0 NOT NULL,
+    poll_max_options smallint DEFAULT '1'::smallint NOT NULL,
+    poll_last_vote integer DEFAULT 0 NOT NULL,
+    poll_vote_change smallint DEFAULT '0'::smallint NOT NULL,
+    topic_visibility smallint DEFAULT '0'::smallint NOT NULL,
+    topic_delete_time integer DEFAULT 0 NOT NULL,
+    topic_delete_reason character varying(255) DEFAULT ''::character varying NOT NULL,
+    topic_delete_user integer DEFAULT 0 NOT NULL,
+    topic_posts_approved integer DEFAULT 0 NOT NULL,
+    topic_posts_unapproved integer DEFAULT 0 NOT NULL,
+    topic_posts_softdeleted integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_topics_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_topics_icon_id_check CHECK ((icon_id >= 0)),
+    CONSTRAINT phpbb_topics_poll_last_vote_check CHECK ((poll_last_vote >= 0)),
+    CONSTRAINT phpbb_topics_poll_length_check CHECK ((poll_length >= 0)),
+    CONSTRAINT phpbb_topics_poll_start_check CHECK ((poll_start >= 0)),
+    CONSTRAINT phpbb_topics_poll_vote_change_check CHECK ((poll_vote_change >= 0)),
+    CONSTRAINT phpbb_topics_topic_attachment_check CHECK ((topic_attachment >= 0)),
+    CONSTRAINT phpbb_topics_topic_bumped_check CHECK ((topic_bumped >= 0)),
+    CONSTRAINT phpbb_topics_topic_bumper_check CHECK ((topic_bumper >= 0)),
+    CONSTRAINT phpbb_topics_topic_delete_time_check CHECK ((topic_delete_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_delete_user_check CHECK ((topic_delete_user >= 0)),
+    CONSTRAINT phpbb_topics_topic_first_post_id_check CHECK ((topic_first_post_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_post_id_check CHECK ((topic_last_post_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_post_time_check CHECK ((topic_last_post_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_poster_id_check CHECK ((topic_last_poster_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_last_view_time_check CHECK ((topic_last_view_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_moved_id_check CHECK ((topic_moved_id >= 0)),
+    CONSTRAINT phpbb_topics_topic_poster_check CHECK ((topic_poster >= 0)),
+    CONSTRAINT phpbb_topics_topic_posts_approved_check CHECK ((topic_posts_approved >= 0)),
+    CONSTRAINT phpbb_topics_topic_posts_softdeleted_check CHECK ((topic_posts_softdeleted >= 0)),
+    CONSTRAINT phpbb_topics_topic_posts_unapproved_check CHECK ((topic_posts_unapproved >= 0)),
+    CONSTRAINT phpbb_topics_topic_reported_check CHECK ((topic_reported >= 0)),
+    CONSTRAINT phpbb_topics_topic_time_check CHECK ((topic_time >= 0)),
+    CONSTRAINT phpbb_topics_topic_time_limit_check CHECK ((topic_time_limit >= 0)),
+    CONSTRAINT phpbb_topics_topic_views_check CHECK ((topic_views >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_posted; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_posted (
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    topic_posted smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_topics_posted_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_posted_topic_posted_check CHECK ((topic_posted >= 0)),
+    CONSTRAINT phpbb_topics_posted_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_track; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_track (
+    user_id integer DEFAULT 0 NOT NULL,
+    topic_id integer DEFAULT 0 NOT NULL,
+    forum_id integer DEFAULT 0 NOT NULL,
+    mark_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_topics_track_forum_id_check CHECK ((forum_id >= 0)),
+    CONSTRAINT phpbb_topics_track_mark_time_check CHECK ((mark_time >= 0)),
+    CONSTRAINT phpbb_topics_track_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_track_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_topics_watch; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_topics_watch (
+    topic_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    notify_status smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_topics_watch_notify_status_check CHECK ((notify_status >= 0)),
+    CONSTRAINT phpbb_topics_watch_topic_id_check CHECK ((topic_id >= 0)),
+    CONSTRAINT phpbb_topics_watch_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_user_group; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_user_group (
+    group_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    group_leader smallint DEFAULT '0'::smallint NOT NULL,
+    user_pending smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_user_group_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_user_group_group_leader_check CHECK ((group_leader >= 0)),
+    CONSTRAINT phpbb_user_group_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_user_group_user_pending_check CHECK ((user_pending >= 0))
+);
+
+
+--
+-- Name: phpbb_user_notifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_user_notifications (
+    item_type character varying(165) DEFAULT ''::character varying NOT NULL,
+    item_id integer DEFAULT 0 NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    method character varying(165) DEFAULT ''::character varying NOT NULL,
+    notify smallint DEFAULT '1'::smallint NOT NULL,
+    CONSTRAINT phpbb_user_notifications_item_id_check CHECK ((item_id >= 0)),
+    CONSTRAINT phpbb_user_notifications_notify_check CHECK ((notify >= 0)),
+    CONSTRAINT phpbb_user_notifications_user_id_check CHECK ((user_id >= 0))
+);
+
+
+--
+-- Name: phpbb_users_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_users_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_users (
+    user_id integer DEFAULT nextval('public.phpbb_users_seq'::regclass) NOT NULL,
+    user_type smallint DEFAULT '0'::smallint NOT NULL,
+    group_id integer DEFAULT 3 NOT NULL,
+    user_permissions text DEFAULT ''::text NOT NULL,
+    user_perm_from integer DEFAULT 0 NOT NULL,
+    user_ip character varying(40) DEFAULT ''::character varying NOT NULL,
+    user_regdate integer DEFAULT 0 NOT NULL,
+    username public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    username_clean public.varchar_ci DEFAULT ''::character varying NOT NULL,
+    user_password character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_passchg integer DEFAULT 0 NOT NULL,
+    user_email character varying(100) DEFAULT ''::character varying NOT NULL,
+    user_birthday character varying(10) DEFAULT ''::character varying NOT NULL,
+    user_lastvisit integer DEFAULT 0 NOT NULL,
+    user_last_active integer DEFAULT 0 NOT NULL,
+    user_lastmark integer DEFAULT 0 NOT NULL,
+    user_lastpost_time integer DEFAULT 0 NOT NULL,
+    user_lastpage character varying(200) DEFAULT ''::character varying NOT NULL,
+    user_last_confirm_key character varying(10) DEFAULT ''::character varying NOT NULL,
+    user_last_search integer DEFAULT 0 NOT NULL,
+    user_warnings smallint DEFAULT '0'::smallint NOT NULL,
+    user_last_warning integer DEFAULT 0 NOT NULL,
+    user_login_attempts smallint DEFAULT '0'::smallint NOT NULL,
+    user_inactive_reason smallint DEFAULT '0'::smallint NOT NULL,
+    user_inactive_time integer DEFAULT 0 NOT NULL,
+    user_posts integer DEFAULT 0 NOT NULL,
+    user_lang character varying(30) DEFAULT ''::character varying NOT NULL,
+    user_timezone character varying(100) DEFAULT ''::character varying NOT NULL,
+    user_dateformat character varying(64) DEFAULT 'd M Y H:i'::character varying NOT NULL,
+    user_style integer DEFAULT 0 NOT NULL,
+    user_rank integer DEFAULT 0 NOT NULL,
+    user_colour character varying(6) DEFAULT ''::character varying NOT NULL,
+    user_new_privmsg integer DEFAULT 0 NOT NULL,
+    user_unread_privmsg integer DEFAULT 0 NOT NULL,
+    user_last_privmsg integer DEFAULT 0 NOT NULL,
+    user_message_rules smallint DEFAULT '0'::smallint NOT NULL,
+    user_full_folder integer DEFAULT '-3'::integer NOT NULL,
+    user_emailtime integer DEFAULT 0 NOT NULL,
+    user_topic_show_days smallint DEFAULT '0'::smallint NOT NULL,
+    user_topic_sortby_type character varying(1) DEFAULT 't'::character varying NOT NULL,
+    user_topic_sortby_dir character varying(1) DEFAULT 'd'::character varying NOT NULL,
+    user_post_show_days smallint DEFAULT '0'::smallint NOT NULL,
+    user_post_sortby_type character varying(1) DEFAULT 't'::character varying NOT NULL,
+    user_post_sortby_dir character varying(1) DEFAULT 'a'::character varying NOT NULL,
+    user_notify smallint DEFAULT '0'::smallint NOT NULL,
+    user_notify_pm smallint DEFAULT '1'::smallint NOT NULL,
+    user_notify_type smallint DEFAULT '0'::smallint NOT NULL,
+    user_allow_pm smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_viewonline smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_viewemail smallint DEFAULT '1'::smallint NOT NULL,
+    user_allow_massemail smallint DEFAULT '1'::smallint NOT NULL,
+    user_options integer DEFAULT 230271 NOT NULL,
+    user_avatar character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_avatar_type character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_avatar_width smallint DEFAULT '0'::smallint NOT NULL,
+    user_avatar_height smallint DEFAULT '0'::smallint NOT NULL,
+    user_sig text DEFAULT ''::text NOT NULL,
+    user_sig_bbcode_uid character varying(8) DEFAULT ''::character varying NOT NULL,
+    user_sig_bbcode_bitfield character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_jabber character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_actkey character varying(32) DEFAULT ''::character varying NOT NULL,
+    user_actkey_expiration integer DEFAULT 0 NOT NULL,
+    reset_token character varying(64) DEFAULT ''::character varying NOT NULL,
+    reset_token_expiration integer DEFAULT 0 NOT NULL,
+    user_newpasswd character varying(255) DEFAULT ''::character varying NOT NULL,
+    user_form_salt character varying(32) DEFAULT ''::character varying NOT NULL,
+    user_new smallint DEFAULT '1'::smallint NOT NULL,
+    user_reminded smallint DEFAULT '0'::smallint NOT NULL,
+    user_reminded_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_users_group_id_check CHECK ((group_id >= 0)),
+    CONSTRAINT phpbb_users_reset_token_expiration_check CHECK ((reset_token_expiration >= 0)),
+    CONSTRAINT phpbb_users_user_actkey_expiration_check CHECK ((user_actkey_expiration >= 0)),
+    CONSTRAINT phpbb_users_user_allow_massemail_check CHECK ((user_allow_massemail >= 0)),
+    CONSTRAINT phpbb_users_user_allow_pm_check CHECK ((user_allow_pm >= 0)),
+    CONSTRAINT phpbb_users_user_allow_viewemail_check CHECK ((user_allow_viewemail >= 0)),
+    CONSTRAINT phpbb_users_user_allow_viewonline_check CHECK ((user_allow_viewonline >= 0)),
+    CONSTRAINT phpbb_users_user_avatar_height_check CHECK ((user_avatar_height >= 0)),
+    CONSTRAINT phpbb_users_user_avatar_width_check CHECK ((user_avatar_width >= 0)),
+    CONSTRAINT phpbb_users_user_emailtime_check CHECK ((user_emailtime >= 0)),
+    CONSTRAINT phpbb_users_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_users_user_inactive_time_check CHECK ((user_inactive_time >= 0)),
+    CONSTRAINT phpbb_users_user_last_active_check CHECK ((user_last_active >= 0)),
+    CONSTRAINT phpbb_users_user_last_privmsg_check CHECK ((user_last_privmsg >= 0)),
+    CONSTRAINT phpbb_users_user_last_search_check CHECK ((user_last_search >= 0)),
+    CONSTRAINT phpbb_users_user_last_warning_check CHECK ((user_last_warning >= 0)),
+    CONSTRAINT phpbb_users_user_lastmark_check CHECK ((user_lastmark >= 0)),
+    CONSTRAINT phpbb_users_user_lastpost_time_check CHECK ((user_lastpost_time >= 0)),
+    CONSTRAINT phpbb_users_user_lastvisit_check CHECK ((user_lastvisit >= 0)),
+    CONSTRAINT phpbb_users_user_message_rules_check CHECK ((user_message_rules >= 0)),
+    CONSTRAINT phpbb_users_user_new_check CHECK ((user_new >= 0)),
+    CONSTRAINT phpbb_users_user_notify_check CHECK ((user_notify >= 0)),
+    CONSTRAINT phpbb_users_user_notify_pm_check CHECK ((user_notify_pm >= 0)),
+    CONSTRAINT phpbb_users_user_options_check CHECK ((user_options >= 0)),
+    CONSTRAINT phpbb_users_user_passchg_check CHECK ((user_passchg >= 0)),
+    CONSTRAINT phpbb_users_user_perm_from_check CHECK ((user_perm_from >= 0)),
+    CONSTRAINT phpbb_users_user_post_show_days_check CHECK ((user_post_show_days >= 0)),
+    CONSTRAINT phpbb_users_user_posts_check CHECK ((user_posts >= 0)),
+    CONSTRAINT phpbb_users_user_rank_check CHECK ((user_rank >= 0)),
+    CONSTRAINT phpbb_users_user_regdate_check CHECK ((user_regdate >= 0)),
+    CONSTRAINT phpbb_users_user_reminded_time_check CHECK ((user_reminded_time >= 0)),
+    CONSTRAINT phpbb_users_user_style_check CHECK ((user_style >= 0)),
+    CONSTRAINT phpbb_users_user_topic_show_days_check CHECK ((user_topic_show_days >= 0))
+);
+
+
+--
+-- Name: phpbb_warnings_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_warnings_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_warnings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_warnings (
+    warning_id integer DEFAULT nextval('public.phpbb_warnings_seq'::regclass) NOT NULL,
+    user_id integer DEFAULT 0 NOT NULL,
+    post_id integer DEFAULT 0 NOT NULL,
+    log_id integer DEFAULT 0 NOT NULL,
+    warning_time integer DEFAULT 0 NOT NULL,
+    CONSTRAINT phpbb_warnings_log_id_check CHECK ((log_id >= 0)),
+    CONSTRAINT phpbb_warnings_post_id_check CHECK ((post_id >= 0)),
+    CONSTRAINT phpbb_warnings_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_warnings_warning_id_check CHECK ((warning_id >= 0)),
+    CONSTRAINT phpbb_warnings_warning_time_check CHECK ((warning_time >= 0))
+);
+
+
+--
+-- Name: phpbb_words_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.phpbb_words_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phpbb_words; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_words (
+    word_id integer DEFAULT nextval('public.phpbb_words_seq'::regclass) NOT NULL,
+    word character varying(255) DEFAULT ''::character varying NOT NULL,
+    replacement character varying(255) DEFAULT ''::character varying NOT NULL,
+    CONSTRAINT phpbb_words_word_id_check CHECK ((word_id >= 0))
+);
+
+
+--
+-- Name: phpbb_zebra; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phpbb_zebra (
+    user_id integer DEFAULT 0 NOT NULL,
+    zebra_id integer DEFAULT 0 NOT NULL,
+    friend smallint DEFAULT '0'::smallint NOT NULL,
+    foe smallint DEFAULT '0'::smallint NOT NULL,
+    CONSTRAINT phpbb_zebra_foe_check CHECK ((foe >= 0)),
+    CONSTRAINT phpbb_zebra_friend_check CHECK ((friend >= 0)),
+    CONSTRAINT phpbb_zebra_user_id_check CHECK ((user_id >= 0)),
+    CONSTRAINT phpbb_zebra_zebra_id_check CHECK ((zebra_id >= 0))
+);
+
+
+--
+-- Name: phpbb_acl_options phpbb_acl_options_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_options
+    ADD CONSTRAINT phpbb_acl_options_pkey PRIMARY KEY (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles_data phpbb_acl_roles_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_roles_data
+    ADD CONSTRAINT phpbb_acl_roles_data_pkey PRIMARY KEY (role_id, auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles phpbb_acl_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_acl_roles
+    ADD CONSTRAINT phpbb_acl_roles_pkey PRIMARY KEY (role_id);
+
+
+--
+-- Name: phpbb_attachments phpbb_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_attachments
+    ADD CONSTRAINT phpbb_attachments_pkey PRIMARY KEY (attach_id);
+
+
+--
+-- Name: phpbb_banlist phpbb_banlist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_banlist
+    ADD CONSTRAINT phpbb_banlist_pkey PRIMARY KEY (ban_id);
+
+
+--
+-- Name: phpbb_bbcodes phpbb_bbcodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bbcodes
+    ADD CONSTRAINT phpbb_bbcodes_pkey PRIMARY KEY (bbcode_id);
+
+
+--
+-- Name: phpbb_bookmarks phpbb_bookmarks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bookmarks
+    ADD CONSTRAINT phpbb_bookmarks_pkey PRIMARY KEY (topic_id, user_id);
+
+
+--
+-- Name: phpbb_bots phpbb_bots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_bots
+    ADD CONSTRAINT phpbb_bots_pkey PRIMARY KEY (bot_id);
+
+
+--
+-- Name: phpbb_config phpbb_config_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_config
+    ADD CONSTRAINT phpbb_config_pkey PRIMARY KEY (config_name);
+
+
+--
+-- Name: phpbb_config_text phpbb_config_text_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_config_text
+    ADD CONSTRAINT phpbb_config_text_pkey PRIMARY KEY (config_name);
+
+
+--
+-- Name: phpbb_confirm phpbb_confirm_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_confirm
+    ADD CONSTRAINT phpbb_confirm_pkey PRIMARY KEY (session_id, confirm_id);
+
+
+--
+-- Name: phpbb_disallow phpbb_disallow_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_disallow
+    ADD CONSTRAINT phpbb_disallow_pkey PRIMARY KEY (disallow_id);
+
+
+--
+-- Name: phpbb_drafts phpbb_drafts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_drafts
+    ADD CONSTRAINT phpbb_drafts_pkey PRIMARY KEY (draft_id);
+
+
+--
+-- Name: phpbb_extension_groups phpbb_extension_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_extension_groups
+    ADD CONSTRAINT phpbb_extension_groups_pkey PRIMARY KEY (group_id);
+
+
+--
+-- Name: phpbb_extensions phpbb_extensions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_extensions
+    ADD CONSTRAINT phpbb_extensions_pkey PRIMARY KEY (extension_id);
+
+
+--
+-- Name: phpbb_forums_access phpbb_forums_access_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums_access
+    ADD CONSTRAINT phpbb_forums_access_pkey PRIMARY KEY (forum_id, user_id, session_id);
+
+
+--
+-- Name: phpbb_forums phpbb_forums_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums
+    ADD CONSTRAINT phpbb_forums_pkey PRIMARY KEY (forum_id);
+
+
+--
+-- Name: phpbb_forums_track phpbb_forums_track_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_forums_track
+    ADD CONSTRAINT phpbb_forums_track_pkey PRIMARY KEY (user_id, forum_id);
+
+
+--
+-- Name: phpbb_groups phpbb_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_groups
+    ADD CONSTRAINT phpbb_groups_pkey PRIMARY KEY (group_id);
+
+
+--
+-- Name: phpbb_icons phpbb_icons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_icons
+    ADD CONSTRAINT phpbb_icons_pkey PRIMARY KEY (icons_id);
+
+
+--
+-- Name: phpbb_lang phpbb_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_lang
+    ADD CONSTRAINT phpbb_lang_pkey PRIMARY KEY (lang_id);
+
+
+--
+-- Name: phpbb_log phpbb_log_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_log
+    ADD CONSTRAINT phpbb_log_pkey PRIMARY KEY (log_id);
+
+
+--
+-- Name: phpbb_migrations phpbb_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_migrations
+    ADD CONSTRAINT phpbb_migrations_pkey PRIMARY KEY (migration_name);
+
+
+--
+-- Name: phpbb_modules phpbb_modules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_modules
+    ADD CONSTRAINT phpbb_modules_pkey PRIMARY KEY (module_id);
+
+
+--
+-- Name: phpbb_notification_emails phpbb_notification_emails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_notification_emails
+    ADD CONSTRAINT phpbb_notification_emails_pkey PRIMARY KEY (notification_type_id, item_id, item_parent_id, user_id);
+
+
+--
+-- Name: phpbb_notification_types phpbb_notification_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_notification_types
+    ADD CONSTRAINT phpbb_notification_types_pkey PRIMARY KEY (notification_type_id);
+
+
+--
+-- Name: phpbb_notifications phpbb_notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_notifications
+    ADD CONSTRAINT phpbb_notifications_pkey PRIMARY KEY (notification_id);
+
+
+--
+-- Name: phpbb_oauth_accounts phpbb_oauth_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_oauth_accounts
+    ADD CONSTRAINT phpbb_oauth_accounts_pkey PRIMARY KEY (user_id, provider);
+
+
+--
+-- Name: phpbb_posts phpbb_posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_posts
+    ADD CONSTRAINT phpbb_posts_pkey PRIMARY KEY (post_id);
+
+
+--
+-- Name: phpbb_privmsgs_folder phpbb_privmsgs_folder_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs_folder
+    ADD CONSTRAINT phpbb_privmsgs_folder_pkey PRIMARY KEY (folder_id);
+
+
+--
+-- Name: phpbb_privmsgs phpbb_privmsgs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs
+    ADD CONSTRAINT phpbb_privmsgs_pkey PRIMARY KEY (msg_id);
+
+
+--
+-- Name: phpbb_privmsgs_rules phpbb_privmsgs_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_privmsgs_rules
+    ADD CONSTRAINT phpbb_privmsgs_rules_pkey PRIMARY KEY (rule_id);
+
+
+--
+-- Name: phpbb_profile_fields_data phpbb_profile_fields_data_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields_data
+    ADD CONSTRAINT phpbb_profile_fields_data_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: phpbb_profile_fields_lang phpbb_profile_fields_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields_lang
+    ADD CONSTRAINT phpbb_profile_fields_lang_pkey PRIMARY KEY (field_id, lang_id, option_id);
+
+
+--
+-- Name: phpbb_profile_fields phpbb_profile_fields_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_fields
+    ADD CONSTRAINT phpbb_profile_fields_pkey PRIMARY KEY (field_id);
+
+
+--
+-- Name: phpbb_profile_lang phpbb_profile_lang_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_profile_lang
+    ADD CONSTRAINT phpbb_profile_lang_pkey PRIMARY KEY (field_id, lang_id);
+
+
+--
+-- Name: phpbb_ranks phpbb_ranks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_ranks
+    ADD CONSTRAINT phpbb_ranks_pkey PRIMARY KEY (rank_id);
+
+
+--
+-- Name: phpbb_reports phpbb_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_reports
+    ADD CONSTRAINT phpbb_reports_pkey PRIMARY KEY (report_id);
+
+
+--
+-- Name: phpbb_reports_reasons phpbb_reports_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_reports_reasons
+    ADD CONSTRAINT phpbb_reports_reasons_pkey PRIMARY KEY (reason_id);
+
+
+--
+-- Name: phpbb_search_results phpbb_search_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_search_results
+    ADD CONSTRAINT phpbb_search_results_pkey PRIMARY KEY (search_key);
+
+
+--
+-- Name: phpbb_search_wordlist phpbb_search_wordlist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_search_wordlist
+    ADD CONSTRAINT phpbb_search_wordlist_pkey PRIMARY KEY (word_id);
+
+
+--
+-- Name: phpbb_sessions_keys phpbb_sessions_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sessions_keys
+    ADD CONSTRAINT phpbb_sessions_keys_pkey PRIMARY KEY (key_id, user_id);
+
+
+--
+-- Name: phpbb_sessions phpbb_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sessions
+    ADD CONSTRAINT phpbb_sessions_pkey PRIMARY KEY (session_id);
+
+
+--
+-- Name: phpbb_sitelist phpbb_sitelist_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_sitelist
+    ADD CONSTRAINT phpbb_sitelist_pkey PRIMARY KEY (site_id);
+
+
+--
+-- Name: phpbb_smilies phpbb_smilies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_smilies
+    ADD CONSTRAINT phpbb_smilies_pkey PRIMARY KEY (smiley_id);
+
+
+--
+-- Name: phpbb_styles phpbb_styles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_styles
+    ADD CONSTRAINT phpbb_styles_pkey PRIMARY KEY (style_id);
+
+
+--
+-- Name: phpbb_teampage phpbb_teampage_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_teampage
+    ADD CONSTRAINT phpbb_teampage_pkey PRIMARY KEY (teampage_id);
+
+
+--
+-- Name: phpbb_topics phpbb_topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics
+    ADD CONSTRAINT phpbb_topics_pkey PRIMARY KEY (topic_id);
+
+
+--
+-- Name: phpbb_topics_posted phpbb_topics_posted_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics_posted
+    ADD CONSTRAINT phpbb_topics_posted_pkey PRIMARY KEY (user_id, topic_id);
+
+
+--
+-- Name: phpbb_topics_track phpbb_topics_track_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_topics_track
+    ADD CONSTRAINT phpbb_topics_track_pkey PRIMARY KEY (user_id, topic_id);
+
+
+--
+-- Name: phpbb_users phpbb_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_users
+    ADD CONSTRAINT phpbb_users_pkey PRIMARY KEY (user_id);
+
+
+--
+-- Name: phpbb_warnings phpbb_warnings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_warnings
+    ADD CONSTRAINT phpbb_warnings_pkey PRIMARY KEY (warning_id);
+
+
+--
+-- Name: phpbb_words phpbb_words_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_words
+    ADD CONSTRAINT phpbb_words_pkey PRIMARY KEY (word_id);
+
+
+--
+-- Name: phpbb_zebra phpbb_zebra_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phpbb_zebra
+    ADD CONSTRAINT phpbb_zebra_pkey PRIMARY KEY (user_id, zebra_id);
+
+
+--
+-- Name: phpbb_acl_groups_auth_opt_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_auth_opt_id ON public.phpbb_acl_groups USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_groups_auth_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_auth_role_id ON public.phpbb_acl_groups USING btree (auth_role_id);
+
+
+--
+-- Name: phpbb_acl_groups_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_groups_group_id ON public.phpbb_acl_groups USING btree (group_id);
+
+
+--
+-- Name: phpbb_acl_options_auth_option; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_acl_options_auth_option ON public.phpbb_acl_options USING btree (auth_option);
+
+
+--
+-- Name: phpbb_acl_roles_data_ath_op_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_data_ath_op_id ON public.phpbb_acl_roles_data USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_roles_role_order; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_role_order ON public.phpbb_acl_roles USING btree (role_order);
+
+
+--
+-- Name: phpbb_acl_roles_role_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_roles_role_type ON public.phpbb_acl_roles USING btree (role_type);
+
+
+--
+-- Name: phpbb_acl_users_auth_option_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_auth_option_id ON public.phpbb_acl_users USING btree (auth_option_id);
+
+
+--
+-- Name: phpbb_acl_users_auth_role_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_auth_role_id ON public.phpbb_acl_users USING btree (auth_role_id);
+
+
+--
+-- Name: phpbb_acl_users_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_acl_users_user_id ON public.phpbb_acl_users USING btree (user_id);
+
+
+--
+-- Name: phpbb_attachments_filetime; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_filetime ON public.phpbb_attachments USING btree (filetime);
+
+
+--
+-- Name: phpbb_attachments_is_orphan; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_is_orphan ON public.phpbb_attachments USING btree (is_orphan);
+
+
+--
+-- Name: phpbb_attachments_post_msg_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_post_msg_id ON public.phpbb_attachments USING btree (post_msg_id);
+
+
+--
+-- Name: phpbb_attachments_poster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_poster_id ON public.phpbb_attachments USING btree (poster_id);
+
+
+--
+-- Name: phpbb_attachments_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_attachments_topic_id ON public.phpbb_attachments USING btree (topic_id);
+
+
+--
+-- Name: phpbb_banlist_ban_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_email ON public.phpbb_banlist USING btree (ban_email, ban_exclude);
+
+
+--
+-- Name: phpbb_banlist_ban_end; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_end ON public.phpbb_banlist USING btree (ban_end);
+
+
+--
+-- Name: phpbb_banlist_ban_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_ip ON public.phpbb_banlist USING btree (ban_ip, ban_exclude);
+
+
+--
+-- Name: phpbb_banlist_ban_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_banlist_ban_user ON public.phpbb_banlist USING btree (ban_userid, ban_exclude);
+
+
+--
+-- Name: phpbb_bbcodes_display_on_post; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_bbcodes_display_on_post ON public.phpbb_bbcodes USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_bots_bot_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_bots_bot_active ON public.phpbb_bots USING btree (bot_active);
+
+
+--
+-- Name: phpbb_config_is_dynamic; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_config_is_dynamic ON public.phpbb_config USING btree (is_dynamic);
+
+
+--
+-- Name: phpbb_confirm_confirm_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_confirm_confirm_type ON public.phpbb_confirm USING btree (confirm_type);
+
+
+--
+-- Name: phpbb_drafts_save_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_drafts_save_time ON public.phpbb_drafts USING btree (save_time);
+
+
+--
+-- Name: phpbb_ext_ext_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_ext_ext_name ON public.phpbb_ext USING btree (ext_name);
+
+
+--
+-- Name: phpbb_forums_forum_lastpost_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_forum_lastpost_id ON public.phpbb_forums USING btree (forum_last_post_id);
+
+
+--
+-- Name: phpbb_forums_left_right_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_left_right_id ON public.phpbb_forums USING btree (left_id, right_id);
+
+
+--
+-- Name: phpbb_forums_watch_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_forum_id ON public.phpbb_forums_watch USING btree (forum_id);
+
+
+--
+-- Name: phpbb_forums_watch_notify_stat; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_notify_stat ON public.phpbb_forums_watch USING btree (notify_status);
+
+
+--
+-- Name: phpbb_forums_watch_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_forums_watch_user_id ON public.phpbb_forums_watch USING btree (user_id);
+
+
+--
+-- Name: phpbb_groups_group_legend_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_groups_group_legend_name ON public.phpbb_groups USING btree (group_legend, group_name);
+
+
+--
+-- Name: phpbb_icons_display_on_posting; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_icons_display_on_posting ON public.phpbb_icons USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_lang_lang_iso; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_lang_lang_iso ON public.phpbb_lang USING btree (lang_iso);
+
+
+--
+-- Name: phpbb_log_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_forum_id ON public.phpbb_log USING btree (forum_id);
+
+
+--
+-- Name: phpbb_log_log_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_log_time ON public.phpbb_log USING btree (log_time);
+
+
+--
+-- Name: phpbb_log_log_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_log_type ON public.phpbb_log USING btree (log_type);
+
+
+--
+-- Name: phpbb_log_reportee_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_reportee_id ON public.phpbb_log USING btree (reportee_id);
+
+
+--
+-- Name: phpbb_log_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_topic_id ON public.phpbb_log USING btree (topic_id);
+
+
+--
+-- Name: phpbb_log_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_log_user_id ON public.phpbb_log USING btree (user_id);
+
+
+--
+-- Name: phpbb_login_attempts_att_for; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_for ON public.phpbb_login_attempts USING btree (attempt_forwarded_for, attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_att_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_ip ON public.phpbb_login_attempts USING btree (attempt_ip, attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_att_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_att_time ON public.phpbb_login_attempts USING btree (attempt_time);
+
+
+--
+-- Name: phpbb_login_attempts_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_login_attempts_user_id ON public.phpbb_login_attempts USING btree (user_id);
+
+
+--
+-- Name: phpbb_moderator_cache_disp_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_moderator_cache_disp_idx ON public.phpbb_moderator_cache USING btree (display_on_index);
+
+
+--
+-- Name: phpbb_moderator_cache_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_moderator_cache_forum_id ON public.phpbb_moderator_cache USING btree (forum_id);
+
+
+--
+-- Name: phpbb_modules_class_left_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_class_left_id ON public.phpbb_modules USING btree (module_class, left_id);
+
+
+--
+-- Name: phpbb_modules_left_right_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_left_right_id ON public.phpbb_modules USING btree (left_id, right_id);
+
+
+--
+-- Name: phpbb_modules_module_enabled; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_modules_module_enabled ON public.phpbb_modules USING btree (module_enabled);
+
+
+--
+-- Name: phpbb_notification_types_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_notification_types_type ON public.phpbb_notification_types USING btree (notification_type_name);
+
+
+--
+-- Name: phpbb_notifications_item_ident; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_notifications_item_ident ON public.phpbb_notifications USING btree (notification_type_id, item_id);
+
+
+--
+-- Name: phpbb_notifications_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_notifications_user ON public.phpbb_notifications USING btree (user_id, notification_read);
+
+
+--
+-- Name: phpbb_oauth_states_provider; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_states_provider ON public.phpbb_oauth_states USING btree (provider);
+
+
+--
+-- Name: phpbb_oauth_states_state_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_states_state_time ON public.phpbb_oauth_states USING btree (state_time);
+
+
+--
+-- Name: phpbb_oauth_states_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_states_user_id ON public.phpbb_oauth_states USING btree (user_id);
+
+
+--
+-- Name: phpbb_oauth_tokens_provider; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_tokens_provider ON public.phpbb_oauth_tokens USING btree (provider);
+
+
+--
+-- Name: phpbb_oauth_tokens_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_oauth_tokens_user_id ON public.phpbb_oauth_tokens USING btree (user_id);
+
+
+--
+-- Name: phpbb_poll_options_poll_opt_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_options_poll_opt_id ON public.phpbb_poll_options USING btree (poll_option_id);
+
+
+--
+-- Name: phpbb_poll_options_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_options_topic_id ON public.phpbb_poll_options USING btree (topic_id);
+
+
+--
+-- Name: phpbb_poll_votes_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_topic_id ON public.phpbb_poll_votes USING btree (topic_id);
+
+
+--
+-- Name: phpbb_poll_votes_vote_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_vote_user_id ON public.phpbb_poll_votes USING btree (vote_user_id);
+
+
+--
+-- Name: phpbb_poll_votes_vote_user_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_poll_votes_vote_user_ip ON public.phpbb_poll_votes USING btree (vote_user_ip);
+
+
+--
+-- Name: phpbb_posts_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_forum_id ON public.phpbb_posts USING btree (forum_id);
+
+
+--
+-- Name: phpbb_posts_post_username; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_post_username ON public.phpbb_posts USING btree (post_username);
+
+
+--
+-- Name: phpbb_posts_post_visibility; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_post_visibility ON public.phpbb_posts USING btree (post_visibility);
+
+
+--
+-- Name: phpbb_posts_poster_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_poster_id ON public.phpbb_posts USING btree (poster_id);
+
+
+--
+-- Name: phpbb_posts_poster_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_poster_ip ON public.phpbb_posts USING btree (poster_ip);
+
+
+--
+-- Name: phpbb_posts_tid_post_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_tid_post_time ON public.phpbb_posts USING btree (topic_id, post_time);
+
+
+--
+-- Name: phpbb_posts_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_posts_topic_id ON public.phpbb_posts USING btree (topic_id);
+
+
+--
+-- Name: phpbb_privmsgs_author_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_author_id ON public.phpbb_privmsgs USING btree (author_id);
+
+
+--
+-- Name: phpbb_privmsgs_author_ip; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_author_ip ON public.phpbb_privmsgs USING btree (author_ip);
+
+
+--
+-- Name: phpbb_privmsgs_folder_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_folder_user_id ON public.phpbb_privmsgs_folder USING btree (user_id);
+
+
+--
+-- Name: phpbb_privmsgs_message_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_message_time ON public.phpbb_privmsgs USING btree (message_time);
+
+
+--
+-- Name: phpbb_privmsgs_root_level; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_root_level ON public.phpbb_privmsgs USING btree (root_level);
+
+
+--
+-- Name: phpbb_privmsgs_rules_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_rules_user_id ON public.phpbb_privmsgs_rules USING btree (user_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_author_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_author_id ON public.phpbb_privmsgs_to USING btree (author_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_msg_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_msg_id ON public.phpbb_privmsgs_to USING btree (msg_id);
+
+
+--
+-- Name: phpbb_privmsgs_to_usr_flder_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_privmsgs_to_usr_flder_id ON public.phpbb_privmsgs_to USING btree (user_id, folder_id);
+
+
+--
+-- Name: phpbb_profile_fields_fld_ordr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_profile_fields_fld_ordr ON public.phpbb_profile_fields USING btree (field_order);
+
+
+--
+-- Name: phpbb_profile_fields_fld_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_profile_fields_fld_type ON public.phpbb_profile_fields USING btree (field_type);
+
+
+--
+-- Name: phpbb_reports_pm_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_reports_pm_id ON public.phpbb_reports USING btree (pm_id);
+
+
+--
+-- Name: phpbb_reports_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_reports_post_id ON public.phpbb_reports USING btree (post_id);
+
+
+--
+-- Name: phpbb_search_wordlist_wrd_cnt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordlist_wrd_cnt ON public.phpbb_search_wordlist USING btree (word_count);
+
+
+--
+-- Name: phpbb_search_wordlist_wrd_txt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_search_wordlist_wrd_txt ON public.phpbb_search_wordlist USING btree (word_text);
+
+
+--
+-- Name: phpbb_search_wordmatch_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordmatch_post_id ON public.phpbb_search_wordmatch USING btree (post_id);
+
+
+--
+-- Name: phpbb_search_wordmatch_un_mtch; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_search_wordmatch_un_mtch ON public.phpbb_search_wordmatch USING btree (word_id, post_id, title_match);
+
+
+--
+-- Name: phpbb_search_wordmatch_word_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_search_wordmatch_word_id ON public.phpbb_search_wordmatch USING btree (word_id);
+
+
+--
+-- Name: phpbb_sessions_keys_last_login; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_keys_last_login ON public.phpbb_sessions_keys USING btree (last_login);
+
+
+--
+-- Name: phpbb_sessions_session_fid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_fid ON public.phpbb_sessions USING btree (session_forum_id);
+
+
+--
+-- Name: phpbb_sessions_session_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_time ON public.phpbb_sessions USING btree (session_time);
+
+
+--
+-- Name: phpbb_sessions_session_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_sessions_session_user_id ON public.phpbb_sessions USING btree (session_user_id);
+
+
+--
+-- Name: phpbb_smilies_display_on_post; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_smilies_display_on_post ON public.phpbb_smilies USING btree (display_on_posting);
+
+
+--
+-- Name: phpbb_styles_style_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_styles_style_name ON public.phpbb_styles USING btree (style_name);
+
+
+--
+-- Name: phpbb_topics_fid_time_moved; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_fid_time_moved ON public.phpbb_topics USING btree (forum_id, topic_last_post_time, topic_moved_id);
+
+
+--
+-- Name: phpbb_topics_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_id ON public.phpbb_topics USING btree (forum_id);
+
+
+--
+-- Name: phpbb_topics_forum_id_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_id_type ON public.phpbb_topics USING btree (forum_id, topic_type);
+
+
+--
+-- Name: phpbb_topics_forum_vis_last; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_forum_vis_last ON public.phpbb_topics USING btree (forum_id, topic_visibility, topic_last_post_id);
+
+
+--
+-- Name: phpbb_topics_last_post_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_last_post_time ON public.phpbb_topics USING btree (topic_last_post_time);
+
+
+--
+-- Name: phpbb_topics_latest_topics; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_latest_topics ON public.phpbb_topics USING btree (forum_id, topic_last_post_time, topic_last_post_id, topic_moved_id);
+
+
+--
+-- Name: phpbb_topics_topic_visibility; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_topic_visibility ON public.phpbb_topics USING btree (topic_visibility);
+
+
+--
+-- Name: phpbb_topics_track_forum_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_track_forum_id ON public.phpbb_topics_track USING btree (forum_id);
+
+
+--
+-- Name: phpbb_topics_track_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_track_topic_id ON public.phpbb_topics_track USING btree (topic_id);
+
+
+--
+-- Name: phpbb_topics_watch_notify_stat; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_notify_stat ON public.phpbb_topics_watch USING btree (notify_status);
+
+
+--
+-- Name: phpbb_topics_watch_topic_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_topic_id ON public.phpbb_topics_watch USING btree (topic_id);
+
+
+--
+-- Name: phpbb_topics_watch_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_topics_watch_user_id ON public.phpbb_topics_watch USING btree (user_id);
+
+
+--
+-- Name: phpbb_user_group_group_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_group_id ON public.phpbb_user_group USING btree (group_id);
+
+
+--
+-- Name: phpbb_user_group_group_leader; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_group_leader ON public.phpbb_user_group USING btree (group_leader);
+
+
+--
+-- Name: phpbb_user_group_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_group_user_id ON public.phpbb_user_group USING btree (user_id);
+
+
+--
+-- Name: phpbb_user_notifications_itm_usr_mthd; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_user_notifications_itm_usr_mthd ON public.phpbb_user_notifications USING btree (item_type, item_id, user_id, method);
+
+
+--
+-- Name: phpbb_user_notifications_uid_itm_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_notifications_uid_itm_id ON public.phpbb_user_notifications USING btree (user_id, item_id);
+
+
+--
+-- Name: phpbb_user_notifications_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_notifications_user_id ON public.phpbb_user_notifications USING btree (user_id);
+
+
+--
+-- Name: phpbb_user_notifications_usr_itm_tpe; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_user_notifications_usr_itm_tpe ON public.phpbb_user_notifications USING btree (user_id, item_type, item_id);
+
+
+--
+-- Name: phpbb_users_user_birthday; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_birthday ON public.phpbb_users USING btree (user_birthday);
+
+
+--
+-- Name: phpbb_users_user_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_email ON public.phpbb_users USING btree (user_email);
+
+
+--
+-- Name: phpbb_users_user_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX phpbb_users_user_type ON public.phpbb_users USING btree (user_type);
+
+
+--
+-- Name: phpbb_users_username_clean; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX phpbb_users_username_clean ON public.phpbb_users USING btree (username_clean);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict Z8ypjMKMNeTqLacgtMJ7JmOyacCaQkfzsZEbQBfdsvJo0tA2iNvS7OPYyZCYlUd
+


### PR DESCRIPTION
Superseded — closing without merging.

Per the discussion on where source schemas should live: the public, GPL repo shouldn't carry third-party source schemas (per-source "are we allowed to redistribute this?" uncertainty + bloat — 15k lines for phpBB alone), and the same policy should hold uniformly for GPL (phpBB) and proprietary (e.g. vBulletin5) sources alike.

So the **generator and the schema fixtures move to a separate, internal repo** (`discourse-converter-schemas`), which also hosts a scheduled runner that checks out `discourse/discourse`, loads the schemas into MariaDB + Postgres, and runs the (already gated) retrieval-lint spec from #211 against them.

What stays public (#211 and below): the converter code and the retrieval-lint spec, which connects to env-configured databases and **skips** when none are reachable — so public CI never needs a schema. Nothing here needs to merge into the public repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gschlager/discourse/212)
<!-- Reviewable:end -->
